### PR TITLE
Support RPC at root

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ $ docker run -e RUST_LOG=<LEVEL> shardlabs/starknet-devnet-rs
 
 Unlike Pythonic Devnet, which supported the gateway and feeder gateway API, Devnet in Rust only supports JSON-RPC, which at the time of writing this is synchronized with [specification v0.4.0](https://github.com/starkware-libs/starknet-specs/tree/v0.4.0/api).
 
+The JSON-RPC API is reachable via `/rpc` and `/` (e.g. if spawning Devnet with default settings, these URLs have the equivalent functionality: `http://127.0.0.1:5050/rpc` and `http://127.0.0.1:5050/`)
+
 ## Predeployed contracts
 
 Devnet predeploys a [UDC](https://docs.openzeppelin.com/contracts-cairo/0.6.1/udc), an [ERC20 (fee token)](https://docs.openzeppelin.com/contracts/3.x/api/token/erc20) contract and a set of funded accounts. The information on this is logged on Devnet startup. The set of accounts can be controlled via [CLI options](#cli-options): `--accounts`, `--initial-balance`, `--seed`.

--- a/crates/starknet-server/src/server.rs
+++ b/crates/starknet-server/src/server.rs
@@ -21,6 +21,7 @@ pub fn serve_http_api_json_rpc(
 
     server::builder::Builder::<JsonRpcHandler, HttpApiHandler>::new(addr, json_rpc, http)
         .set_config(config)
+        .json_rpc_route("/")
         .json_rpc_route("/rpc")
         .http_api_route("/is_alive", get(http::is_alive))
         .http_api_route("/dump", post(http::dump_load::dump))

--- a/crates/starknet-server/tests/common/constants.rs
+++ b/crates/starknet-server/tests/common/constants.rs
@@ -9,6 +9,10 @@ pub const ACCOUNTS: usize = 3;
 pub const CHAIN_ID: FieldElement = starknet_rs_core::chain_id::TESTNET;
 pub const CHAIN_ID_CLI_PARAM: &str = "TESTNET";
 
+// URL paths
+pub const RPC_PATH: &str = "/rpc";
+pub const HEALTHCHECK_PATH: &str = "/is_alive";
+
 // predeployed account info with seed=42
 pub const PREDEPLOYED_ACCOUNT_ADDRESS: &str =
     "0x34ba56f92265f0868c57d3fe72ecab144fc96f97954bbbc4252cef8e8a979ba";

--- a/crates/starknet-server/tests/common/devnet.rs
+++ b/crates/starknet-server/tests/common/devnet.rs
@@ -15,8 +15,8 @@ use tokio::sync::Mutex;
 use url::Url;
 
 use super::constants::{
-    ACCOUNTS, CHAIN_ID_CLI_PARAM, HOST, MAX_PORT, MIN_PORT, PREDEPLOYED_ACCOUNT_INITIAL_BALANCE,
-    SEED,
+    ACCOUNTS, CHAIN_ID_CLI_PARAM, HEALTHCHECK_PATH, HOST, MAX_PORT, MIN_PORT,
+    PREDEPLOYED_ACCOUNT_INITIAL_BALANCE, RPC_PATH, SEED,
 };
 
 #[derive(Error, Debug)]
@@ -71,7 +71,7 @@ impl BackgroundDevnet {
         let free_port = get_free_port().expect("No free ports");
 
         let devnet_url = format!("http://{HOST}:{free_port}");
-        let devnet_rpc_url = Url::parse(format!("{}/rpc", devnet_url.as_str()).as_str())?;
+        let devnet_rpc_url = Url::parse(format!("{}{RPC_PATH}", devnet_url.as_str()).as_str())?;
         let json_rpc_client = JsonRpcClient::new(HttpTransport::new(devnet_rpc_url.clone()));
 
         let process = Command::new("cargo")
@@ -93,7 +93,7 @@ impl BackgroundDevnet {
                 .expect("Could not start background devnet");
 
         let healthcheck_uri =
-            format!("{}/is_alive", devnet_url.as_str()).as_str().parse::<Uri>()?;
+            format!("{}{HEALTHCHECK_PATH}", devnet_url.as_str()).as_str().parse::<Uri>()?;
 
         let mut retries = 0;
         let max_retries = 30; // limit the number of times we check if devnet is spawned

--- a/crates/starknet-server/tests/general_integration_tests.rs
+++ b/crates/starknet-server/tests/general_integration_tests.rs
@@ -2,11 +2,35 @@
 pub mod common;
 
 mod general_integration_tests {
+    use hyper::{Body, Response};
+    use serde_json::json;
+
+    use crate::common::constants::RPC_PATH;
     use crate::common::devnet::BackgroundDevnet;
 
     #[tokio::test]
     /// Asserts that a background instance can be spawned
     async fn spawnable() {
         BackgroundDevnet::spawn().await.expect("Could not start Devnet");
+    }
+
+    #[tokio::test]
+    async fn rpc_at_root() {
+        let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
+
+        async fn extract_body_as_string(resp: Response<Body>) -> String {
+            let bytes = hyper::body::to_bytes(resp.into_body()).await.unwrap().to_vec();
+            String::from_utf8(bytes).unwrap()
+        }
+
+        let resp_root =
+            devnet.post_json("/".into(), Body::from(json!({}).to_string())).await.unwrap();
+        let resp_root_body = extract_body_as_string(resp_root).await;
+
+        let resp_rpc =
+            devnet.post_json(RPC_PATH.into(), Body::from(json!({}).to_string())).await.unwrap();
+        let resp_rpc_body = extract_body_as_string(resp_rpc).await;
+
+        assert_eq!(resp_root_body, resp_rpc_body);
     }
 }


### PR DESCRIPTION
## Usage related changes

- Close #181

## Development related changes

- Implement the titular change by adding `.json_rpc_route("/")`. Not sure if this needlessly copies something.
- Extract URL paths as constants.

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing - `cargo test`
