### PR TITLE
Error per crate/module

### DIFF
--- a/crates/starknet-server/src/api/http/error.rs
+++ b/crates/starknet-server/src/api/http/error.rs
@@ -2,10 +2,13 @@ use axum::response::IntoResponse;
 use axum::Json;
 use hyper::StatusCode;
 use serde_json::json;
+use thiserror::Error;
 
-#[derive(Debug)]
-pub(crate) enum HttpApiError {
+#[derive(Error, Debug)]
+pub enum HttpApiError {
+    #[error("Path not found")]
     PathNotFound,
+    #[error("General error")]
     GeneralError,
 }
 

--- a/crates/starknet-server/src/api/http/mod.rs
+++ b/crates/starknet-server/src/api/http/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) mod endpoints;
-mod error;
+pub(crate) mod error;
 #[allow(unused)]
 mod models;
 

--- a/crates/starknet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-server/src/api/json_rpc/endpoints.rs
@@ -1,4 +1,3 @@
-use server::rpc_core::error::RpcError;
 use starknet_types::felt::Felt;
 use starknet_types::starknet_api::block::BlockNumber;
 
@@ -81,17 +80,10 @@ impl JsonRpcHandler {
         block_id: BlockId,
         contract_address: ContractAddressHex,
     ) -> RpcResult<ClassHashHex> {
-        let parsed_address = contract_address.0.try_into().map_err(|_| {
-            error::ApiError::RpcError(RpcError::invalid_params(format!(
-                "Invalid contract_address: {:?}",
-                contract_address.0
-            )))
-        })?;
+        let parsed_address = contract_address.0.try_into()?;
 
         let starknet = self.api.starknet.read().await;
-        let state = starknet
-            .get_state_reader_at(&block_id.into())
-            .map_err(|_| error::ApiError::BlockNotFound)?;
+        let state = starknet.get_state_reader_at(&block_id.into())?;
         match state.address_to_class_hash.get(&parsed_address) {
             Some(class_hash) => Ok(FeltHex(Felt::from(*class_hash))),
             None => Err(error::ApiError::ContractNotFound),

--- a/crates/starknet-server/src/api/json_rpc/error.rs
+++ b/crates/starknet-server/src/api/json_rpc/error.rs
@@ -1,6 +1,5 @@
 use server::rpc_core::error::RpcError;
 use starknet_types;
-
 use thiserror::Error;
 use tracing::error;
 

--- a/crates/starknet-server/src/api/json_rpc/error.rs
+++ b/crates/starknet-server/src/api/json_rpc/error.rs
@@ -1,9 +1,16 @@
 use server::rpc_core::error::RpcError;
+use starknet_types;
+
+use thiserror::Error;
 use tracing::error;
 
 #[allow(unused)]
-#[derive(thiserror::Error, Debug)]
+#[derive(Error, Debug)]
 pub enum ApiError {
+    #[error(transparent)]
+    StarknetDevnetError(#[from] starknet_core::error::Error),
+    #[error("Types error")]
+    TypesError(#[from] starknet_types::error::Error),
     #[error("Rpc error {0:?}")]
     RpcError(RpcError),
     #[error("Block not found")]

--- a/crates/starknet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-server/src/api/json_rpc/mod.rs
@@ -111,7 +111,6 @@ impl<T: Serialize> ToRpcResponseResult for RpcResult<T> {
                     data: None,
                 },
                 ApiError::StarknetDevnetError(error) => RpcError {
-                    // random error coe
                     code: server::rpc_core::error::ErrorCode::ServerError(WILDCARD_RPC_ERROR_CODE),
                     message: error.to_string().into(),
                     data: None,

--- a/crates/starknet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-server/src/api/json_rpc/mod.rs
@@ -25,6 +25,9 @@ pub(crate) trait ToRpcResponseResult {
     fn to_rpc_result(self) -> ResponseResult;
 }
 
+/// Used when there is no defined code to use
+pub const WILDCARD_RPC_ERROR_CODE: i64 = -1;
+
 /// Converts a serializable value into a `ResponseResult`
 pub fn to_rpc_result<T: Serialize>(val: T) -> ResponseResult {
     match serde_json::to_value(val) {
@@ -103,14 +106,13 @@ impl<T: Serialize> ToRpcResponseResult for RpcResult<T> {
                     data: None,
                 },
                 err @ ApiError::TypesError(_) => RpcError {
-                    // random error coe
-                    code: server::rpc_core::error::ErrorCode::ServerError(32600),
+                    code: server::rpc_core::error::ErrorCode::ServerError(WILDCARD_RPC_ERROR_CODE),
                     message: err.to_string().into(),
                     data: None,
                 },
                 ApiError::StarknetDevnetError(error) => RpcError {
                     // random error coe
-                    code: server::rpc_core::error::ErrorCode::ServerError(32600),
+                    code: server::rpc_core::error::ErrorCode::ServerError(WILDCARD_RPC_ERROR_CODE),
                     message: error.to_string().into(),
                     data: None,
                 },

--- a/crates/starknet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-server/src/api/json_rpc/mod.rs
@@ -104,13 +104,13 @@ impl<T: Serialize> ToRpcResponseResult for RpcResult<T> {
                 },
                 err @ ApiError::TypesError(_) => RpcError {
                     // random error coe
-                    code: server::rpc_core::error::ErrorCode::ServerError(52),
+                    code: server::rpc_core::error::ErrorCode::ServerError(32600),
                     message: err.to_string().into(),
                     data: None,
                 },
                 ApiError::StarknetDevnetError(error) => RpcError {
                     // random error coe
-                    code: server::rpc_core::error::ErrorCode::ServerError(53),
+                    code: server::rpc_core::error::ErrorCode::ServerError(32600),
                     message: error.to_string().into(),
                     data: None,
                 },

--- a/crates/starknet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-server/src/api/json_rpc/mod.rs
@@ -1,5 +1,5 @@
 mod endpoints;
-mod error;
+pub mod error;
 mod models;
 mod write_endpoints;
 
@@ -102,10 +102,30 @@ impl<T: Serialize> ToRpcResponseResult for RpcResult<T> {
                     message: err.to_string().into(),
                     data: None,
                 },
+                err @ ApiError::TypesError(_) => RpcError {
+                    // random error coe
+                    code: server::rpc_core::error::ErrorCode::ServerError(52),
+                    message: err.to_string().into(),
+                    data: None,
+                },
+                ApiError::StarknetDevnetError(error) => RpcError {
+                    // random error coe
+                    code: server::rpc_core::error::ErrorCode::ServerError(53),
+                    message: error.to_string().into(),
+                    data: None,
+                },
             }
             .into(),
         }
     }
+}
+
+/// This object will be used as a shared state between HTTP calls.
+/// Is simillar to the HttpApiHandler but is with extended functionality and is used for JSON-RPC
+/// methods
+#[derive(Clone)]
+pub struct JsonRpcHandler {
+    pub api: Api,
 }
 
 #[async_trait::async_trait]
@@ -116,14 +136,6 @@ impl RpcHandler for JsonRpcHandler {
         info!(target: "rpc", "received method in on_request");
         self.execute(request).await
     }
-}
-
-/// This object will be used as a shared state between HTTP calls.
-/// Is simillar to the HttpApiHandler but is with extended functionality and is used for JSON-RPC
-/// methods
-#[derive(Clone)]
-pub struct JsonRpcHandler {
-    pub api: Api,
 }
 
 impl JsonRpcHandler {

--- a/crates/starknet-server/src/api/json_rpc/write_endpoints.rs
+++ b/crates/starknet-server/src/api/json_rpc/write_endpoints.rs
@@ -1,7 +1,6 @@
 use serde_json::json;
 use server::rpc_core::error::RpcError;
 use starknet_core::transactions::declare_transaction::DeclareTransactionV1;
-use starknet_core::TransactionError;
 use starknet_types::contract_class::ContractClass;
 use starknet_types::felt::Felt;
 
@@ -22,20 +21,11 @@ impl JsonRpcHandler {
     ) -> RpcResult<DeclareTransactionOutput> {
         let chain_id = self.api.starknet.read().await.config.chain_id.to_felt();
         let (transaction_hash, class_hash) = match request {
-            BroadcastedDeclareTransaction::V1(broadcasted_declare_txn) => self
-                .api
-                .starknet
-                .write()
-                .await
-                .add_declare_transaction_v1(
+            BroadcastedDeclareTransaction::V1(broadcasted_declare_txn) => {
+                self.api.starknet.write().await.add_declare_transaction_v1(
                     (convert_to_declare_transaction_v1(*broadcasted_declare_txn, chain_id.into()))?,
-                )
-                .map_err(|err| match err {
-                    starknet_types::error::Error::TransactionError(
-                        TransactionError::ClassAlreadyDeclared(_),
-                    ) => ApiError::ClassAlreadyDeclared,
-                    _ => ApiError::InvalidContractClass,
-                })?,
+                )?
+            }
             BroadcastedDeclareTransaction::V2(_) => todo!(),
         };
 

--- a/crates/starknet/src/account.rs
+++ b/crates/starknet/src/account.rs
@@ -110,10 +110,10 @@ mod tests {
     use starknet_in_rust::core::errors::state_errors::StateError;
     use starknet_types::contract_address::ContractAddress;
     use starknet_types::contract_storage_key::ContractStorageKey;
-    use starknet_types::error::Error;
     use starknet_types::felt::Felt;
 
     use super::Account;
+    use crate::error::Error;
     use crate::state::StarknetState;
     use crate::traits::Accounted;
     use crate::utils::get_storage_var_address;

--- a/crates/starknet/src/account.rs
+++ b/crates/starknet/src/account.rs
@@ -9,8 +9,8 @@ use starknet_types::contract_class::ContractClass;
 use starknet_types::contract_storage_key::ContractStorageKey;
 use starknet_types::error::Error;
 use starknet_types::felt::{Balance, ClassHash, Felt, Key};
-use starknet_types::DevnetResult;
 
+use crate::error::Result;
 use crate::traits::{Accounted, StateChanger, StateExtractor};
 use crate::utils::get_storage_var_address;
 
@@ -37,7 +37,7 @@ impl Account {
         class_hash: ClassHash,
         contract_class: ContractClass,
         fee_token_address: ContractAddress,
-    ) -> DevnetResult<Self> {
+    ) -> Result<Self> {
         Ok(Self {
             initial_balance,
             public_key,
@@ -49,7 +49,7 @@ impl Account {
         })
     }
 
-    fn compute_account_address(public_key: &Key) -> DevnetResult<ContractAddress> {
+    fn compute_account_address(public_key: &Key) -> Result<ContractAddress> {
         let account_address = calculate_contract_address(
             ContractAddressSalt(stark_felt!(20u32)),
             Felt::from_prefixed_hex_str(ACCOUNT_CLASS_HASH_HEX_FOR_ADDRESS_COMPUTATION)?.into(),
@@ -61,7 +61,7 @@ impl Account {
         Ok(ContractAddress::from(account_address))
     }
 
-    fn balance_storage_key(&self) -> DevnetResult<ContractStorageKey> {
+    fn balance_storage_key(&self) -> Result<ContractStorageKey> {
         let storage_var_address =
             get_storage_var_address("ERC20_balances", &[Felt::from(self.account_address)])?;
         Ok(ContractStorageKey::new(self.fee_token_address, storage_var_address))
@@ -69,7 +69,7 @@ impl Account {
 }
 
 impl Accounted for Account {
-    fn deploy(&self, state: &mut impl StateChanger) -> Result<(), Error> {
+    fn deploy(&self, state: &mut impl StateChanger) -> Result<()> {
         // declare if not declared
         if !state.is_contract_declared(&self.class_hash)? {
             state.declare_contract_class(self.class_hash, self.contract_class.clone())?;
@@ -86,7 +86,7 @@ impl Accounted for Account {
         Ok(())
     }
 
-    fn set_initial_balance(&self, state: &mut impl StateChanger) -> DevnetResult<()> {
+    fn set_initial_balance(&self, state: &mut impl StateChanger) -> Result<()> {
         let storage_var_address =
             get_storage_var_address("ERC20_balances", &[Felt::from(self.account_address)])?;
         let storage_key = ContractStorageKey::new(self.fee_token_address, storage_var_address);
@@ -100,7 +100,7 @@ impl Accounted for Account {
         self.account_address
     }
 
-    fn get_balance(&self, state: &mut impl StateExtractor) -> DevnetResult<Balance> {
+    fn get_balance(&self, state: &mut impl StateExtractor) -> Result<Balance> {
         state.get_storage(self.balance_storage_key()?)
     }
 }

--- a/crates/starknet/src/error.rs
+++ b/crates/starknet/src/error.rs
@@ -1,0 +1,26 @@
+use starknet_types;
+
+use starknet_in_rust;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    StarknetApiError(#[from] starknet_api::StarknetApiError),
+    #[error(transparent)]
+    StateError(#[from] starknet_in_rust::core::errors::state_errors::StateError),
+    #[error(transparent)]
+    TransactionError(#[from] starknet_in_rust::transaction::error::TransactionError),
+    #[error("Types error")]
+    TypesError(#[from] starknet_types::error::Error),
+    #[error("Specifying block by hash is currently not enabled")]
+    BlockIdHashUnimplementedError,
+    #[error("Specifying block by number is currently not enabled")]
+    BlockIdNumberUnimplementedError,
+    #[error("I/O error")]
+    IoError(#[from] std::io::Error),
+    #[error("Error when reading file {path}")]
+    ReadFileError { source: std::io::Error, path: String },
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/crates/starknet/src/error.rs
+++ b/crates/starknet/src/error.rs
@@ -1,7 +1,5 @@
-use starknet_types;
-
-use starknet_in_rust;
 use thiserror::Error;
+use {starknet_in_rust, starknet_types};
 
 #[derive(Error, Debug)]
 pub enum Error {

--- a/crates/starknet/src/lib.rs
+++ b/crates/starknet/src/lib.rs
@@ -265,15 +265,14 @@ impl Starknet {
 #[cfg(test)]
 mod tests {
     use starknet_api::block::{BlockHash, BlockNumber, BlockStatus, BlockTimestamp, GasPrice};
-    use starknet_in_rust::core::errors::state_errors::StateError;
     use starknet_in_rust::definitions::block_context::StarknetChainId;
     use starknet_rs_core::types::{BlockId, BlockTag};
     use starknet_types::contract_address::ContractAddress;
-    use starknet_types::error::Error;
     use starknet_types::felt::Felt;
     use starknet_types::traits::HashProducer;
 
     use crate::blocks::StarknetBlock;
+    use crate::error::Error;
     use crate::traits::Accounted;
     use crate::utils::test_utils::{dummy_declare_transaction_v1, starknet_config_for_test};
     use crate::Starknet;
@@ -419,7 +418,7 @@ mod tests {
         let config = starknet_config_for_test();
         let starknet = Starknet::new(&config).unwrap();
         match starknet.get_state_reader_at(&BlockId::Number(2)) {
-            Err(Error::StateError(StateError::CustomError(_))) => (),
+            Err(Error::BlockIdNumberUnimplementedError) => (),
             _ => panic!("Should have failed"),
         }
     }
@@ -429,7 +428,7 @@ mod tests {
         let config = starknet_config_for_test();
         let starknet = Starknet::new(&config).unwrap();
         match starknet.get_state_reader_at(&BlockId::Number(2)) {
-            Err(Error::StateError(StateError::CustomError(_))) => (),
+            Err(Error::BlockIdNumberUnimplementedError) => (),
             _ => panic!("Should have failed"),
         }
     }

--- a/crates/starknet/src/lib.rs
+++ b/crates/starknet/src/lib.rs
@@ -1,3 +1,9 @@
+use std::collections::HashMap;
+use std::time::SystemTime;
+
+use blocks::{StarknetBlock, StarknetBlocks};
+use constants::ERC20_CONTRACT_ADDRESS;
+use predeployed_accounts::PredeployedAccounts;
 use starknet_api::block::{BlockNumber, BlockStatus, BlockTimestamp, GasPrice};
 use starknet_in_rust::definitions::block_context::{
     BlockContext, StarknetChainId, StarknetOsConfig,
@@ -12,17 +18,11 @@ use starknet_in_rust::state::in_memory_state_reader::InMemoryStateReader;
 use starknet_in_rust::state::BlockInfo;
 use starknet_in_rust::testing::TEST_SEQUENCER_ADDRESS;
 use starknet_rs_core::types::{BlockId, TransactionStatus};
-use std::collections::HashMap;
-use std::time::SystemTime;
-use tracing::error;
-
-use blocks::{StarknetBlock, StarknetBlocks};
-use constants::ERC20_CONTRACT_ADDRESS;
-use predeployed_accounts::PredeployedAccounts;
 use starknet_types::contract_address::ContractAddress;
 use starknet_types::felt::{Felt, TransactionHash};
 use starknet_types::traits::HashProducer;
 use state::StarknetState;
+use tracing::error;
 use traits::{AccountGenerator, Accounted, HashIdentifiedMut, StateChanger};
 use transactions::{StarknetTransaction, StarknetTransactions, Transaction};
 

--- a/crates/starknet/src/predeployed_accounts.rs
+++ b/crates/starknet/src/predeployed_accounts.rs
@@ -3,9 +3,9 @@ use starknet_rs_signers::SigningKey;
 use starknet_types::contract_address::ContractAddress;
 use starknet_types::contract_class::ContractClass;
 use starknet_types::felt::{ClassHash, Felt, Key};
-use starknet_types::DevnetResult;
 
 use crate::account::Account;
+use crate::error::Result;
 use crate::traits::AccountGenerator;
 use crate::utils::generate_u128_random_numbers;
 
@@ -28,14 +28,14 @@ impl PredeployedAccounts {
 }
 
 impl PredeployedAccounts {
-    fn generate_private_keys(&self, number_of_accounts: u8) -> DevnetResult<Vec<Key>> {
+    fn generate_private_keys(&self, number_of_accounts: u8) -> Result<Vec<Key>> {
         let random_numbers = generate_u128_random_numbers(self.seed, number_of_accounts)?;
         let private_keys = random_numbers.into_iter().map(Key::from).collect::<Vec<Key>>();
 
         Ok(private_keys)
     }
 
-    fn generate_public_key(&self, private_key: &Key) -> DevnetResult<Key> {
+    fn generate_public_key(&self, private_key: &Key) -> Result<Key> {
         let private_key_field_element = FieldElement::from(*private_key);
 
         let public_key = Key::from(
@@ -58,7 +58,7 @@ impl AccountGenerator for PredeployedAccounts {
         number_of_accounts: u8,
         class_hash: ClassHash,
         contract_class: ContractClass,
-    ) -> DevnetResult<&Vec<Self::Acc>> {
+    ) -> Result<&Vec<Self::Acc>> {
         let private_keys = self.generate_private_keys(number_of_accounts)?;
 
         for private_key in private_keys {

--- a/crates/starknet/src/services/add_declare_transaction.rs
+++ b/crates/starknet/src/services/add_declare_transaction.rs
@@ -1,9 +1,8 @@
 use starknet_in_rust::transaction::{verify_version, Declare, DeclareV2};
-use starknet_types::error::Error;
 use starknet_types::felt::{ClassHash, TransactionHash};
 use starknet_types::traits::HashProducer;
-use starknet_types::DevnetResult;
 
+use crate::error::{Error, Result};
 use crate::transactions::declare_transaction::DeclareTransactionV1;
 use crate::transactions::declare_transaction_v2::DeclareTransactionV2;
 use crate::transactions::{StarknetTransaction, Transaction};
@@ -13,7 +12,7 @@ impl Starknet {
     pub fn add_declare_transaction_v2(
         &mut self,
         declare_transaction: DeclareTransactionV2,
-    ) -> DevnetResult<(TransactionHash, ClassHash)> {
+    ) -> Result<(TransactionHash, ClassHash)> {
         let mut declare_transaction = declare_transaction;
 
         let class_hash = declare_transaction.sierra_contract_class.generate_hash()?;
@@ -86,7 +85,7 @@ impl Starknet {
     pub fn add_declare_transaction_v1(
         &mut self,
         declare_transaction: DeclareTransactionV1,
-    ) -> DevnetResult<(TransactionHash, ClassHash)> {
+    ) -> Result<(TransactionHash, ClassHash)> {
         let mut declare_transaction = declare_transaction;
 
         let class_hash = declare_transaction.contract_class.generate_hash()?;

--- a/crates/starknet/src/services/add_declare_transaction.rs
+++ b/crates/starknet/src/services/add_declare_transaction.rs
@@ -166,6 +166,7 @@ mod tests {
 
     use crate::account::Account;
     use crate::constants::{self};
+    use crate::error::Error;
     use crate::traits::{Accounted, HashIdentifiedMut, StateChanger};
     use crate::transactions::declare_transaction::DeclareTransactionV1;
     use crate::transactions::declare_transaction_v2::DeclareTransactionV2;
@@ -223,7 +224,7 @@ mod tests {
         ));
 
         match starknet.add_declare_transaction_v2(declare_txn).err().unwrap() {
-            starknet_types::error::Error::TransactionError(generated_error) => {
+            Error::TransactionError(generated_error) => {
                 assert_eq!(generated_error.to_string(), expected_error.to_string());
             }
             _ => panic!("Wrong error type"),
@@ -287,7 +288,7 @@ mod tests {
         ));
 
         match starknet.add_declare_transaction_v1(declare_txn).err().unwrap() {
-            starknet_types::error::Error::TransactionError(generated_error) => {
+            Error::TransactionError(generated_error) => {
                 assert_eq!(generated_error.to_string(), expected_error.to_string());
             }
             _ => panic!("Wrong error type"),

--- a/crates/starknet/src/services/predeployed.rs
+++ b/crates/starknet/src/services/predeployed.rs
@@ -1,11 +1,9 @@
-use starknet_types::error::Error;
-use starknet_types::DevnetResult;
-
 use crate::account::Account;
 use crate::constants::{
     ERC20_CONTRACT_ADDRESS, ERC20_CONTRACT_CLASS_HASH, ERC20_CONTRACT_PATH, UDC_CONTRACT_ADDRESS,
     UDC_CONTRACT_CLASS_HASH, UDC_CONTRACT_PATH,
 };
+use crate::error::{Error, Result};
 use crate::system_contract::SystemContract;
 use crate::Starknet;
 
@@ -14,7 +12,7 @@ impl Starknet {
         self.predeployed_accounts.get_accounts().to_vec()
     }
 
-    pub(crate) fn create_erc20() -> DevnetResult<SystemContract> {
+    pub(crate) fn create_erc20() -> Result<SystemContract> {
         let erc20_contract_class_json_str =
             std::fs::read_to_string(ERC20_CONTRACT_PATH).map_err(|err| Error::ReadFileError {
                 source: err,
@@ -29,7 +27,7 @@ impl Starknet {
         Ok(erc20_fee_contract)
     }
 
-    pub(crate) fn create_udc20() -> DevnetResult<SystemContract> {
+    pub(crate) fn create_udc20() -> Result<SystemContract> {
         let udc_contract_class_json_str =
             std::fs::read_to_string(UDC_CONTRACT_PATH).map_err(|err| Error::ReadFileError {
                 source: err,

--- a/crates/starknet/src/state.rs
+++ b/crates/starknet/src/state.rs
@@ -194,10 +194,10 @@ mod tests {
     use starknet_in_rust::state::state_api::{State, StateReader};
     use starknet_types::cairo_felt::Felt252;
     use starknet_types::contract_address::ContractAddress;
-    use starknet_types::error::Error;
     use starknet_types::felt::Felt;
 
     use super::StarknetState;
+    use crate::error::Error;
     use crate::traits::{StateChanger, StateExtractor};
     use crate::utils::test_utils::{
         dummy_cairo_0_contract_class, dummy_contract_address, dummy_contract_storage_key,

--- a/crates/starknet/src/state.rs
+++ b/crates/starknet/src/state.rs
@@ -272,24 +272,28 @@ mod tests {
             dummy_contract_address().try_into().unwrap();
 
         // check if current nonce is 0
-        assert!(state
-            .state
-            .address_to_nonce
-            .get(&starknet_in_rust_address)
-            .unwrap()
-            .eq(&Felt252::from(0)));
+        assert!(
+            state
+                .state
+                .address_to_nonce
+                .get(&starknet_in_rust_address)
+                .unwrap()
+                .eq(&Felt252::from(0))
+        );
 
         state.synchronize_states();
         state.pending_state.increment_nonce(&starknet_in_rust_address).unwrap();
         state.apply_cached_state().unwrap();
 
         // check if nonce update was correct
-        assert!(state
-            .state
-            .address_to_nonce
-            .get(&starknet_in_rust_address)
-            .unwrap()
-            .eq(&Felt252::from(1)));
+        assert!(
+            state
+                .state
+                .address_to_nonce
+                .get(&starknet_in_rust_address)
+                .unwrap()
+                .eq(&Felt252::from(1))
+        );
     }
 
     #[test]
@@ -312,12 +316,14 @@ mod tests {
         assert!(state.deploy_contract(address, felt).is_ok());
         assert!(state.state.address_to_class_hash.len() == 1);
         assert!(state.state.address_to_class_hash.contains_key(&(address.try_into().unwrap())));
-        assert!(state
-            .state
-            .address_to_nonce
-            .get(&(address.try_into().unwrap()))
-            .unwrap()
-            .eq(&Felt252::from(0)));
+        assert!(
+            state
+                .state
+                .address_to_nonce
+                .get(&(address.try_into().unwrap()))
+                .unwrap()
+                .eq(&Felt252::from(0))
+        );
     }
 
     #[test]

--- a/crates/starknet/src/state.rs
+++ b/crates/starknet/src/state.rs
@@ -10,8 +10,8 @@ use starknet_types::contract_address::ContractAddress;
 use starknet_types::contract_class::ContractClass;
 use starknet_types::contract_storage_key::ContractStorageKey;
 use starknet_types::felt::{ClassHash, Felt};
-use starknet_types::DevnetResult;
 
+use crate::error::Result;
 use crate::traits::{StateChanger, StateExtractor};
 
 #[derive(Debug)]
@@ -48,7 +48,7 @@ impl StateChanger for StarknetState {
         &mut self,
         class_hash: ClassHash,
         contract_class: ContractClass,
-    ) -> DevnetResult<()> {
+    ) -> Result<()> {
         match contract_class {
             ContractClass::Cairo0(_) => {
                 self.state.class_hash_to_contract_class_mut().insert(
@@ -66,11 +66,7 @@ impl StateChanger for StarknetState {
         Ok(())
     }
 
-    fn deploy_contract(
-        &mut self,
-        address: ContractAddress,
-        class_hash: ClassHash,
-    ) -> DevnetResult<()> {
+    fn deploy_contract(&mut self, address: ContractAddress, class_hash: ClassHash) -> Result<()> {
         let addr: Address = address.try_into()?;
         self.state.address_to_class_hash_mut().insert(addr.clone(), class_hash.bytes());
         self.state.address_to_nonce_mut().insert(addr, Felt252::new(0));
@@ -78,13 +74,13 @@ impl StateChanger for StarknetState {
         Ok(())
     }
 
-    fn change_storage(&mut self, storage_key: ContractStorageKey, data: Felt) -> DevnetResult<()> {
+    fn change_storage(&mut self, storage_key: ContractStorageKey, data: Felt) -> Result<()> {
         self.state.address_to_storage_mut().insert(storage_key.try_into()?, data.into());
 
         Ok(())
     }
 
-    fn increment_nonce(&mut self, address: ContractAddress) -> DevnetResult<()> {
+    fn increment_nonce(&mut self, address: ContractAddress) -> Result<()> {
         let addr: Address = address.try_into()?;
         let nonce = self.state.get_nonce_at(&addr)?;
         self.state.address_to_nonce_mut().insert(addr, nonce + Felt252::new(1));
@@ -92,11 +88,11 @@ impl StateChanger for StarknetState {
         Ok(())
     }
 
-    fn is_contract_declared(&mut self, class_hash: &ClassHash) -> DevnetResult<bool> {
+    fn is_contract_declared(&mut self, class_hash: &ClassHash) -> Result<bool> {
         Ok(self.state.class_hash_to_contract_class.contains_key(&(class_hash.bytes())))
     }
 
-    fn apply_cached_state(&mut self) -> DevnetResult<()> {
+    fn apply_cached_state(&mut self) -> Result<()> {
         let new_casm_classes =
             self.pending_state.casm_contract_classes().clone().unwrap_or_default();
 
@@ -187,7 +183,7 @@ impl StateChanger for StarknetState {
 }
 
 impl StateExtractor for StarknetState {
-    fn get_storage(&mut self, storage_key: ContractStorageKey) -> DevnetResult<Felt> {
+    fn get_storage(&mut self, storage_key: ContractStorageKey) -> Result<Felt> {
         Ok(self.state.get_storage_at(&storage_key.try_into()?).map(Felt::from)?)
     }
 }
@@ -276,28 +272,24 @@ mod tests {
             dummy_contract_address().try_into().unwrap();
 
         // check if current nonce is 0
-        assert!(
-            state
-                .state
-                .address_to_nonce
-                .get(&starknet_in_rust_address)
-                .unwrap()
-                .eq(&Felt252::from(0))
-        );
+        assert!(state
+            .state
+            .address_to_nonce
+            .get(&starknet_in_rust_address)
+            .unwrap()
+            .eq(&Felt252::from(0)));
 
         state.synchronize_states();
         state.pending_state.increment_nonce(&starknet_in_rust_address).unwrap();
         state.apply_cached_state().unwrap();
 
         // check if nonce update was correct
-        assert!(
-            state
-                .state
-                .address_to_nonce
-                .get(&starknet_in_rust_address)
-                .unwrap()
-                .eq(&Felt252::from(1))
-        );
+        assert!(state
+            .state
+            .address_to_nonce
+            .get(&starknet_in_rust_address)
+            .unwrap()
+            .eq(&Felt252::from(1)));
     }
 
     #[test]
@@ -320,14 +312,12 @@ mod tests {
         assert!(state.deploy_contract(address, felt).is_ok());
         assert!(state.state.address_to_class_hash.len() == 1);
         assert!(state.state.address_to_class_hash.contains_key(&(address.try_into().unwrap())));
-        assert!(
-            state
-                .state
-                .address_to_nonce
-                .get(&(address.try_into().unwrap()))
-                .unwrap()
-                .eq(&Felt252::from(0))
-        );
+        assert!(state
+            .state
+            .address_to_nonce
+            .get(&(address.try_into().unwrap()))
+            .unwrap()
+            .eq(&Felt252::from(0)));
     }
 
     #[test]

--- a/crates/starknet/src/system_contract.rs
+++ b/crates/starknet/src/system_contract.rs
@@ -1,8 +1,8 @@
 use starknet_types::contract_address::ContractAddress;
 use starknet_types::contract_class::ContractClass;
 use starknet_types::felt::{Balance, ClassHash, Felt};
-use starknet_types::DevnetResult;
 
+use crate::error::Result;
 use crate::traits::Accounted;
 
 pub(crate) struct SystemContract {
@@ -16,7 +16,7 @@ impl SystemContract {
         class_hash: &str,
         address: &str,
         contract_class_json_str: &str,
-    ) -> DevnetResult<Self> {
+    ) -> Result<Self> {
         Ok(Self {
             class_hash: Felt::from_prefixed_hex_str(class_hash)?,
             address: ContractAddress::new(Felt::from_prefixed_hex_str(address)?)?,
@@ -26,10 +26,7 @@ impl SystemContract {
 }
 
 impl Accounted for SystemContract {
-    fn deploy(
-        &self,
-        state: &mut impl crate::traits::StateChanger,
-    ) -> Result<(), starknet_types::error::Error> {
+    fn deploy(&self, state: &mut impl crate::traits::StateChanger) -> Result<()> {
         if !state.is_contract_declared(&self.class_hash)? {
             state.declare_contract_class(self.class_hash, self.contract_class.clone())?;
         }
@@ -39,10 +36,7 @@ impl Accounted for SystemContract {
         Ok(())
     }
 
-    fn set_initial_balance(
-        &self,
-        _state: &mut impl crate::traits::StateChanger,
-    ) -> DevnetResult<()> {
+    fn set_initial_balance(&self, _state: &mut impl crate::traits::StateChanger) -> Result<()> {
         Ok(())
     }
 
@@ -50,10 +44,7 @@ impl Accounted for SystemContract {
         self.address
     }
 
-    fn get_balance(
-        &self,
-        _state: &mut impl crate::traits::StateExtractor,
-    ) -> DevnetResult<Balance> {
+    fn get_balance(&self, _state: &mut impl crate::traits::StateExtractor) -> Result<Balance> {
         Ok(Felt::default())
     }
 }

--- a/crates/starknet/src/traits.rs
+++ b/crates/starknet/src/traits.rs
@@ -1,9 +1,9 @@
 use starknet_types::contract_address::ContractAddress;
 use starknet_types::contract_class::ContractClass;
 use starknet_types::contract_storage_key::ContractStorageKey;
-use starknet_types::error::Error;
 use starknet_types::felt::{Balance, ClassHash, Felt};
-use starknet_types::DevnetResult;
+
+use crate::error::Result;
 
 /// This trait should be implemented by structures that internally have collections and each element
 /// could be found by a hash
@@ -23,9 +23,9 @@ pub trait HashIdentifiedMut {
 
 /// This trait sets the interface for the account
 pub trait Accounted {
-    fn deploy(&self, state: &mut impl StateChanger) -> Result<(), Error>;
-    fn set_initial_balance(&self, state: &mut impl StateChanger) -> DevnetResult<()>;
-    fn get_balance(&self, state: &mut impl StateExtractor) -> DevnetResult<Balance>;
+    fn deploy(&self, state: &mut impl StateChanger) -> Result<()>;
+    fn set_initial_balance(&self, state: &mut impl StateChanger) -> Result<()>;
+    fn get_balance(&self, state: &mut impl StateExtractor) -> Result<Balance>;
     fn get_address(&self) -> ContractAddress;
 }
 
@@ -35,22 +35,18 @@ pub trait StateChanger {
         &mut self,
         class_hash: ClassHash,
         contract_class: ContractClass,
-    ) -> DevnetResult<()>;
-    fn deploy_contract(
-        &mut self,
-        address: ContractAddress,
-        class_hash: ClassHash,
-    ) -> DevnetResult<()>;
-    fn change_storage(&mut self, storage_key: ContractStorageKey, data: Felt) -> DevnetResult<()>;
-    fn increment_nonce(&mut self, address: ContractAddress) -> DevnetResult<()>;
-    fn is_contract_declared(&mut self, class_hash: &ClassHash) -> DevnetResult<bool>;
+    ) -> Result<()>;
+    fn deploy_contract(&mut self, address: ContractAddress, class_hash: ClassHash) -> Result<()>;
+    fn change_storage(&mut self, storage_key: ContractStorageKey, data: Felt) -> Result<()>;
+    fn increment_nonce(&mut self, address: ContractAddress) -> Result<()>;
+    fn is_contract_declared(&mut self, class_hash: &ClassHash) -> Result<bool>;
     // get differences from pending state and apply them to "persistent" state
-    fn apply_cached_state(&mut self) -> DevnetResult<()>;
+    fn apply_cached_state(&mut self) -> Result<()>;
 }
 
 /// Interface for extracting data from the state
 pub trait StateExtractor {
-    fn get_storage(&mut self, storage_key: ContractStorageKey) -> DevnetResult<Felt>;
+    fn get_storage(&mut self, storage_key: ContractStorageKey) -> Result<Felt>;
 }
 
 /// This trait should be implemented by structures that generate accounts
@@ -61,5 +57,5 @@ pub trait AccountGenerator {
         number_of_accounts: u8,
         class_hash: ClassHash,
         contract_class: ContractClass,
-    ) -> DevnetResult<&Vec<Self::Acc>>;
+    ) -> Result<&Vec<Self::Acc>>;
 }

--- a/crates/starknet/src/transactions/declare_transaction.rs
+++ b/crates/starknet/src/transactions/declare_transaction.rs
@@ -7,6 +7,7 @@ use starknet_types::contract_class::ContractClass;
 use starknet_types::error::Error;
 use starknet_types::felt::{ClassHash, Felt, TransactionHash};
 use starknet_types::traits::HashProducer;
+use starknet_types::DevnetResult;
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct DeclareTransactionV1 {
@@ -47,7 +48,7 @@ impl DeclareTransactionV1 {
 }
 
 impl HashProducer for DeclareTransactionV1 {
-    fn generate_hash(&self) -> starknet_types::DevnetResult<Felt> {
+    fn generate_hash(&self) -> DevnetResult<Felt> {
         let class_hash = self.class_hash.unwrap_or(self.contract_class.generate_hash()?);
 
         let (calldata, additional_data) = (Vec::new(), vec![class_hash.into()]);

--- a/crates/starknet/src/transactions/declare_transaction_v2.rs
+++ b/crates/starknet/src/transactions/declare_transaction_v2.rs
@@ -3,9 +3,9 @@ use starknet_in_rust::core::transaction_hash::{
 };
 use starknet_types::contract_address::ContractAddress;
 use starknet_types::contract_class::ContractClass;
-use starknet_types::error::Error;
 use starknet_types::felt::{ClassHash, Felt, TransactionHash};
 use starknet_types::traits::HashProducer;
+use starknet_types::DevnetResult;
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct DeclareTransactionV2 {
@@ -27,7 +27,7 @@ impl DeclareTransactionV2 {
 }
 
 impl HashProducer for DeclareTransactionV2 {
-    fn generate_hash(&self) -> starknet_types::DevnetResult<Felt> {
+    fn generate_hash(&self) -> DevnetResult<Felt> {
         let class_hash = self.class_hash.unwrap_or(self.sierra_contract_class.generate_hash()?);
 
         let calldata = [class_hash.into()].to_vec();
@@ -44,7 +44,7 @@ impl HashProducer for DeclareTransactionV2 {
             &additional_data,
         )
         .map_err(|err| {
-            Error::TransactionError(
+            starknet_types::error::Error::TransactionError(
                 starknet_in_rust::transaction::error::TransactionError::Syscall(err),
             )
         })?

--- a/crates/starknet/src/utils.rs
+++ b/crates/starknet/src/utils.rs
@@ -4,30 +4,27 @@ use starknet_api::hash::{pedersen_hash, StarkFelt};
 use starknet_in_rust::utils::calculate_sn_keccak;
 use starknet_types::cairo_felt::Felt252;
 use starknet_types::contract_class::ContractClass;
-use starknet_types::error::Error;
 use starknet_types::felt::Felt;
 use starknet_types::num_integer::Integer;
 use starknet_types::patricia_key::{PatriciaKey, StorageKey};
-use starknet_types::DevnetResult;
+
+use crate::error::{Error, Result};
 
 pub(crate) fn generate_u128_random_numbers(
     seed: u32,
     random_numbers_count: u8,
-) -> DevnetResult<Vec<u128>> {
+) -> Result<Vec<u128>> {
     Ok(random_number_generator::generate_u128_random_numbers(seed, random_numbers_count))
 }
 
-pub(crate) fn load_cairo_0_contract_class(path: &str) -> DevnetResult<ContractClass> {
+pub(crate) fn load_cairo_0_contract_class(path: &str) -> Result<ContractClass> {
     let contract_class_str = fs::read_to_string(path)
         .map_err(|err| Error::ReadFileError { source: err, path: path.to_string() })?;
-    ContractClass::cairo_0_from_json_str(&contract_class_str)
+    Ok(ContractClass::cairo_0_from_json_str(&contract_class_str)?)
 }
 
 /// Returns the storage address of a StarkNet storage variable given its name and arguments.
-pub(crate) fn get_storage_var_address(
-    storage_var_name: &str,
-    args: &[Felt],
-) -> DevnetResult<StorageKey> {
+pub(crate) fn get_storage_var_address(storage_var_name: &str, args: &[Felt]) -> Result<StorageKey> {
     let storage_var_name_hash = calculate_sn_keccak(storage_var_name.as_bytes());
     let storage_var_name_hash = StarkFelt::new(storage_var_name_hash)?;
 
@@ -39,7 +36,7 @@ pub(crate) fn get_storage_var_address(
         &Felt252::from_bytes_be(&starknet_api::core::L2_ADDRESS_UPPER_BOUND.to_bytes_be()),
     );
 
-    PatriciaKey::new(Felt::new(storage_key.to_be_bytes())?)
+    Ok(PatriciaKey::new(Felt::new(storage_key.to_be_bytes())?)?)
 }
 
 #[cfg(test)]

--- a/crates/types/src/error.rs
+++ b/crates/types/src/error.rs
@@ -3,17 +3,11 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum Error {
     #[error(transparent)]
-    StateError(#[from] starknet_in_rust::core::errors::state_errors::StateError),
-    #[error(transparent)]
     StarknetApiError(#[from] starknet_api::StarknetApiError),
     #[error("Error when calling python module")]
     PyModuleError,
     #[error(transparent)]
     ConversionError(#[from] ConversionError),
-    #[error(transparent)]
-    IOError(#[from] std::io::Error),
-    #[error("Error when reading file {path}")]
-    ReadFileError { source: std::io::Error, path: String },
     #[error(transparent)]
     JsonError(#[from] JsonError),
     #[error(transparent)]

--- a/crates/types/src/patricia_key.rs
+++ b/crates/types/src/patricia_key.rs
@@ -55,13 +55,15 @@ mod tests {
 
     #[test]
     fn creation_of_patricia_key_should_be_successful() {
-        assert!(PatriciaKey::new(
-            Felt::from_prefixed_hex_str(
-                "0x7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        assert!(
+            PatriciaKey::new(
+                Felt::from_prefixed_hex_str(
+                    "0x7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+                )
+                .unwrap()
             )
-            .unwrap()
-        )
-        .is_ok());
+            .is_ok()
+        );
     }
 
     #[test]

--- a/crates/types/src/patricia_key.rs
+++ b/crates/types/src/patricia_key.rs
@@ -34,7 +34,7 @@ impl TryFrom<PatriciaKey> for starknet_api::core::PatriciaKey {
 
     fn try_from(value: PatriciaKey) -> Result<Self, Self::Error> {
         let stark_hash: starknet_api::hash::StarkFelt = value.0.into();
-        starknet_api::core::PatriciaKey::try_from(stark_hash).map_err(Error::StarknetApiError)
+        Ok(starknet_api::core::PatriciaKey::try_from(stark_hash)?)
     }
 }
 
@@ -55,15 +55,13 @@ mod tests {
 
     #[test]
     fn creation_of_patricia_key_should_be_successful() {
-        assert!(
-            PatriciaKey::new(
-                Felt::from_prefixed_hex_str(
-                    "0x7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-                )
-                .unwrap()
+        assert!(PatriciaKey::new(
+            Felt::from_prefixed_hex_str(
+                "0x7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
             )
-            .is_ok()
-        );
+            .unwrap()
+        )
+        .is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

## Development related changes

<!-- How these changes affect the developers of this project. E.g. changes in dev tools, testing, CI/CD... -->
This pr aims to create tree like error structure. Where each crate/large module contains error module that encapsulates the errors of dependant crates. Prior most of the errors where created in types/error which would make harder to track errors since the same error could appear in different crates.

Errors from subcrate can be transformed with adding corresponding enum variant, ex:

```
#[derive(Error, Debug)]
pub enum CrateError {
  #[error("Subcrate error")]
  SubcrateError(#[from] subcrate::error::Error)
}
```


## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Documented the changes
- [ ] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing - `cargo test`
