### PR TITLE
Get nonce fix

### DIFF
--- a/crates/starknet/src/account.rs
+++ b/crates/starknet/src/account.rs
@@ -259,7 +259,12 @@ mod tests {
         let fee_token_address = dummy_contract_address();
 
         // deploy the erc20 contract
-        state.deploy_contract(fee_token_address, Felt::from_prefixed_hex_str(ERC20_CONTRACT_CLASS_HASH).unwrap()).unwrap();
+        state
+            .deploy_contract(
+                fee_token_address,
+                Felt::from_prefixed_hex_str(ERC20_CONTRACT_CLASS_HASH).unwrap(),
+            )
+            .unwrap();
 
         (
             Account::new(

--- a/crates/starknet/src/account.rs
+++ b/crates/starknet/src/account.rs
@@ -140,6 +140,7 @@ mod tests {
     use starknet_types::felt::Felt;
 
     use super::Account;
+    use crate::constants::ERC20_CONTRACT_CLASS_HASH;
     use crate::state::StarknetState;
     use crate::traits::{Accounted, Deployed, StateChanger};
     use crate::utils::exported_test_utils::dummy_cairo_0_contract_class;
@@ -257,7 +258,8 @@ mod tests {
         let mut state = StarknetState::default();
         let fee_token_address = dummy_contract_address();
 
-        state.deploy_contract(fee_token_address, Felt::from(2)).unwrap();
+        // deploy the erc20 contract
+        state.deploy_contract(fee_token_address, Felt::from_prefixed_hex_str(ERC20_CONTRACT_CLASS_HASH).unwrap()).unwrap();
 
         (
             Account::new(

--- a/crates/starknet/src/starknet/mod.rs
+++ b/crates/starknet/src/starknet/mod.rs
@@ -492,10 +492,7 @@ impl Starknet {
         contract_address: ContractAddress,
     ) -> DevnetResult<Felt> {
         let state = self.get_state_at(&block_id)?;
-        match state.state.address_to_nonce.get(&contract_address.into()) {
-            Some(nonce) => Ok(Felt::from(nonce.clone())),
-            None => Err(Error::ContractNotFound),
-        }
+        state.get_nonce(&contract_address)
     }
 
     pub fn contract_storage_at_block(

--- a/crates/starknet/src/state/mod.rs
+++ b/crates/starknet/src/state/mod.rs
@@ -265,7 +265,7 @@ mod tests {
             .pending_state
             .deploy_contract(
                 dummy_contract_storage_key().get_contract_address().into(),
-                Felt::from(1).into(),
+                dummy_felt().into(),
             )
             .unwrap();
 

--- a/crates/starknet/src/state/mod.rs
+++ b/crates/starknet/src/state/mod.rs
@@ -148,7 +148,7 @@ impl StateChanger for StarknetState {
 
         // update accounts nonce
         state_diff.inner.address_to_nonce().iter().for_each(|(contract_address, nonce)| {
-                        old_state.address_to_nonce_mut().insert(contract_address.clone(), nonce.clone());
+            old_state.address_to_nonce_mut().insert(contract_address.clone(), nonce.clone());
         });
 
         Ok(())
@@ -406,8 +406,8 @@ mod tests {
     fn get_nonce_should_return_error_when_contract_not_deployed() {
         let (state, _) = setup();
         match state.get_nonce(&ContractAddress::new(Felt::from(1)).unwrap()) {
-            Err(Error::ContractNotFound) => {},
-            _ => panic!("Expected to return an error - ContractNotFound")
+            Err(Error::ContractNotFound) => {}
+            _ => panic!("Expected to return an error - ContractNotFound"),
         }
     }
 

--- a/crates/starknet/src/traits.rs
+++ b/crates/starknet/src/traits.rs
@@ -61,6 +61,7 @@ pub trait StateExtractor {
         address: &ContractAddress,
     ) -> DevnetResult<ClassHash>;
     fn extract_state_diff_from_pending_state(&self) -> DevnetResult<StateDiff>;
+    fn get_nonce(&self, address: &ContractAddress) -> DevnetResult<Felt>;
 }
 
 /// This trait should be implemented by structures that generate accounts

--- a/crates/types/src/contract_storage_key.rs
+++ b/crates/types/src/contract_storage_key.rs
@@ -10,6 +10,10 @@ impl ContractStorageKey {
     pub fn new(address: ContractAddress, storage_key: StorageKey) -> Self {
         Self(address, storage_key)
     }
+
+    pub fn get_contract_address(&self) -> &ContractAddress {
+        &self.0
+    }
 }
 
 impl From<&ContractStorageKey> for starknet_in_rust::state::state_cache::StorageEntry {


### PR DESCRIPTION
## Development related changes

Return 0 as nonce for newly deployed contracts. If contract is not deployed it will return ContractNotFound.
The change is required, because starknet_in_rust doesn't set any entry in StateDiff for newly deployed contracts.

## Checklist:

- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] Performed code self-review
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Documented the changes
- [ ] Linked the issues which this PR resolves
- [ ] Updated the tests
- [ ] All tests are passing - `cargo test`
