### PR TITLE
Block number fix

### DIFF
--- a/crates/starknet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-server/src/api/json_rpc/endpoints.rs
@@ -293,8 +293,12 @@ impl JsonRpcHandler {
 
     /// starknet_blockNumber
     pub(crate) async fn block_number(&self) -> RpcResult<BlockNumber> {
-        let block_number = self.api.starknet.read().await.block_number();
-        Ok(block_number)
+        let block = self.api.starknet.read().await.get_latest_block().map_err(|err| match err {
+            Error::NoBlock => ApiError::BlockNotFound,
+            unknown_error => ApiError::StarknetDevnetError(unknown_error),
+        })?;
+
+        Ok(block.block_number())
     }
 
     /// starknet_blockHashAndNumber

--- a/crates/starknet/src/starknet/get_class_impls.rs
+++ b/crates/starknet/src/starknet/get_class_impls.rs
@@ -127,12 +127,12 @@ mod tests {
     fn get_sierra_class() {
         let (mut starknet, account) = setup(Some(100000000));
 
-        let block_number = starknet.block_number();
         let declare_txn = dummy_broadcasted_declare_transaction_v2(&account.account_address);
 
         let expected: ContractClass = declare_txn.contract_class.clone().into();
         let (_, class_hash) = starknet.add_declare_transaction_v2(declare_txn).unwrap();
 
+        let block_number = starknet.get_latest_block().unwrap().block_number();
         let contract_class =
             starknet.get_class(BlockId::Number(block_number.0), class_hash).unwrap();
 
@@ -143,11 +143,11 @@ mod tests {
     fn get_class_hash_at_generated_accounts() {
         let (mut starknet, account) = setup(Some(100000000));
 
-        let block_number = starknet.block_number();
-        let block_id = BlockId::Number(block_number.0);
-
         starknet.generate_new_block(StateDiff::default(), starknet.state.clone()).unwrap();
         starknet.generate_pending_block().unwrap();
+
+        let block_number = starknet.get_latest_block().unwrap().block_number();
+        let block_id = BlockId::Number(block_number.0);
 
         let class_hash = starknet.get_class_hash_at(block_id, account.account_address).unwrap();
         let expected = account.class_hash;
@@ -158,11 +158,11 @@ mod tests {
     fn get_class_at_generated_accounts() {
         let (mut starknet, account) = setup(Some(100000000));
 
-        let block_number = starknet.block_number();
-        let block_id = BlockId::Number(block_number.0);
-
         starknet.generate_new_block(StateDiff::default(), starknet.state.clone()).unwrap();
         starknet.generate_pending_block().unwrap();
+
+        let block_number = starknet.get_latest_block().unwrap().block_number();
+        let block_id = BlockId::Number(block_number.0);
 
         let contract_class = starknet.get_class_at(block_id, account.account_address).unwrap();
         assert_eq!(contract_class, account.contract_class);


### PR DESCRIPTION
## Usage related changes

starknet_blockNumber returns NoBlock instead of 0.

## Development related changes

Removed block_number function from starknet crate, instead used get_latest_block

## Consequences
The change will fix partially one of starknet.js failing tests, but will make another one fail, because it relies on the genesis block, which is not implemented.

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [ ] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing - `cargo test`
