### PR TITLE
Add bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ""
+labels: ""
+assignees: ""
+---
+
+**Describe the bug (observed vs expected behavior)**
+
+A clear and concise description of what the bug is. If applicable, add screenshots to help explain your problem. However, prefer providing plain text.
+
+**Not reproducible on alpha-goerli**
+
+- [ ] This issue is only present on Devnet and cannot be reproduced on alpha-goerli (check the box if true).
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. ...
+2. ...
+   ...
+
+**Devnet version**
+
+- I am using Devnet version:
+- [ ] This happens with a dockerized Devnet (check the box if true).
+- This does not appear on the following Devnet version:
+
+**System specifications**
+
+- OS:


### PR DESCRIPTION
## Usage related changes

- Introduce a bug report template based on [the one used in the devnet-py repo]
(https://github.com/0xSpaceShard/starknet-devnet/blob/master/.github/ISSUE_TEMPLATE/bug_report.md)
  - Inspired by the recent bug reports such as #145 and #147 that seem to have been based on the old template
  - The template in this PR has less content that the one in devnet-py to allow for easier bug reporting.