### PR TITLE
fix serialization of SyncingOutput struct

### DIFF
--- a/crates/starknet-server/src/api/json_rpc/models.rs
+++ b/crates/starknet-server/src/api/json_rpc/models.rs
@@ -65,6 +65,7 @@ pub struct BlockHashAndNumberOutput {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
 pub enum SyncingOutput {
     True(SyncStatus),
     False(bool),


### PR DESCRIPTION
## Usage related changes

An error returned in starknet.js tests, due to serialization issue.

Expected: false
Received: {"False": false}

## Checklist:

- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] Performed code self-review
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Documented the changes
- [ ] Linked the issues which this PR resolves
- [ ] Updated the tests
- [ ] All tests are passing - `cargo test`
