### PR TITLE
Update starknet in rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5041,7 +5041,7 @@ dependencies = [
 [[package]]
 name = "starknet_in_rust"
 version = "0.3.1"
-source = "git+https://github.com/lambdaclass/starknet_in_rust?rev=7abb894#7abb894f77a546268c564342c8a8901076c56165"
+source = "git+https://github.com/lambdaclass/starknet_in_rust?rev=7c9d906#7c9d906e6820e05dafff65c210a7f3568fc9d468"
 dependencies = [
  "anyhow",
  "base64 0.21.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5041,7 +5041,7 @@ dependencies = [
 [[package]]
 name = "starknet_in_rust"
 version = "0.3.1"
-source = "git+https://github.com/lambdaclass/starknet_in_rust?rev=89a36ff#89a36ff687f18f567214f3edd71b9618fa9ddf8b"
+source = "git+https://github.com/lambdaclass/starknet_in_rust?rev=bfd588f#bfd588ff45dec075cdf057c4bb01b810549613c2"
 dependencies = [
  "anyhow",
  "base64 0.21.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5039,9 +5039,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "starknet_api"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6e445fbd6bf3826dda26fd64aa5311353b4799c9bd1119d6ec1906be4c73bf"
+dependencies = [
+ "cairo-lang-starknet 2.1.0",
+ "derive_more",
+ "hex",
+ "indexmap 1.9.3",
+ "once_cell",
+ "primitive-types 0.12.1",
+ "serde",
+ "serde_json",
+ "starknet-crypto 0.5.1",
+ "thiserror",
+]
+
+[[package]]
 name = "starknet_in_rust"
 version = "0.3.1"
-source = "git+https://github.com/lambdaclass/starknet_in_rust?rev=bfd588f#bfd588ff45dec075cdf057c4bb01b810549613c2"
+source = "git+https://github.com/lambdaclass/starknet_in_rust?rev=579156a#579156a8b2cc1f8f4b1d4327183842a62ac37c29"
 dependencies = [
  "anyhow",
  "base64 0.21.2",
@@ -5067,7 +5085,7 @@ dependencies = [
  "sha3 0.10.8",
  "starknet 0.5.0",
  "starknet-crypto 0.5.1",
- "starknet_api 0.3.0",
+ "starknet_api 0.4.1",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5041,7 +5041,7 @@ dependencies = [
 [[package]]
 name = "starknet_in_rust"
 version = "0.3.1"
-source = "git+https://github.com/lambdaclass/starknet_in_rust?rev=7c9d906#7c9d906e6820e05dafff65c210a7f3568fc9d468"
+source = "git+https://github.com/lambdaclass/starknet_in_rust?rev=3309108#3309108beb1d82079b4552ef788a477f8dd8026f"
 dependencies = [
  "anyhow",
  "base64 0.21.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5041,7 +5041,7 @@ dependencies = [
 [[package]]
 name = "starknet_in_rust"
 version = "0.3.1"
-source = "git+https://github.com/lambdaclass/starknet_in_rust?rev=3309108#3309108beb1d82079b4552ef788a477f8dd8026f"
+source = "git+https://github.com/lambdaclass/starknet_in_rust?rev=08c212b#08c212b958c7e8336d1150fe1c6e4cc75dad7a2a"
 dependencies = [
  "anyhow",
  "base64 0.21.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5041,7 +5041,7 @@ dependencies = [
 [[package]]
 name = "starknet_in_rust"
 version = "0.3.1"
-source = "git+https://github.com/lambdaclass/starknet_in_rust?rev=f05da40#f05da407a33f493e161ff70775be0c3c5856c124"
+source = "git+https://github.com/lambdaclass/starknet_in_rust?rev=7abb894#7abb894f77a546268c564342c8a8901076c56165"
 dependencies = [
  "anyhow",
  "base64 0.21.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5041,7 +5041,7 @@ dependencies = [
 [[package]]
 name = "starknet_in_rust"
 version = "0.3.1"
-source = "git+https://github.com/lambdaclass/starknet_in_rust?rev=08c212b#08c212b958c7e8336d1150fe1c6e4cc75dad7a2a"
+source = "git+https://github.com/lambdaclass/starknet_in_rust?rev=89a36ff#89a36ff687f18f567214f3edd71b9618fa9ddf8b"
 dependencies = [
  "anyhow",
  "base64 0.21.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ anyhow = "1"
 
 # Starknet dependencies
 starknet_api = { version = "0.3.0", features = ["testing"] }
-starknet-in-rust = { git = "https://github.com/lambdaclass/starknet_in_rust", rev = "7abb894", package="starknet_in_rust" }
+starknet-in-rust = { git = "https://github.com/lambdaclass/starknet_in_rust", rev = "7c9d906", package="starknet_in_rust" }
 starknet-rs-signers = { version = "0.4.0", package="starknet-signers" }
 starknet-rs-ff = { version = "0.3.4", package = "starknet-ff" }
 starknet-rs-core = {  version = "0.6.0", package = "starknet-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ anyhow = "1"
 
 # Starknet dependencies
 starknet_api = { version = "0.3.0", features = ["testing"] }
-starknet-in-rust = { git = "https://github.com/lambdaclass/starknet_in_rust", rev = "7c9d906", package="starknet_in_rust" }
+starknet-in-rust = { git = "https://github.com/lambdaclass/starknet_in_rust", rev = "3309108", package="starknet_in_rust" }
 starknet-rs-signers = { version = "0.4.0", package="starknet-signers" }
 starknet-rs-ff = { version = "0.3.4", package = "starknet-ff" }
 starknet-rs-core = {  version = "0.6.0", package = "starknet-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ anyhow = "1"
 
 # Starknet dependencies
 starknet_api = { version = "0.3.0", features = ["testing"] }
-starknet-in-rust = { git = "https://github.com/lambdaclass/starknet_in_rust", rev = "bfd588f", package="starknet_in_rust" }
+starknet-in-rust = { git = "https://github.com/lambdaclass/starknet_in_rust", rev = "579156a", package="starknet_in_rust" }
 starknet-rs-signers = { version = "0.4.0", package="starknet-signers" }
 starknet-rs-ff = { version = "0.3.4", package = "starknet-ff" }
 starknet-rs-core = {  version = "0.6.0", package = "starknet-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ anyhow = "1"
 
 # Starknet dependencies
 starknet_api = { version = "0.3.0", features = ["testing"] }
-starknet-in-rust = { git = "https://github.com/lambdaclass/starknet_in_rust", rev = "f05da40", package="starknet_in_rust" }
+starknet-in-rust = { git = "https://github.com/lambdaclass/starknet_in_rust", rev = "7abb894", package="starknet_in_rust" }
 starknet-rs-signers = { version = "0.4.0", package="starknet-signers" }
 starknet-rs-ff = { version = "0.3.4", package = "starknet-ff" }
 starknet-rs-core = {  version = "0.6.0", package = "starknet-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ anyhow = "1"
 
 # Starknet dependencies
 starknet_api = { version = "0.3.0", features = ["testing"] }
-starknet-in-rust = { git = "https://github.com/lambdaclass/starknet_in_rust", rev = "3309108", package="starknet_in_rust" }
+starknet-in-rust = { git = "https://github.com/lambdaclass/starknet_in_rust", rev = "08c212b", package="starknet_in_rust" }
 starknet-rs-signers = { version = "0.4.0", package="starknet-signers" }
 starknet-rs-ff = { version = "0.3.4", package = "starknet-ff" }
 starknet-rs-core = {  version = "0.6.0", package = "starknet-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ anyhow = "1"
 
 # Starknet dependencies
 starknet_api = { version = "0.3.0", features = ["testing"] }
-starknet-in-rust = { git = "https://github.com/lambdaclass/starknet_in_rust", rev = "89a36ff", package="starknet_in_rust" }
+starknet-in-rust = { git = "https://github.com/lambdaclass/starknet_in_rust", rev = "bfd588f", package="starknet_in_rust" }
 starknet-rs-signers = { version = "0.4.0", package="starknet-signers" }
 starknet-rs-ff = { version = "0.3.4", package = "starknet-ff" }
 starknet-rs-core = {  version = "0.6.0", package = "starknet-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ anyhow = "1"
 
 # Starknet dependencies
 starknet_api = { version = "0.3.0", features = ["testing"] }
-starknet-in-rust = { git = "https://github.com/lambdaclass/starknet_in_rust", rev = "08c212b", package="starknet_in_rust" }
+starknet-in-rust = { git = "https://github.com/lambdaclass/starknet_in_rust", rev = "89a36ff", package="starknet_in_rust" }
 starknet-rs-signers = { version = "0.4.0", package="starknet-signers" }
 starknet-rs-ff = { version = "0.3.4", package = "starknet-ff" }
 starknet-rs-core = {  version = "0.6.0", package = "starknet-core" }

--- a/crates/starknet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-server/src/api/json_rpc/endpoints.rs
@@ -247,6 +247,7 @@ impl JsonRpcHandler {
         request: FunctionCall,
     ) -> RpcResult<Vec<Felt>> {
         let starknet = self.api.starknet.read().await;
+
         match starknet.call(
             block_id.into(),
             request.contract_address.into(),

--- a/crates/starknet-server/tests/test_estimate_message_fee.rs
+++ b/crates/starknet-server/tests/test_estimate_message_fee.rs
@@ -83,7 +83,7 @@ mod test_estimate_message_fee {
             .await
             .unwrap();
 
-        assert_eq!(res.gas_consumed, 19695);
+        assert_eq!(res.gas_consumed, 18471);
     }
 
     #[tokio::test]

--- a/crates/starknet/src/starknet/add_declare_transaction.rs
+++ b/crates/starknet/src/starknet/add_declare_transaction.rs
@@ -196,7 +196,7 @@ mod tests {
     fn add_declare_v2_transaction_should_return_rejected_txn_and_not_be_part_of_pending_state() {
         let (mut starknet, sender) = setup(Some(1));
         let initial_cached_state =
-            starknet.state.pending_state.casm_contract_classes().as_ref().unwrap().len();
+            starknet.state.pending_state.contract_classes().len();
         let declare_txn = dummy_broadcasted_declare_transaction_v2(&sender);
         let (txn_hash, class_hash) = starknet.add_declare_transaction_v2(declare_txn).unwrap();
         let txn = starknet.transactions.get_by_hash_mut(&txn_hash).unwrap();
@@ -205,7 +205,7 @@ mod tests {
         assert_eq!(txn.execution_result.status(), TransactionExecutionStatus::Reverted);
         assert_eq!(
             initial_cached_state,
-            starknet.state.pending_state.casm_contract_classes().as_ref().unwrap().len()
+            starknet.state.pending_state.contract_classes().len()
         );
         assert!(starknet.state.contract_classes.get(&class_hash).is_none())
     }
@@ -245,7 +245,7 @@ mod tests {
             !starknet
                 .state
                 .state
-                .casm_contract_classes_mut()
+                .class_hash_to_compiled_class
                 .contains_key(&expected_compiled_class_hash.bytes())
         );
 
@@ -288,7 +288,7 @@ mod tests {
     fn add_declare_v1_transaction_should_return_rejected_txn_and_not_be_part_of_pending_state() {
         let (mut starknet, sender) = setup(Some(1));
         let initial_cached_state =
-            starknet.state.pending_state.contract_classes().as_ref().unwrap().len();
+            starknet.state.pending_state.contract_classes().len();
         let declare_txn = broadcasted_declare_transaction_v1(sender);
         let (txn_hash, _) = starknet.add_declare_transaction_v1(declare_txn).unwrap();
         let txn = starknet.transactions.get_by_hash_mut(&txn_hash).unwrap();
@@ -297,7 +297,7 @@ mod tests {
         assert_eq!(txn.execution_result.status(), TransactionExecutionStatus::Reverted);
         assert_eq!(
             initial_cached_state,
-            starknet.state.pending_state.contract_classes().as_ref().unwrap().len()
+            starknet.state.pending_state.contract_classes().len()
         );
     }
 

--- a/crates/starknet/src/starknet/add_declare_transaction.rs
+++ b/crates/starknet/src/starknet/add_declare_transaction.rs
@@ -195,18 +195,14 @@ mod tests {
     #[test]
     fn add_declare_v2_transaction_should_return_rejected_txn_and_not_be_part_of_pending_state() {
         let (mut starknet, sender) = setup(Some(1));
-        let initial_cached_state =
-            starknet.state.pending_state.contract_classes().len();
+        let initial_cached_state = starknet.state.pending_state.contract_classes().len();
         let declare_txn = dummy_broadcasted_declare_transaction_v2(&sender);
         let (txn_hash, class_hash) = starknet.add_declare_transaction_v2(declare_txn).unwrap();
         let txn = starknet.transactions.get_by_hash_mut(&txn_hash).unwrap();
 
         assert_eq!(txn.finality_status, None);
         assert_eq!(txn.execution_result.status(), TransactionExecutionStatus::Reverted);
-        assert_eq!(
-            initial_cached_state,
-            starknet.state.pending_state.contract_classes().len()
-        );
+        assert_eq!(initial_cached_state, starknet.state.pending_state.contract_classes().len());
         assert!(starknet.state.contract_classes.get(&class_hash).is_none())
     }
 
@@ -287,18 +283,14 @@ mod tests {
     #[test]
     fn add_declare_v1_transaction_should_return_rejected_txn_and_not_be_part_of_pending_state() {
         let (mut starknet, sender) = setup(Some(1));
-        let initial_cached_state =
-            starknet.state.pending_state.contract_classes().len();
+        let initial_cached_state = starknet.state.pending_state.contract_classes().len();
         let declare_txn = broadcasted_declare_transaction_v1(sender);
         let (txn_hash, _) = starknet.add_declare_transaction_v1(declare_txn).unwrap();
         let txn = starknet.transactions.get_by_hash_mut(&txn_hash).unwrap();
 
         assert_eq!(txn.finality_status, None);
         assert_eq!(txn.execution_result.status(), TransactionExecutionStatus::Reverted);
-        assert_eq!(
-            initial_cached_state,
-            starknet.state.pending_state.contract_classes().len()
-        );
+        assert_eq!(initial_cached_state, starknet.state.pending_state.contract_classes().len());
     }
 
     #[test]

--- a/crates/starknet/src/starknet/mod.rs
+++ b/crates/starknet/src/starknet/mod.rs
@@ -250,7 +250,7 @@ impl Starknet {
         );
 
         let mut block_info = BlockInfo::empty(TEST_SEQUENCER_ADDRESS.clone());
-        block_info.gas_price = gas_price;
+        block_info.gas_price = gas_price as u128;
 
         let block_context = BlockContext::new(
             starknet_os_config,
@@ -288,7 +288,7 @@ impl Starknet {
         let mut block = StarknetBlock::create_pending_block();
 
         block.header.block_number = BlockNumber(self.block_context.block_info().block_number);
-        block.header.gas_price = GasPrice(self.block_context.block_info().gas_price.into());
+        block.header.gas_price = GasPrice(self.block_context.block_info().gas_price);
         block.header.sequencer =
             ContractAddress::try_from(self.block_context.block_info().sequencer_address.clone())?
                 .try_into()?;
@@ -706,7 +706,7 @@ mod tests {
         );
         assert_eq!(starknet.pending_block().header.block_number, BlockNumber(initial_block_number));
         assert_eq!(starknet.pending_block().header.parent_hash, BlockHash::default());
-        assert_eq!(starknet.pending_block().header.gas_price, GasPrice(initial_gas_price as u128));
+        assert_eq!(starknet.pending_block().header.gas_price, GasPrice(initial_gas_price));
         assert_eq!(
             starknet.pending_block().header.sequencer,
             initial_sequencer.try_into().unwrap()

--- a/crates/starknet/src/starknet/mod.rs
+++ b/crates/starknet/src/starknet/mod.rs
@@ -89,7 +89,7 @@ impl Default for StarknetConfig {
             host: String::default(),
             port: u16::default(),
             timeout: u16::default(),
-            gas_price: u64::default(),
+            gas_price: Default::default(),
             chain_id: StarknetChainId::TestNet,
         }
     }

--- a/crates/starknet/src/state/mod.rs
+++ b/crates/starknet/src/state/mod.rs
@@ -154,7 +154,16 @@ impl StateChanger for StarknetState {
 
 impl StateExtractor for StarknetState {
     fn get_storage(&self, storage_key: ContractStorageKey) -> DevnetResult<Felt> {
-        Ok(self.state.get_storage_at(&storage_key.into()).map(Felt::from)?)
+        let storage_entry = storage_key.into();
+        let data = self.state
+            .get_storage_at(&storage_entry)
+            .map(Felt::from)?;
+
+        if data == Felt::default() {
+            return Err(Error::StateError(starknet_in_rust::core::errors::state_errors::StateError::NoneStorage(storage_entry)));
+        }
+        
+        Ok(data)
     }
 
     fn is_contract_declared(&mut self, class_hash: &ClassHash) -> bool {

--- a/crates/starknet/src/state/mod.rs
+++ b/crates/starknet/src/state/mod.rs
@@ -117,9 +117,10 @@ impl StateChanger for StarknetState {
 
         // update cairo 0 differences
         for (class_hash, cairo_0_contract_class) in state_diff.cairo_0_declared_contracts {
-            old_state
-                .class_hash_to_compiled_class_mut()
-                .insert(class_hash.bytes(), CompiledClass::Deprecated(Arc::new(cairo_0_contract_class)));
+            old_state.class_hash_to_compiled_class_mut().insert(
+                class_hash.bytes(),
+                CompiledClass::Deprecated(Arc::new(cairo_0_contract_class)),
+            );
         }
 
         // update class_hash -> compiled_class_hash differences
@@ -133,7 +134,9 @@ impl StateChanger for StarknetState {
 
         // update cairo 1 differences
         state_diff.declared_contracts.into_iter().for_each(|(class_hash, cairo_1_casm)| {
-            old_state.class_hash_to_compiled_class_mut().insert(class_hash.bytes(), CompiledClass::Casm(Arc::new(cairo_1_casm)));
+            old_state
+                .class_hash_to_compiled_class_mut()
+                .insert(class_hash.bytes(), CompiledClass::Casm(Arc::new(cairo_1_casm)));
         });
 
         // update deployed contracts
@@ -155,14 +158,16 @@ impl StateChanger for StarknetState {
 impl StateExtractor for StarknetState {
     fn get_storage(&self, storage_key: ContractStorageKey) -> DevnetResult<Felt> {
         let storage_entry = storage_key.into();
-        let data = self.state
-            .get_storage_at(&storage_entry)
-            .map(Felt::from)?;
+        let data = self.state.get_storage_at(&storage_entry).map(Felt::from)?;
 
         if data == Felt::default() {
-            return Err(Error::StateError(starknet_in_rust::core::errors::state_errors::StateError::NoneStorage(storage_entry)));
+            return Err(Error::StateError(
+                starknet_in_rust::core::errors::state_errors::StateError::NoneStorage(
+                    storage_entry,
+                ),
+            ));
         }
-        
+
         Ok(data)
     }
 
@@ -220,7 +225,10 @@ mod tests {
 
         state
             .pending_state
-            .set_contract_class(&class_hash, &CompiledClass::Deprecated(Arc::new(contract_class.try_into().unwrap())))
+            .set_contract_class(
+                &class_hash,
+                &CompiledClass::Deprecated(Arc::new(contract_class.try_into().unwrap())),
+            )
             .unwrap();
 
         assert!(!state.is_contract_declared(&dummy_felt()));
@@ -324,11 +332,11 @@ mod tests {
         assert!(state.state.class_hash_to_compiled_class.len() == 1);
         let declared_contract_class =
             state.state.class_hash_to_compiled_class.get(&class_hash.bytes()).unwrap().to_owned();
-        
+
         match declared_contract_class {
             CompiledClass::Deprecated(deprecated_contract_class) => {
                 assert_eq!(*deprecated_contract_class, contract_class.try_into().unwrap())
-            },
+            }
             _ => panic!("Wrong version of contract class"),
         }
     }

--- a/crates/starknet/src/state/mod.rs
+++ b/crates/starknet/src/state/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use starknet_in_rust::services::api::contract_classes::compiled_class::CompiledClass;
 use starknet_in_rust::services::api::contract_classes::deprecated_contract_class::ContractClass as StarknetInRustContractClass;
 use starknet_in_rust::state::cached_state::CachedState;
 use starknet_in_rust::state::in_memory_state_reader::InMemoryStateReader;
@@ -34,8 +35,7 @@ impl StarknetState {
     pub(crate) fn synchronize_states(&mut self) {
         self.pending_state = CachedState::new(
             Arc::new(self.state.clone()),
-            Some(self.state.class_hash_to_contract_class.clone()),
-            Some(self.state.casm_contract_classes_mut().clone()),
+            self.state.class_hash_to_compiled_class_mut().clone(),
         );
     }
 }
@@ -45,11 +45,7 @@ impl Default for StarknetState {
         let in_memory_state = InMemoryStateReader::default();
         Self {
             state: in_memory_state.clone(),
-            pending_state: CachedState::new(
-                Arc::new(in_memory_state),
-                Some(Default::default()),
-                Some(Default::default()),
-            ),
+            pending_state: CachedState::new(Arc::new(in_memory_state), Default::default()),
             contract_classes: HashMap::new(),
         }
     }
@@ -65,16 +61,16 @@ impl StateChanger for StarknetState {
 
         match contract_class {
             ContractClass::Cairo0(deprecated_contract_class) => {
-                self.state.class_hash_to_contract_class_mut().insert(
+                self.state.class_hash_to_compiled_class_mut().insert(
                     class_hash.bytes(),
-                    StarknetInRustContractClass::try_from(deprecated_contract_class)?,
+                    starknet_in_rust::services::api::contract_classes::compiled_class::CompiledClass::Deprecated(Arc::new(StarknetInRustContractClass::try_from(deprecated_contract_class)?)),
                 );
             }
             ContractClass::Cairo1(sierra_contract_class) => {
-                self.state.casm_contract_classes_mut().insert(
+                self.state.class_hash_to_compiled_class_mut().insert(
                     class_hash.bytes(),
-                    CasmContractClass::from_contract_class(sierra_contract_class, true)
-                        .map_err(|_| Error::SierraCompilationError)?,
+                    starknet_in_rust::services::api::contract_classes::compiled_class::CompiledClass::Casm(Arc::new(CasmContractClass::from_contract_class(sierra_contract_class, true)
+                        .map_err(|_| Error::SierraCompilationError)?)),
                 );
             }
         }
@@ -122,8 +118,8 @@ impl StateChanger for StarknetState {
         // update cairo 0 differences
         for (class_hash, cairo_0_contract_class) in state_diff.cairo_0_declared_contracts {
             old_state
-                .class_hash_to_contract_class
-                .insert(class_hash.bytes(), cairo_0_contract_class);
+                .class_hash_to_compiled_class_mut()
+                .insert(class_hash.bytes(), CompiledClass::Deprecated(Arc::new(cairo_0_contract_class)));
         }
 
         // update class_hash -> compiled_class_hash differences
@@ -137,7 +133,7 @@ impl StateChanger for StarknetState {
 
         // update cairo 1 differences
         state_diff.declared_contracts.into_iter().for_each(|(class_hash, cairo_1_casm)| {
-            old_state.casm_contract_classes_mut().insert(class_hash.bytes(), cairo_1_casm);
+            old_state.class_hash_to_compiled_class_mut().insert(class_hash.bytes(), CompiledClass::Casm(Arc::new(cairo_1_casm)));
         });
 
         // update deployed contracts
@@ -163,7 +159,7 @@ impl StateExtractor for StarknetState {
 
     fn is_contract_declared(&mut self, class_hash: &ClassHash) -> bool {
         self.state.class_hash_to_compiled_class_hash_mut().contains_key(&class_hash.bytes())
-            || self.state.class_hash_to_contract_class.contains_key(&(class_hash.bytes()))
+            || self.state.class_hash_to_compiled_class.contains_key(&(class_hash.bytes()))
     }
 
     fn is_contract_deployed(&self, address: &ContractAddress) -> bool {
@@ -188,7 +184,10 @@ impl StateExtractor for StarknetState {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use starknet_in_rust::core::errors::state_errors::StateError;
+    use starknet_in_rust::services::api::contract_classes::compiled_class::CompiledClass;
     use starknet_in_rust::state::state_api::{State, StateReader};
     use starknet_types::cairo_felt::Felt252;
     use starknet_types::contract_address::ContractAddress;
@@ -212,7 +211,7 @@ mod tests {
 
         state
             .pending_state
-            .set_contract_class(&class_hash, &contract_class.try_into().unwrap())
+            .set_contract_class(&class_hash, &CompiledClass::Deprecated(Arc::new(contract_class.try_into().unwrap())))
             .unwrap();
 
         assert!(!state.is_contract_declared(&dummy_felt()));
@@ -313,11 +312,16 @@ mod tests {
                 .declare_contract_class(class_hash, contract_class.clone().try_into().unwrap())
                 .is_ok()
         );
-        assert!(state.state.class_hash_to_contract_class.len() == 1);
+        assert!(state.state.class_hash_to_compiled_class.len() == 1);
         let declared_contract_class =
-            state.state.class_hash_to_contract_class.get(&class_hash.bytes());
-        assert!(declared_contract_class.is_some());
-        assert_eq!(*declared_contract_class.unwrap(), contract_class.try_into().unwrap());
+            state.state.class_hash_to_compiled_class.get(&class_hash.bytes()).unwrap().to_owned();
+        
+        match declared_contract_class {
+            CompiledClass::Deprecated(deprecated_contract_class) => {
+                assert_eq!(*deprecated_contract_class, contract_class.try_into().unwrap())
+            },
+            _ => panic!("Wrong version of contract class"),
+        }
     }
 
     #[test]

--- a/crates/starknet/src/state/state_diff.rs
+++ b/crates/starknet/src/state/state_diff.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
-use starknet_in_rust::services::api::contract_classes::{deprecated_contract_class::ContractClass as DeprecatedContractClass, compiled_class::CompiledClass as StarknetInRustCompiledClass };
+use starknet_in_rust::services::api::contract_classes::compiled_class::CompiledClass as StarknetInRustCompiledClass;
+use starknet_in_rust::services::api::contract_classes::deprecated_contract_class::ContractClass as DeprecatedContractClass;
 use starknet_in_rust::state::cached_state::CachedState;
 use starknet_in_rust::state::in_memory_state_reader::InMemoryStateReader;
 use starknet_in_rust::state::StateDiff as StarknetInRustStateDiff;
@@ -63,10 +64,10 @@ impl StateDiff {
             match compiled_class {
                 StarknetInRustCompiledClass::Deprecated(cairo_0) => {
                     cairo_0_declared_contracts.insert(key, cairo_0.as_ref().clone());
-                },
+                }
                 StarknetInRustCompiledClass::Casm(cairo_1) => {
                     declared_contracts.insert(key, cairo_1.as_ref().clone());
-                },
+                }
             }
         }
 
@@ -142,10 +143,12 @@ mod tests {
         let compiled_class_hash = Felt::from(1);
         casm_cache.insert(
             compiled_class_hash.bytes(),
-            CompiledClass::Casm(Arc::new(CasmContractClass::from_contract_class(dummy_cairo_1_contract_class(), true).unwrap())),
+            CompiledClass::Casm(Arc::new(
+                CasmContractClass::from_contract_class(dummy_cairo_1_contract_class(), true)
+                    .unwrap(),
+            )),
         );
-        let new_state =
-            CachedState::new(Arc::new(old_state.clone()), casm_cache);
+        let new_state = CachedState::new(Arc::new(old_state.clone()), casm_cache);
 
         let generated_diff =
             super::StateDiff::difference_between_old_and_new_state(old_state, new_state).unwrap();
@@ -166,13 +169,12 @@ mod tests {
         let class_hash = Felt::from(1);
         let cairo_0_contract_class: Cairo0ContractClass = dummy_cairo_0_contract_class().into();
         let mut cairo_0_classes = ContractClassCache::new();
-        cairo_0_classes
-            .insert(class_hash.bytes(), CompiledClass::Deprecated(Arc::new(cairo_0_contract_class.clone().try_into().unwrap())));
-
-        let new_state = CachedState::new(
-            Arc::new(old_state.clone()),
-            cairo_0_classes
+        cairo_0_classes.insert(
+            class_hash.bytes(),
+            CompiledClass::Deprecated(Arc::new(cairo_0_contract_class.clone().try_into().unwrap())),
         );
+
+        let new_state = CachedState::new(Arc::new(old_state.clone()), cairo_0_classes);
 
         let generated_diff =
             super::StateDiff::difference_between_old_and_new_state(old_state, new_state).unwrap();
@@ -222,8 +224,7 @@ mod tests {
 
     fn setup() -> (InMemoryStateReader, CachedState<InMemoryStateReader>) {
         let state = InMemoryStateReader::default();
-        let cached_state =
-            CachedState::new(Arc::new(state.clone()), HashMap::new());
+        let cached_state = CachedState::new(Arc::new(state.clone()), HashMap::new());
 
         (state, cached_state)
     }

--- a/crates/starknet/src/state/state_diff.rs
+++ b/crates/starknet/src/state/state_diff.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use starknet_in_rust::services::api::contract_classes::deprecated_contract_class::ContractClass as DeprecatedContractClass;
+use starknet_in_rust::services::api::contract_classes::{deprecated_contract_class::ContractClass as DeprecatedContractClass, compiled_class::CompiledClass as StarknetInRustCompiledClass };
 use starknet_in_rust::state::cached_state::CachedState;
 use starknet_in_rust::state::in_memory_state_reader::InMemoryStateReader;
 use starknet_in_rust::state::StateDiff as StarknetInRustStateDiff;
@@ -50,31 +50,24 @@ impl StateDiff {
             class_hash_to_compiled_class_hash.insert(key, value);
         }
 
-        // extract difference of compiled_class_hash -> CasmContractClass mapping, which is Cairo 1
-        // contract
-        let new_casm_contract_classes =
-            new_state.casm_contract_classes().clone().unwrap_or_default();
-
-        let compiled_class_hash_to_cairo_casm = subtract_mappings(
-            new_casm_contract_classes,
-            old_state.casm_contract_classes_mut().clone(),
+        // extract difference of class hash -> CompiledClass. When CompiledClass is Cairo 1, then
+        // the class hash is compiled class hash
+        let new_compiled_contract_classes = subtract_mappings(
+            new_state.contract_classes().clone(),
+            old_state.class_hash_to_compiled_class_mut().clone(),
         );
 
-        for (compiled_class_hash_bytes, casm_contract_class) in compiled_class_hash_to_cairo_casm {
-            let key = Felt::new(compiled_class_hash_bytes).map_err(crate::error::Error::from)?;
+        for (class_hash, compiled_class) in new_compiled_contract_classes {
+            let key = Felt::new(class_hash).map_err(crate::error::Error::from)?;
 
-            declared_contracts.insert(key, casm_contract_class);
-        }
-
-        // extract difference of class_hash -> Cairo 0 contract class
-        let class_hash_to_cairo_0_contract_class = subtract_mappings(
-            new_state.contract_classes().clone().unwrap_or_default(),
-            old_state.class_hash_to_contract_class.clone(),
-        );
-
-        for (class_hash_bytes, cairo_0_contract_class) in class_hash_to_cairo_0_contract_class {
-            let key = Felt::new(class_hash_bytes).map_err(crate::error::Error::from)?;
-            cairo_0_declared_contracts.insert(key, cairo_0_contract_class);
+            match compiled_class {
+                StarknetInRustCompiledClass::Deprecated(cairo_0) => {
+                    cairo_0_declared_contracts.insert(key, cairo_0.as_ref().clone());
+                },
+                StarknetInRustCompiledClass::Casm(cairo_1) => {
+                    declared_contracts.insert(key, cairo_1.as_ref().clone());
+                },
+            }
         }
 
         let diff = StarknetInRustStateDiff::from_cached_state(new_state)?;
@@ -93,7 +86,8 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
-    use starknet_in_rust::state::cached_state::{CachedState, CasmClassCache, ContractClassCache};
+    use starknet_in_rust::services::api::contract_classes::compiled_class::CompiledClass;
+    use starknet_in_rust::state::cached_state::{CachedState, ContractClassCache};
     use starknet_in_rust::state::in_memory_state_reader::InMemoryStateReader;
     use starknet_in_rust::CasmContractClass;
     use starknet_types::contract_class::Cairo0ContractClass;
@@ -143,15 +137,15 @@ mod tests {
     #[test]
     fn correct_difference_in_declared_classes() {
         let old_state = InMemoryStateReader::default();
-        let mut casm_cache = CasmClassCache::default();
+        let mut casm_cache = ContractClassCache::default();
 
         let compiled_class_hash = Felt::from(1);
         casm_cache.insert(
             compiled_class_hash.bytes(),
-            CasmContractClass::from_contract_class(dummy_cairo_1_contract_class(), true).unwrap(),
+            CompiledClass::Casm(Arc::new(CasmContractClass::from_contract_class(dummy_cairo_1_contract_class(), true).unwrap())),
         );
         let new_state =
-            CachedState::new(Arc::new(old_state.clone()), Some(HashMap::new()), Some(casm_cache));
+            CachedState::new(Arc::new(old_state.clone()), casm_cache);
 
         let generated_diff =
             super::StateDiff::difference_between_old_and_new_state(old_state, new_state).unwrap();
@@ -173,12 +167,11 @@ mod tests {
         let cairo_0_contract_class: Cairo0ContractClass = dummy_cairo_0_contract_class().into();
         let mut cairo_0_classes = ContractClassCache::new();
         cairo_0_classes
-            .insert(class_hash.bytes(), cairo_0_contract_class.clone().try_into().unwrap());
+            .insert(class_hash.bytes(), CompiledClass::Deprecated(Arc::new(cairo_0_contract_class.clone().try_into().unwrap())));
 
         let new_state = CachedState::new(
             Arc::new(old_state.clone()),
-            Some(cairo_0_classes),
-            Some(HashMap::new()),
+            cairo_0_classes
         );
 
         let generated_diff =
@@ -230,7 +223,7 @@ mod tests {
     fn setup() -> (InMemoryStateReader, CachedState<InMemoryStateReader>) {
         let state = InMemoryStateReader::default();
         let cached_state =
-            CachedState::new(Arc::new(state.clone()), Some(HashMap::new()), Some(HashMap::new()));
+            CachedState::new(Arc::new(state.clone()), HashMap::new());
 
         (state, cached_state)
     }

--- a/crates/types/src/rpc/transactions/broadcasted_declare_transaction_v1.rs
+++ b/crates/types/src/rpc/transactions/broadcasted_declare_transaction_v1.rs
@@ -5,7 +5,6 @@ use starknet_in_rust::core::transaction_hash::{
     calculate_transaction_hash_common, TransactionHashPrefix as SirTransactionHashPrefix,
 };
 use starknet_in_rust::definitions::constants::VALIDATE_DECLARE_ENTRY_POINT_SELECTOR;
-use starknet_in_rust::definitions::transaction_type::TransactionType as SirTransactionType;
 use starknet_in_rust::transaction::{verify_version, Declare as SirDeclare};
 
 use crate::contract_address::ContractAddress;
@@ -55,7 +54,6 @@ impl BroadcastedDeclareTransactionV1 {
         let declare = SirDeclare {
             class_hash: class_hash.into(),
             sender_address: self.sender_address.into(),
-            tx_type: SirTransactionType::Declare,
             validate_entry_point_selector: VALIDATE_DECLARE_ENTRY_POINT_SELECTOR.clone(),
             version: self.common.version.into(),
             max_fee: self.common.max_fee.0,


### PR DESCRIPTION
## Development related changes

Update version of starknet_in_rust to [579156a](https://github.com/lambdaclass/starknet_in_rust/commit/579156a8b2cc1f8f4b1d4327183842a62ac37c29).

Most notable changes :
- starknet_in_rust returns for get_class_hash_at, get_storage_at default values instead of errors.
- gas_price of BlockInfo struct type is changed from u64 to u128
- there is a change in gas_consumed computation

!!! Estimate fee integration tests are not updated.

## Checklist:

- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] Performed code self-review
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Documented the changes
- [ ] Linked the issues which this PR resolves
- [ ] Updated the tests
- [ ] All tests are passing - `cargo test`
