### PR TITLE
get_transaction_by_hash 

### DIFF
--- a/crates/starknet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-server/src/api/json_rpc/endpoints.rs
@@ -18,8 +18,8 @@ use crate::api::models::state::{
 };
 use crate::api::models::transaction::{
     BroadcastedTransactionWithType, DeclareTransactionV0V1, DeclareTransactionV2, EventFilter,
-    EventsChunk, FunctionCall, Transaction, TransactionReceipt, TransactionType,
-    TransactionWithType, Transactions, InvokeTransactionV1
+    EventsChunk, FunctionCall, InvokeTransactionV1, Transaction, TransactionReceipt,
+    TransactionType, TransactionWithType, Transactions,
 };
 use crate::api::models::{BlockId, ContractAddressHex, PatriciaKeyHex};
 
@@ -193,7 +193,8 @@ impl JsonRpcHandler {
             }
             starknet_core::transactions::Transaction::DeployAccount(deploy) => {
                 transaction_type = TransactionType::DeployAccount;
-                Transaction::DeployAccount(crate::api::models::transaction::DeployAccountTransaction {
+                Transaction::DeployAccount(
+                    crate::api::models::transaction::DeployAccountTransaction {
                         transaction_hash: Felt::from(deploy.inner.hash_value().clone()),
                         max_fee: Fee(deploy.max_fee),
                         version: deploy.version,
@@ -201,8 +202,8 @@ impl JsonRpcHandler {
                         nonce: deploy.nonce,
                         class_hash: deploy.class_hash().unwrap(), // Panic?
                         contract_address_salt: deploy.contract_address_salt(),
-                        constructor_calldata: deploy.constructor_calldata().clone(),
-                    }
+                        constructor_calldata: deploy.constructor_calldata(),
+                    },
                 )
             }
             starknet_core::transactions::Transaction::Invoke(invoke) => {

--- a/crates/starknet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-server/src/api/json_rpc/endpoints.rs
@@ -171,7 +171,7 @@ impl JsonRpcHandler {
                         nonce: declare_v1.nonce,
                         max_fee: Fee(declare_v1.max_fee),
                         version: Felt::from(1),
-                        transaction_hash: declare_v1.transaction_hash.unwrap(),
+                        transaction_hash: declare_v1.transaction_hash.unwrap_or_default(),
                         signature: declare_v1.signature,
                     },
                 ))
@@ -180,12 +180,12 @@ impl JsonRpcHandler {
                 transaction_type = TransactionType::Declare;
                 Transaction::Declare(crate::api::models::transaction::DeclareTransaction::Version2(
                     DeclareTransactionV2 {
-                        class_hash: declare_v2.class_hash.unwrap(),
+                        class_hash: declare_v2.class_hash.unwrap_or_default(),
                         sender_address: ContractAddressHex(declare_v2.sender_address),
                         nonce: declare_v2.nonce,
                         max_fee: Fee(declare_v2.max_fee),
                         version: Felt::from(2),
-                        transaction_hash: declare_v2.transaction_hash.unwrap(),
+                        transaction_hash: declare_v2.transaction_hash.unwrap_or_default(),
                         signature: declare_v2.signature,
                         compiled_class_hash: declare_v2.compiled_class_hash,
                     },
@@ -200,7 +200,7 @@ impl JsonRpcHandler {
                         version: deploy.version,
                         signature: deploy.signature.clone(),
                         nonce: deploy.nonce,
-                        class_hash: deploy.class_hash().unwrap(), // Panic?
+                        class_hash: deploy.class_hash().unwrap_or_default(),
                         contract_address_salt: deploy.contract_address_salt(),
                         constructor_calldata: deploy.constructor_calldata(),
                     },
@@ -216,7 +216,9 @@ impl JsonRpcHandler {
                         signature: invoke.signature.clone(),
                         nonce: invoke.nonce,
                         calldata: invoke.calldata.clone(),
-                        sender_address: ContractAddressHex(invoke.sender_address().unwrap()), /* Panic? */
+                        sender_address: ContractAddressHex(
+                            invoke.sender_address().unwrap_or_default(),
+                        ),
                     },
                 ))
             }

--- a/crates/starknet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-server/src/api/json_rpc/endpoints.rs
@@ -19,7 +19,7 @@ use crate::api::models::state::{
 use crate::api::models::transaction::{
     BroadcastedTransactionWithType, DeclareTransactionV0V1, DeclareTransactionV2, EventFilter,
     EventsChunk, FunctionCall, Transaction, TransactionReceipt, TransactionType,
-    TransactionWithType, Transactions,
+    TransactionWithType, Transactions, InvokeTransactionV0
 };
 use crate::api::models::{BlockId, ContractAddressHex, PatriciaKeyHex};
 
@@ -191,12 +191,36 @@ impl JsonRpcHandler {
                     },
                 ))
             }
-            starknet_core::transactions::Transaction::DeployAccount(_deploy) => {
-                return Err(error::ApiError::TransactionNotFound);
+            starknet_core::transactions::Transaction::DeployAccount(deploy) => {
+                transaction_type = TransactionType::DeployAccount;
+                Transaction::DeployAccount(crate::api::models::transaction::DeployAccountTransaction {
+                        transaction_hash: Felt::from(deploy.inner.hash_value().clone()), // Clone is ok?
+                        max_fee: Fee(deploy.max_fee),
+                        version: deploy.version,
+                        signature: deploy.signature,
+                        nonce: deploy.nonce,
+                        class_hash: deploy.class_hash().unwrap(), // Panic?
+                        contract_address_salt: deploy.contract_address_salt(),
+                        constructor_calldata: deploy.constructor_calldata(),
+                    }
+                )
             }
-            starknet_core::transactions::Transaction::Invoke(_invoke) => {
-                return Err(error::ApiError::TransactionNotFound);
+            starknet_core::transactions::Transaction::Invoke(invoke) => {
+                transaction_type = TransactionType::Invoke;
+                Transaction::Invoke(crate::api::models::transaction::InvokeTransaction::Version0(
+                    InvokeTransactionV0 {
+                        transaction_hash: Felt::from(invoke.inner.hash_value().clone()), // Clone is ok?
+                        max_fee: Fee(invoke.max_fee),
+                        version: invoke.version,
+                        signature: invoke.signature,
+                        nonce: invoke.nonce,
+                        contract_address: ContractAddressHex(invoke.inner.contract_address),
+                        entry_point_selector: Felt::from(invoke.inner.entry_point_selector.clone()), // Clone is ok?,
+                        calldata: invoke.calldata,
+                    },
+                ))
             }
+            // What about InvokeV2?
         };
 
         let transaction =

--- a/crates/starknet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-server/src/api/json_rpc/endpoints.rs
@@ -194,7 +194,7 @@ impl JsonRpcHandler {
             starknet_core::transactions::Transaction::DeployAccount(deploy) => {
                 transaction_type = TransactionType::DeployAccount;
                 Transaction::DeployAccount(crate::api::models::transaction::DeployAccountTransaction {
-                        transaction_hash: Felt::from(deploy.inner.hash_value().clone()), // Clone is ok?
+                        transaction_hash: Felt::from(deploy.inner.hash_value().clone()),
                         max_fee: Fee(deploy.max_fee),
                         version: deploy.version,
                         signature: deploy.signature.clone(),
@@ -209,7 +209,7 @@ impl JsonRpcHandler {
                 transaction_type = TransactionType::Invoke;
                 Transaction::Invoke(crate::api::models::transaction::InvokeTransaction::Version1(
                     InvokeTransactionV1 {
-                        transaction_hash: Felt::from(invoke.inner.hash_value().clone()), // Clone is ok?
+                        transaction_hash: Felt::from(invoke.inner.hash_value().clone()),
                         max_fee: Fee(invoke.max_fee),
                         version: invoke.version,
                         signature: invoke.signature.clone(),

--- a/crates/starknet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-server/src/api/json_rpc/endpoints.rs
@@ -4,7 +4,6 @@ use starknet_in_rust::transaction::error::TransactionError;
 use starknet_in_rust::utils::Address;
 use starknet_types::felt::{ClassHash, Felt, TransactionHash};
 use starknet_types::starknet_api::block::BlockNumber;
-use starknet_types::starknet_api::transaction::Fee;
 use starknet_types::traits::ToHexString;
 
 use super::error::{self, ApiError};
@@ -17,9 +16,8 @@ use crate::api::models::state::{
     ThinStateDiff,
 };
 use crate::api::models::transaction::{
-    BroadcastedTransactionWithType, DeclareTransactionV0V1, DeclareTransactionV2, EventFilter,
-    EventsChunk, FunctionCall, InvokeTransactionV1, Transaction, TransactionReceipt,
-    TransactionType, TransactionWithType, Transactions,
+    BroadcastedTransactionWithType, EventFilter, EventsChunk, FunctionCall, Transaction,
+    TransactionReceipt, TransactionWithType, Transactions,
 };
 use crate::api::models::{BlockId, ContractAddressHex, PatriciaKeyHex};
 
@@ -156,12 +154,13 @@ impl JsonRpcHandler {
         transaction_hash: TransactionHash,
     ) -> RpcResult<TransactionWithType> {
         let starknet = self.api.starknet.read().await;
-        let transaction = starknet
+        let transaction_to_map = starknet
             .transactions
             .get(&transaction_hash)
             .ok_or(error::ApiError::TransactionNotFound)?;
+        let transaction = TransactionWithType::try_from(&transaction_to_map.inner)?;
 
-        Ok(TransactionWithType::try_from(&transaction.inner)?)
+        Ok(transaction)
     }
 
     /// starknet_getTransactionByBlockIdAndIndex

--- a/crates/starknet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-server/src/api/json_rpc/endpoints.rs
@@ -216,7 +216,7 @@ impl JsonRpcHandler {
                         signature: invoke.signature.clone(),
                         nonce: invoke.nonce,
                         calldata: invoke.calldata.clone(),
-                        sender_address: ContractAddressHex(invoke.sender_address().unwrap()),
+                        sender_address: ContractAddressHex(invoke.sender_address().unwrap()), /* Panic? */
                     },
                 ))
             }

--- a/crates/starknet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-server/src/api/json_rpc/endpoints.rs
@@ -193,37 +193,32 @@ impl JsonRpcHandler {
             }
             starknet_core::transactions::Transaction::DeployAccount(deploy) => {
                 transaction_type = TransactionType::DeployAccount;
-                let test1 = deploy.class_hash().unwrap();
-                let test2 = deploy.contract_address_salt();
-                let test3 = deploy.constructor_calldata().clone();
                 Transaction::DeployAccount(crate::api::models::transaction::DeployAccountTransaction {
                         transaction_hash: Felt::from(deploy.inner.hash_value().clone()), // Clone is ok?
                         max_fee: Fee(deploy.max_fee),
                         version: deploy.version,
-                        signature: deploy.signature,
+                        signature: deploy.signature.clone(),
                         nonce: deploy.nonce,
-                        class_hash: test1, // Panic?
-                        contract_address_salt: test2,
-                        constructor_calldata: test3,
+                        class_hash: deploy.class_hash().unwrap(), // Panic?
+                        contract_address_salt: deploy.contract_address_salt(),
+                        constructor_calldata: deploy.constructor_calldata().clone(),
                     }
                 )
             }
             starknet_core::transactions::Transaction::Invoke(invoke) => {
                 transaction_type = TransactionType::Invoke;
-                let test1 = invoke.sender_address().unwrap(); //why I need to use test variable?
                 Transaction::Invoke(crate::api::models::transaction::InvokeTransaction::Version1(
                     InvokeTransactionV1 {
                         transaction_hash: Felt::from(invoke.inner.hash_value().clone()), // Clone is ok?
                         max_fee: Fee(invoke.max_fee),
                         version: invoke.version,
-                        signature: invoke.signature,
+                        signature: invoke.signature.clone(),
                         nonce: invoke.nonce,
-                        calldata: invoke.calldata,
-                        sender_address: ContractAddressHex(test1),
+                        calldata: invoke.calldata.clone(),
+                        sender_address: ContractAddressHex(invoke.sender_address().unwrap()),
                     },
                 ))
             }
-            // What about InvokeV0?
         };
 
         let transaction =

--- a/crates/starknet-server/tests/get_transaction_by_hash.rs
+++ b/crates/starknet-server/tests/get_transaction_by_hash.rs
@@ -117,11 +117,6 @@ mod get_transaction_by_hash_integration_tests {
     #[tokio::test]
     async fn get_deploy_account_transaction_by_hash_happy_path() {
         let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
-        // Just some dummy data to pass validation, this will change once
-        // get_transaction_receipt_by_hash will be implemented.
-        // I tried to use ACCOUNT_CLASS_HASH_HEX_FOR_ADDRESS_COMPUTATION but I recived error
-        // ClassHashNotFound, so I just used UDC_CONTRACT_CLASS_HASH as string for now to pass
-        // validation.
         let deploy_account_txn = BroadcastedDeployAccountTransaction {
             max_fee: FieldElement::from_hex_be("0xde0b6b3a7640000").unwrap(),
             signature: vec![
@@ -130,7 +125,7 @@ mod get_transaction_by_hash_integration_tests {
             ],
             nonce: FieldElement::from_hex_be("0x0").unwrap(),
             class_hash: FieldElement::from_hex_be(
-                "0x7B3E05F48F0C69E4A65CE5E076A66271A527AFF2C34CE1083EC6E1526997A69",
+                "0x7B3E05F48F0C69E4A65CE5E076A66271A527AFF2C34CE1083EC6E1526997A69", // UDC_CONTRACT_CLASS_HASH as string
             )
             .unwrap(),
             contract_address_salt: FieldElement::from_hex_be("0x1").unwrap(),
@@ -159,8 +154,6 @@ mod get_transaction_by_hash_integration_tests {
     #[tokio::test]
     async fn get_invoke_v1_transaction_by_hash_happy_path() {
         let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
-        // Just some dummy data to pass validation, this will change once
-        // get_transaction_receipt_by_hash will be implemented.
         let invoke_txn_v1 = BroadcastedInvokeTransactionV1 {
             max_fee: FieldElement::from_hex_be("0xde0b6b3a7640000").unwrap(),
             signature: vec![],

--- a/crates/starknet-server/tests/get_transaction_by_hash.rs
+++ b/crates/starknet-server/tests/get_transaction_by_hash.rs
@@ -66,7 +66,7 @@ mod get_transaction_by_hash_integration_tests {
                 FieldElement::from_hex_be(DECLARE_V1_TRANSACTION_HASH).unwrap()
             );
         } else {
-            panic!(); // Otherwise test should fail
+            panic!("Could not unpack the transaction from {result:?}");
         }
     }
 
@@ -147,7 +147,7 @@ mod get_transaction_by_hash_integration_tests {
                 FieldElement::from_hex_be(DEPLOY_ACCOUNT_TRANSACTION_HASH).unwrap()
             );
         } else {
-            panic!(); // Otherwise test should fail
+            panic!("Could not unpack the transaction from {result:?}");
         }
     }
 
@@ -185,7 +185,7 @@ mod get_transaction_by_hash_integration_tests {
                 FieldElement::from_hex_be(INVOKE_V1_TRANSACTION_HASH).unwrap()
             );
         } else {
-            panic!(); // Otherwise test should fail
+            panic!("Could not unpack the transaction from {result:?}");
         }
     }
 

--- a/crates/starknet-server/tests/get_transaction_by_hash.rs
+++ b/crates/starknet-server/tests/get_transaction_by_hash.rs
@@ -3,7 +3,6 @@ pub mod common;
 mod get_transaction_by_hash_integration_tests {
     use std::sync::Arc;
 
-    use starknet_core::constants::UDC_CONTRACT_CLASS_HASH;
     use starknet_rs_accounts::{Account, SingleOwnerAccount};
     use starknet_rs_core::chain_id;
     use starknet_rs_core::types::contract::{CompiledClass, SierraClass};
@@ -119,8 +118,10 @@ mod get_transaction_by_hash_integration_tests {
     async fn get_deploy_account_transaction_by_hash_happy_path() {
         let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
         // Just some dummy data to pass validation, this will change once
-        // get_transaction_receipt_by_hash will be implemented I tired to use
-        // ACCOUNT_CLASS_HASH_HEX_FOR_ADDRESS_COMPUTATION but ClassHashNotFound
+        // get_transaction_receipt_by_hash will be implemented.
+        // I tried to use ACCOUNT_CLASS_HASH_HEX_FOR_ADDRESS_COMPUTATION but I recived error
+        // ClassHashNotFound, so I just used UDC_CONTRACT_CLASS_HASH as string for now to pass
+        // validation.
         let deploy_account_txn = BroadcastedDeployAccountTransaction {
             max_fee: FieldElement::from_hex_be("0xde0b6b3a7640000").unwrap(),
             signature: vec![
@@ -128,7 +129,10 @@ mod get_transaction_by_hash_integration_tests {
                 FieldElement::from_hex_be("0x1").unwrap(),
             ],
             nonce: FieldElement::from_hex_be("0x0").unwrap(),
-            class_hash: FieldElement::from_hex_be(UDC_CONTRACT_CLASS_HASH).unwrap(),
+            class_hash: FieldElement::from_hex_be(
+                "0x7B3E05F48F0C69E4A65CE5E076A66271A527AFF2C34CE1083EC6E1526997A69",
+            )
+            .unwrap(),
             contract_address_salt: FieldElement::from_hex_be("0x1").unwrap(),
             constructor_calldata: vec![FieldElement::from_hex_be("0x1").unwrap()],
         };
@@ -156,7 +160,7 @@ mod get_transaction_by_hash_integration_tests {
     async fn get_invoke_v1_transaction_by_hash_happy_path() {
         let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
         // Just some dummy data to pass validation, this will change once
-        // get_transaction_receipt_by_hash will be implemented
+        // get_transaction_receipt_by_hash will be implemented.
         let invoke_txn_v1 = BroadcastedInvokeTransactionV1 {
             max_fee: FieldElement::from_hex_be("0xde0b6b3a7640000").unwrap(),
             signature: vec![],

--- a/crates/starknet-server/tests/get_transaction_by_hash.rs
+++ b/crates/starknet-server/tests/get_transaction_by_hash.rs
@@ -8,9 +8,9 @@ mod get_transaction_by_hash_integration_tests {
     use starknet_rs_core::types::contract::{CompiledClass, SierraClass};
     use starknet_rs_core::types::{
         BlockId, BlockTag, BroadcastedDeclareTransactionV1, BroadcastedDeployAccountTransaction,
-        BroadcastedInvokeTransactionV1, FieldElement,
+        BroadcastedInvokeTransactionV1, FieldElement, StarknetError,
     };
-    use starknet_rs_providers::Provider;
+    use starknet_rs_providers::{Provider, ProviderError};
     use starknet_rs_signers::{LocalWallet, SigningKey};
     use starknet_types::felt::Felt;
     use starknet_types::traits::ToHexString;
@@ -66,7 +66,7 @@ mod get_transaction_by_hash_integration_tests {
                 FieldElement::from_hex_be(DECLARE_V1_TRANSACTION_HASH).unwrap()
             );
         } else {
-            panic!();
+            panic!(); // Otherwise test should fail
         }
     }
 
@@ -147,7 +147,7 @@ mod get_transaction_by_hash_integration_tests {
                 FieldElement::from_hex_be(DEPLOY_ACCOUNT_TRANSACTION_HASH).unwrap()
             );
         } else {
-            panic!();
+            panic!(); // Otherwise test should fail
         }
     }
 
@@ -185,7 +185,22 @@ mod get_transaction_by_hash_integration_tests {
                 FieldElement::from_hex_be(INVOKE_V1_TRANSACTION_HASH).unwrap()
             );
         } else {
-            panic!();
+            panic!(); // Otherwise test should fail
+        }
+    }
+
+    #[tokio::test]
+    async fn get_non_existing_transaction() {
+        let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
+        let result = devnet
+            .json_rpc_client
+            .get_transaction_by_hash(FieldElement::from_hex_be("0x0").unwrap())
+            .await
+            .unwrap_err();
+
+        match result {
+            ProviderError::StarknetError(StarknetError::TransactionHashNotFound) => (),
+            _ => panic!("Invalid error: {result:?}"),
         }
     }
 }

--- a/crates/starknet/src/constants.rs
+++ b/crates/starknet/src/constants.rs
@@ -21,7 +21,7 @@ pub const ERC20_CONTRACT_ADDRESS: &str =
 pub(crate) const UDC_CONTRACT_PATH: &str =
     concat!(env!("CARGO_MANIFEST_DIR"), "/accounts_artifacts/UDC_OZ_0.5.0.json");
 
-pub const UDC_CONTRACT_CLASS_HASH: &str =
+pub(crate) const UDC_CONTRACT_CLASS_HASH: &str =
     "0x7B3E05F48F0C69E4A65CE5E076A66271A527AFF2C34CE1083EC6E1526997A69";
 
 pub(crate) const UDC_CONTRACT_ADDRESS: &str =

--- a/crates/starknet/src/constants.rs
+++ b/crates/starknet/src/constants.rs
@@ -21,7 +21,7 @@ pub const ERC20_CONTRACT_ADDRESS: &str =
 pub(crate) const UDC_CONTRACT_PATH: &str =
     concat!(env!("CARGO_MANIFEST_DIR"), "/accounts_artifacts/UDC_OZ_0.5.0.json");
 
-pub(crate) const UDC_CONTRACT_CLASS_HASH: &str =
+pub const UDC_CONTRACT_CLASS_HASH: &str =
     "0x7B3E05F48F0C69E4A65CE5E076A66271A527AFF2C34CE1083EC6E1526997A69";
 
 pub(crate) const UDC_CONTRACT_ADDRESS: &str =

--- a/crates/starknet/src/transactions/deploy_account_transaction.rs
+++ b/crates/starknet/src/transactions/deploy_account_transaction.rs
@@ -8,12 +8,12 @@ use crate::error::{self, Result};
 
 #[derive(Clone)]
 pub struct DeployAccountTransaction {
-    pub(crate) inner: DeployAccount,
-    pub(crate) chain_id: Felt,
-    pub(crate) signature: Vec<Felt>,
-    pub(crate) max_fee: u128,
-    pub(crate) nonce: Felt,
-    pub(crate) version: Felt,
+    pub inner: DeployAccount,
+    pub chain_id: Felt,
+    pub signature: Vec<Felt>,
+    pub max_fee: u128,
+    pub nonce: Felt,
+    pub version: Felt,
 }
 
 impl Eq for DeployAccountTransaction {}

--- a/crates/starknet/src/transactions/invoke_transaction.rs
+++ b/crates/starknet/src/transactions/invoke_transaction.rs
@@ -4,6 +4,7 @@ use starknet_in_rust::transaction::InvokeFunction;
 use starknet_types::contract_address::ContractAddress;
 use starknet_types::felt::Felt;
 use starknet_types::traits::HashProducer;
+use starknet_types::cairo_felt::Felt252;
 
 use crate::error::{self, Result};
 
@@ -65,6 +66,11 @@ impl InvokeTransactionV1 {
 
     pub fn sender_address(&self) -> Result<ContractAddress> {
         self.inner.contract_address().clone().try_into().map_err(error::Error::from)
+    }
+
+    pub fn entry_point_selector(&self) -> Felt252 {
+        // self.inner.entry_point_selector - needs to be decorated with #[getset(get = "pub")]
+        Felt252::from(0)
     }
 
     pub fn calldata(&self) -> &Vec<Felt> {

--- a/crates/starknet/src/transactions/invoke_transaction.rs
+++ b/crates/starknet/src/transactions/invoke_transaction.rs
@@ -68,11 +68,6 @@ impl InvokeTransactionV1 {
         self.inner.contract_address().clone().try_into().map_err(error::Error::from)
     }
 
-    pub fn entry_point_selector(&self) -> Felt252 {
-        // self.inner.entry_point_selector - needs to be decorated with #[getset(get = "pub")]
-        Felt252::from(0)
-    }
-
     pub fn calldata(&self) -> &Vec<Felt> {
         &self.calldata
     }

--- a/crates/starknet/src/transactions/invoke_transaction.rs
+++ b/crates/starknet/src/transactions/invoke_transaction.rs
@@ -9,13 +9,13 @@ use crate::error::{self, Result};
 
 #[derive(Clone)]
 pub struct InvokeTransactionV1 {
-    pub(crate) inner: InvokeFunction,
-    pub(crate) chain_id: Felt,
-    pub(crate) signature: Vec<Felt>,
-    pub(crate) nonce: Felt,
-    pub(crate) calldata: Vec<Felt>,
-    pub(crate) max_fee: u128,
-    pub(crate) version: Felt,
+    pub inner: InvokeFunction,
+    pub chain_id: Felt,
+    pub signature: Vec<Felt>,
+    pub nonce: Felt,
+    pub calldata: Vec<Felt>,
+    pub max_fee: u128,
+    pub version: Felt,
 }
 
 impl Eq for InvokeTransactionV1 {}

--- a/crates/starknet/src/transactions/invoke_transaction.rs
+++ b/crates/starknet/src/transactions/invoke_transaction.rs
@@ -4,7 +4,6 @@ use starknet_in_rust::transaction::InvokeFunction;
 use starknet_types::contract_address::ContractAddress;
 use starknet_types::felt::Felt;
 use starknet_types::traits::HashProducer;
-use starknet_types::cairo_felt::Felt252;
 
 use crate::error::{self, Result};
 


### PR DESCRIPTION
## Usage related changes

- Add of `get_transaction_by_hash()` RPC endpoint for Declare (v1), Declare (v2), DeployAccount, Invoke.

## Development related changes

- Integration tests for `get_transaction_by_hash()` RPC endpoint were added but they will be refactored again after the merge of `get_transaction_receipt_by_hash()` PR. I also added note here https://github.com/0xSpaceShard/starknet-devnet-rs/issues/92.

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing - `cargo test`
