### PR TITLE
Example PR. FeltHex and Felt united under types

### DIFF
--- a/crates/starknet-server/src/api/http/endpoints/mint_token.rs
+++ b/crates/starknet-server/src/api/http/endpoints/mint_token.rs
@@ -46,6 +46,6 @@ pub(crate) async fn mint(
     Ok(Json(MintTokensResponse {
         new_balance: new_balance.to_str_radix(10),
         unit: "WEI".to_string(),
-        tx_hash: FeltHex(tx_hash),
+        tx_hash,
     }))
 }

--- a/crates/starknet-server/src/api/http/endpoints/postman.rs
+++ b/crates/starknet-server/src/api/http/endpoints/postman.rs
@@ -5,7 +5,7 @@ use crate::api::http::models::{
     MessageFromL2, MessageHash, MessageToL2, PostmanLoadL1MessagingContract,
 };
 use crate::api::http::HttpApiResult;
-use crate::api::models::transaction::TransactionHashHex;
+use starknet_types::felt::TransactionHash;
 
 pub(crate) async fn postman_load(
     Json(_l1_contract): Json<PostmanLoadL1MessagingContract>,
@@ -19,7 +19,7 @@ pub(crate) async fn postman_flush() -> HttpApiResult<()> {
 
 pub(crate) async fn postman_send_message_to_l2(
     Json(_data): Json<MessageToL2>,
-) -> HttpApiResult<Json<TransactionHashHex>> {
+) -> HttpApiResult<Json<TransactionHash>> {
     Err(HttpApiError::GeneralError)
 }
 

--- a/crates/starknet-server/src/api/http/models.rs
+++ b/crates/starknet-server/src/api/http/models.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
+use starknet_types::felt::{Calldata, EntryPointSelector, Nonce, TransactionHash};
 use starknet_types::starknet_api::transaction::Fee;
 
 use crate::api::models::block::BlockHashHex;
-use crate::api::models::transaction::{Calldata, EntryPointSelectorHex, Nonce, TransactionHashHex};
 use crate::api::models::{ContractAddressHex, FeltHex};
 
 #[derive(Deserialize, Debug)]
@@ -20,7 +20,7 @@ pub(crate) struct PostmanLoadL1MessagingContract {
 #[derive(Deserialize)]
 pub(crate) struct MessageToL2 {
     l2_contract_address: ContractAddressHex,
-    entry_point_selector: EntryPointSelectorHex,
+    entry_point_selector: EntryPointSelector,
     l1_contract_addresss: ContractAddressHex,
     payload: Calldata,
     paid_fee_on_l1: Fee,
@@ -96,7 +96,7 @@ pub(crate) struct MintTokensResponse {
     /// decimal repr
     pub(crate) new_balance: String,
     pub(crate) unit: String,
-    pub(crate) tx_hash: TransactionHashHex,
+    pub(crate) tx_hash: TransactionHash,
 }
 
 #[derive(Serialize)]

--- a/crates/starknet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-server/src/api/json_rpc/mod.rs
@@ -334,9 +334,7 @@ mod requests_tests {
 
         match request {
             StarknetRequest::TransactionByHash(input) => {
-                assert!(
-                    input.transaction_hash.0 == Felt::from_prefixed_hex_str("0x134134").unwrap()
-                );
+                assert!(input.transaction_hash == Felt::from_prefixed_hex_str("0x134134").unwrap());
             }
             _ => panic!("Wrong request type"),
         }

--- a/crates/starknet-server/src/api/json_rpc/models.rs
+++ b/crates/starknet-server/src/api/json_rpc/models.rs
@@ -1,11 +1,11 @@
 use serde::{Deserialize, Serialize};
+use starknet_types::felt::{ClassHash, TransactionHash};
 use starknet_types::starknet_api::block::BlockNumber;
 
 use crate::api::models::block::{BlockHashHex, SyncStatus};
 use crate::api::models::transaction::{
     BroadcastedDeclareTransaction, BroadcastedDeployAccountTransaction,
-    BroadcastedInvokeTransaction, BroadcastedTransactionWithType, ClassHashHex, EventFilter,
-    FunctionCall, TransactionHashHex,
+    BroadcastedInvokeTransaction, BroadcastedTransactionWithType, EventFilter, FunctionCall,
 };
 use crate::api::models::{BlockId, ContractAddressHex, PatriciaKeyHex};
 
@@ -16,7 +16,7 @@ pub struct BlockIdInput {
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct TransactionHashInput {
-    pub(crate) transaction_hash: TransactionHashHex,
+    pub(crate) transaction_hash: TransactionHash,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
@@ -35,7 +35,7 @@ pub struct BlockAndIndexInput {
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct BlockAndClassHashInput {
     pub(crate) block_id: BlockId,
-    pub(crate) class_hash: ClassHashHex,
+    pub(crate) class_hash: ClassHash,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
@@ -87,8 +87,8 @@ pub struct BroadcastedDeclareTransactionInput {
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct DeclareTransactionOutput {
-    pub transaction_hash: TransactionHashHex,
-    pub class_hash: ClassHashHex,
+    pub transaction_hash: TransactionHash,
+    pub class_hash: ClassHash,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
@@ -98,7 +98,7 @@ pub struct BroadcastedDeployAccountTransactionInput {
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct DeployAccountTransactionOutput {
-    pub transaction_hash: TransactionHashHex,
+    pub transaction_hash: TransactionHash,
     pub contract_address: ContractAddressHex,
 }
 
@@ -109,7 +109,7 @@ pub struct BroadcastedInvokeTransactionInput {
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct InvokeTransactionOutput {
-    pub transaction_hash: TransactionHashHex,
+    pub transaction_hash: TransactionHash,
 }
 
 #[cfg(test)]
@@ -342,8 +342,8 @@ mod tests {
                     contract_address: ContractAddressHex(
                         ContractAddress::new(Felt::from_prefixed_hex_str("0x01").unwrap()).unwrap()
                     ),
-                    entry_point_selector: FeltHex(Felt::from_prefixed_hex_str("0x02").unwrap()),
-                    calldata: vec![FeltHex(Felt::from_prefixed_hex_str("0x03").unwrap())],
+                    entry_point_selector: Felt::from_prefixed_hex_str("0x02").unwrap(),
+                    calldata: vec![Felt::from_prefixed_hex_str("0x03").unwrap()],
                 },
                 block_id: BlockId::HashOrNumber(BlockHashOrNumber::Number(BlockNumber(1))),
             }
@@ -554,7 +554,7 @@ mod tests {
             serde_json::from_str::<super::TransactionHashInput>(json_str_transaction_hash)
         {
             transaction_hash_input.transaction_hash
-                == FeltHex(Felt::from_prefixed_hex_str(expected_transaction_hash).unwrap())
+                == Felt::from_prefixed_hex_str(expected_transaction_hash).unwrap()
         } else {
             false
         };

--- a/crates/starknet-server/src/api/json_rpc/write_endpoints.rs
+++ b/crates/starknet-server/src/api/json_rpc/write_endpoints.rs
@@ -40,10 +40,7 @@ impl JsonRpcHandler {
             }
         };
 
-        Ok(DeclareTransactionOutput {
-            transaction_hash: FeltHex(transaction_hash),
-            class_hash: FeltHex(class_hash),
-        })
+        Ok(DeclareTransactionOutput { transaction_hash, class_hash })
     }
 
     pub(crate) async fn add_deploy_account_transaction(
@@ -68,7 +65,7 @@ impl JsonRpcHandler {
             })?;
 
         Ok(DeployAccountTransactionOutput {
-            transaction_hash: FeltHex(transaction_hash),
+            transaction_hash,
             contract_address: ContractAddressHex(contract_address),
         })
     }
@@ -91,7 +88,7 @@ impl JsonRpcHandler {
             }
         }?;
 
-        Ok(InvokeTransactionOutput { transaction_hash: FeltHex(hash) })
+        Ok(InvokeTransactionOutput { transaction_hash: hash })
     }
 }
 
@@ -102,8 +99,8 @@ fn convert_to_declare_transaction_v1(
     DeclareTransactionV1::new(
         value.sender_address.0,
         value.common.max_fee.0,
-        value.common.signature.iter().map(|x| x.0).collect(),
-        value.common.nonce.0,
+        value.common.signature,
+        value.common.nonce,
         ContractClass::try_from(value.contract_class)?,
         chain_id,
     )
@@ -115,14 +112,14 @@ fn convert_to_deploy_account_transaction(
     chain_id: Felt,
 ) -> RpcResult<DeployAccountTransaction> {
     DeployAccountTransaction::new(
-        broadcasted_txn.constructor_calldata.iter().map(|felt_hex| felt_hex.0).collect(),
+        broadcasted_txn.constructor_calldata,
         broadcasted_txn.common.max_fee.0,
-        broadcasted_txn.common.signature.iter().map(|felt_hex| felt_hex.0).collect(),
-        broadcasted_txn.common.nonce.0,
-        broadcasted_txn.class_hash.0,
-        broadcasted_txn.contract_address_salt.0,
+        broadcasted_txn.common.signature,
+        broadcasted_txn.common.nonce,
+        broadcasted_txn.class_hash,
+        broadcasted_txn.contract_address_salt,
         chain_id,
-        broadcasted_txn.common.version.0,
+        broadcasted_txn.common.version,
     )
     .map_err(|err| {
         ApiError::RpcError(RpcError::invalid_params(format!(
@@ -138,11 +135,11 @@ fn convert_to_declare_transaction_v2(
 ) -> RpcResult<DeclareTransactionV2> {
     DeclareTransactionV2::new(
         ContractClass::from(value.contract_class),
-        value.compiled_class_hash.0,
+        value.compiled_class_hash,
         value.sender_address.0,
         value.common.max_fee.0,
-        value.common.signature.iter().map(|x| x.0).collect(),
-        value.common.nonce.0,
+        value.common.signature,
+        value.common.nonce,
         chain_id,
     )
     .map_err(ApiError::StarknetDevnetError)
@@ -155,9 +152,9 @@ fn convert_to_invoke_transaction_v1(
     InvokeTransactionV1::new(
         value.sender_address.0,
         value.common.max_fee.0,
-        value.common.signature.iter().map(|felt_hex| felt_hex.0).collect(),
-        value.common.nonce.0,
-        value.calldata.iter().map(|felt_hex| felt_hex.0).collect(),
+        value.common.signature,
+        value.common.nonce,
+        value.calldata,
         chain_id,
     )
     .map_err(ApiError::StarknetDevnetError)
@@ -195,7 +192,7 @@ mod tests {
         // which resulted in transaction_hash
         // 0x1d50d192f54d8d75e73c8ab8fb7159e70bfdbccc322abb43a081889a3043627 Could be checked in https://testnet.starkscan.co/tx/0x1d50d192f54d8d75e73c8ab8fb7159e70bfdbccc322abb43a081889a3043627
         assert_eq!(
-            result.class_hash.0.to_prefixed_hex_str(),
+            result.class_hash.to_prefixed_hex_str(),
             "0x399998c787e0a063c3ac1d2abac084dcbe09954e3b156d53a8c43a02aa27d35"
         );
     }

--- a/crates/starknet-server/src/api/models/state.rs
+++ b/crates/starknet-server/src/api/models/state.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
+use starknet_types::felt::{ClassHash, Nonce};
 
 use super::block::{BlockHashHex, GlobalRootHex};
-use super::transaction::{ClassHashHex, Nonce};
 use super::{ContractAddressHex, FeltHex, PatriciaKeyHex};
 
 pub type CompiledClassHashHex = FeltHex;
@@ -19,7 +19,7 @@ pub struct ThinStateDiff {
     pub deployed_contracts: Vec<DeployedContract>,
     pub storage_diffs: Vec<StorageDiff>,
     pub declared_classes: Vec<ClassHashes>,
-    pub deprecated_declared_classes: Vec<ClassHashHex>,
+    pub deprecated_declared_classes: Vec<ClassHash>,
     pub nonces: Vec<ContractNonce>,
     pub replaced_classes: Vec<ReplacedClasses>,
 }
@@ -28,7 +28,7 @@ pub struct ThinStateDiff {
 #[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct DeployedContract {
     pub address: ContractAddressHex,
-    pub class_hash: ClassHashHex,
+    pub class_hash: ClassHash,
 }
 
 /// Storage differences in Starknet.
@@ -48,14 +48,14 @@ pub struct StorageEntry {
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct ClassHashes {
-    pub class_hash: ClassHashHex,
+    pub class_hash: ClassHash,
     pub compiled_class_hash: CompiledClassHashHex,
 }
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct ReplacedClasses {
     pub contract_address: ContractAddressHex,
-    pub class_hash: ClassHashHex,
+    pub class_hash: ClassHash,
 }
 
 /// The nonce of a Starknet contract.

--- a/crates/starknet-server/src/api/models/transaction.rs
+++ b/crates/starknet-server/src/api/models/transaction.rs
@@ -2,6 +2,10 @@ use std::collections::HashSet;
 
 use serde::{Deserialize, Serialize};
 use starknet_rs_core::types::BlockId;
+use starknet_types::felt::{
+    Calldata, ClassHash, CompiledClassHash, ContractAddressSalt, EntryPointSelector, Felt, Nonce,
+    TransactionHash, TransactionSignature, TransactionVersion,
+};
 use starknet_types::starknet_api::block::BlockNumber;
 use starknet_types::starknet_api::transaction::{EthAddress, Fee};
 
@@ -10,20 +14,10 @@ use super::contract_class::DeprecatedContractClass;
 use super::{ContractAddressHex, FeltHex};
 use crate::api::serde_helpers::rpc_sierra_contract_class_to_sierra_contract_class::deserialize_to_sierra_contract_class;
 
-pub type TransactionHashHex = FeltHex;
-pub type ClassHashHex = FeltHex;
-pub type Nonce = FeltHex;
-pub type TransactionVersionHex = FeltHex;
-pub type TransactionSignature = Vec<FeltHex>;
-pub type CompiledClassHashHex = FeltHex;
-pub type EntryPointSelectorHex = FeltHex;
-pub type Calldata = Vec<FeltHex>;
-pub type ContractAddressSaltHex = FeltHex;
-
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum Transactions {
-    Hashes(Vec<TransactionHashHex>),
+    Hashes(Vec<TransactionHash>),
     Full(Vec<TransactionWithType>),
 }
 
@@ -61,24 +55,24 @@ pub enum Transaction {
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct DeclareTransactionV0V1 {
-    pub class_hash: ClassHashHex,
+    pub class_hash: ClassHash,
     pub sender_address: ContractAddressHex,
     pub nonce: Nonce,
     pub max_fee: Fee,
-    pub version: TransactionVersionHex,
-    pub transaction_hash: TransactionHashHex,
+    pub version: TransactionVersion,
+    pub transaction_hash: TransactionHash,
     pub signature: TransactionSignature,
 }
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct DeclareTransactionV2 {
-    pub class_hash: ClassHashHex,
-    pub compiled_class_hash: CompiledClassHashHex,
+    pub class_hash: ClassHash,
+    pub compiled_class_hash: CompiledClassHash,
     pub sender_address: ContractAddressHex,
     pub nonce: Nonce,
     pub max_fee: Fee,
-    pub version: TransactionVersionHex,
-    pub transaction_hash: TransactionHashHex,
+    pub version: TransactionVersion,
+    pub transaction_hash: TransactionHash,
     pub signature: TransactionSignature,
 }
 
@@ -92,21 +86,21 @@ pub enum DeclareTransaction {
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct InvokeTransactionV0 {
-    pub transaction_hash: TransactionHashHex,
+    pub transaction_hash: TransactionHash,
     pub max_fee: Fee,
-    pub version: TransactionVersionHex,
+    pub version: TransactionVersion,
     pub signature: TransactionSignature,
     pub nonce: Nonce,
     pub contract_address: ContractAddressHex,
-    pub entry_point_selector: EntryPointSelectorHex,
+    pub entry_point_selector: EntryPointSelector,
     pub calldata: Calldata,
 }
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct InvokeTransactionV1 {
-    pub transaction_hash: TransactionHashHex,
+    pub transaction_hash: TransactionHash,
     pub max_fee: Fee,
-    pub version: TransactionVersionHex,
+    pub version: TransactionVersion,
     pub signature: TransactionSignature,
     pub nonce: Nonce,
     pub sender_address: ContractAddressHex,
@@ -122,32 +116,32 @@ pub enum InvokeTransaction {
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct DeployAccountTransaction {
-    pub transaction_hash: TransactionHashHex,
+    pub transaction_hash: TransactionHash,
     pub max_fee: Fee,
-    pub version: TransactionVersionHex,
+    pub version: TransactionVersion,
     pub signature: TransactionSignature,
     pub nonce: Nonce,
-    pub class_hash: ClassHashHex,
-    pub contract_address_salt: ContractAddressSaltHex,
+    pub class_hash: ClassHash,
+    pub contract_address_salt: ContractAddressSalt,
     pub constructor_calldata: Calldata,
 }
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct DeployTransaction {
-    pub transaction_hash: TransactionHashHex,
-    pub version: TransactionVersionHex,
-    pub class_hash: ClassHashHex,
-    pub contract_address_salt: ContractAddressSaltHex,
+    pub transaction_hash: TransactionHash,
+    pub version: TransactionVersion,
+    pub class_hash: ClassHash,
+    pub contract_address_salt: ContractAddressSalt,
     pub constructor_calldata: Calldata,
 }
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct L1HandlerTransaction {
-    pub transaction_hash: TransactionHashHex,
-    pub version: TransactionVersionHex,
+    pub transaction_hash: TransactionHash,
+    pub version: TransactionVersion,
     pub nonce: Nonce,
     pub contract_address: ContractAddressHex,
-    pub entry_point_selector: EntryPointSelectorHex,
+    pub entry_point_selector: EntryPointSelector,
     pub calldata: Calldata,
 }
 
@@ -192,7 +186,7 @@ pub struct DeployTransactionReceipt {
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct CommonTransactionReceipt {
-    pub transaction_hash: TransactionHashHex,
+    pub transaction_hash: TransactionHash,
     pub r#type: TransactionType,
     pub block_hash: BlockHashHex,
     pub block_number: BlockNumber,
@@ -254,14 +248,14 @@ pub struct EventsChunk {
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct FunctionCall {
     pub contract_address: ContractAddressHex,
-    pub entry_point_selector: EntryPointSelectorHex,
+    pub entry_point_selector: EntryPointSelector,
     pub calldata: Calldata,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct BroadcastedTransactionCommon {
     pub max_fee: Fee,
-    pub version: TransactionVersionHex,
+    pub version: TransactionVersion,
     pub signature: TransactionSignature,
     pub nonce: Nonce,
 }
@@ -300,7 +294,7 @@ pub struct BroadcastedInvokeTransactionV0 {
     #[serde(flatten)]
     pub common: BroadcastedTransactionCommon,
     pub contract_address: ContractAddressHex,
-    pub entry_point_selector: EntryPointSelectorHex,
+    pub entry_point_selector: EntryPointSelector,
     pub calldata: Calldata,
 }
 
@@ -327,14 +321,14 @@ pub struct BroadcastedDeclareTransactionV2 {
     #[serde(deserialize_with = "deserialize_to_sierra_contract_class")]
     pub contract_class: starknet_in_rust::SierraContractClass,
     pub sender_address: ContractAddressHex,
-    pub compiled_class_hash: CompiledClassHashHex,
+    pub compiled_class_hash: CompiledClassHash,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct BroadcastedDeployAccountTransaction {
     #[serde(flatten)]
     pub common: BroadcastedTransactionCommon,
-    pub contract_address_salt: ContractAddressSaltHex,
+    pub contract_address_salt: ContractAddressSalt,
     pub constructor_calldata: Calldata,
-    pub class_hash: ClassHashHex,
+    pub class_hash: ClassHash,
 }

--- a/crates/starknet/src/transactions/mod.rs
+++ b/crates/starknet/src/transactions/mod.rs
@@ -9,13 +9,14 @@ use starknet_api::block::BlockNumber;
 use starknet_in_rust::execution::TransactionExecutionInfo;
 use starknet_in_rust::transaction::error::TransactionError;
 use starknet_rs_core::types::TransactionStatus;
-use starknet_types::felt::{BlockHash, TransactionHash};
 
 use self::declare_transaction::DeclareTransactionV1;
 use self::declare_transaction_v2::DeclareTransactionV2;
 use self::deploy_account_transaction::DeployAccountTransaction;
 use self::invoke_transaction::InvokeTransactionV1;
 use crate::traits::HashIdentifiedMut;
+use starknet_types::felt::{BlockHash, TransactionHash};
+use starknet_types::starknet_api::transaction::{EthAddress, Fee};
 
 #[derive(Default)]
 pub struct StarknetTransactions(HashMap<TransactionHash, StarknetTransaction>);


### PR DESCRIPTION
Migrating and uniting Models ContractClasses with Types ContractClasses classes isn't possible without doing so FeltHex. Here's an example PR of how it is going to look.

P.S pr is into my working branch so there're some warning of unused imports during compilation. In case of wanting this in main branch I can cherry-pick those changes and make pr to main branch