### PR TITLE
Get storage at return zero instead of NoneState error

### DIFF
--- a/crates/starknet/src/account.rs
+++ b/crates/starknet/src/account.rs
@@ -259,7 +259,12 @@ mod tests {
         let fee_token_address = dummy_contract_address();
 
         // deploy the erc20 contract
-        state.deploy_contract(fee_token_address, Felt::from_prefixed_hex_str(ERC20_CONTRACT_CLASS_HASH).unwrap()).unwrap();
+        state
+            .deploy_contract(
+                fee_token_address,
+                Felt::from_prefixed_hex_str(ERC20_CONTRACT_CLASS_HASH).unwrap(),
+            )
+            .unwrap();
 
         (
             Account::new(

--- a/crates/starknet/src/account.rs
+++ b/crates/starknet/src/account.rs
@@ -140,6 +140,7 @@ mod tests {
     use starknet_types::felt::Felt;
 
     use super::Account;
+    use crate::constants::ERC20_CONTRACT_CLASS_HASH;
     use crate::state::StarknetState;
     use crate::traits::{Accounted, Deployed, StateChanger};
     use crate::utils::exported_test_utils::dummy_cairo_0_contract_class;
@@ -257,7 +258,8 @@ mod tests {
         let mut state = StarknetState::default();
         let fee_token_address = dummy_contract_address();
 
-        state.deploy_contract(fee_token_address, Felt::from(2)).unwrap();
+        // deploy the erc20 contract
+        state.deploy_contract(fee_token_address, Felt::from_prefixed_hex_str(ERC20_CONTRACT_CLASS_HASH).unwrap()).unwrap();
 
         (
             Account::new(

--- a/crates/starknet/src/state/mod.rs
+++ b/crates/starknet/src/state/mod.rs
@@ -265,7 +265,7 @@ mod tests {
             .pending_state
             .deploy_contract(
                 dummy_contract_storage_key().get_contract_address().into(),
-                Felt::from(1).into(),
+                dummy_felt().into(),
             )
             .unwrap();
 

--- a/crates/types/src/contract_storage_key.rs
+++ b/crates/types/src/contract_storage_key.rs
@@ -10,6 +10,10 @@ impl ContractStorageKey {
     pub fn new(address: ContractAddress, storage_key: StorageKey) -> Self {
         Self(address, storage_key)
     }
+
+    pub fn get_contract_address(&self) -> &ContractAddress {
+        &self.0
+    }
 }
 
 impl From<&ContractStorageKey> for starknet_in_rust::state::state_cache::StorageEntry {


### PR DESCRIPTION
## Development related changes

- get_storage_at returns zero felt, when there is no entry for the provided storage key in the contract
- get_storage_at returns ContractNotFound if the contract address is missing

## Reason for the change
https://github.com/starkware-libs/starknet-specs/blob/6fadca1f1abf48523c0aa799a10061f40f973468/api/starknet_api_openrpc.json#L157

## Checklist:

- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] Performed code self-review
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Documented the changes
- [ ] Linked the issues which this PR resolves
- [ ] Updated the tests
- [ ] All tests are passing - `cargo test`
