### PR TITLE
refactor state to have only CachedState instead of CachedState and InMemoryStateReader

### DIFF
--- a/crates/starknet/src/starknet/add_declare_transaction.rs
+++ b/crates/starknet/src/starknet/add_declare_transaction.rs
@@ -26,14 +26,12 @@ pub fn add_declare_transaction_v2(
     let transaction_hash = sir_declare_transaction.hash_value.clone().into();
     let class_hash: ClassHash = sir_declare_transaction.sierra_class_hash.clone().into();
 
-    let state_before_txn = starknet.state.pending_state.clone();
+    let state_before_txn = starknet.state.state.clone();
     let transaction = Transaction::Declare(DeclareTransaction::Version2(
         sir_declare_transaction.clone().try_into()?,
     ));
 
-    match sir_declare_transaction
-        .execute(&mut starknet.state.pending_state, &starknet.block_context)
-    {
+    match sir_declare_transaction.execute(&mut starknet.state.state, &starknet.block_context) {
         Ok(tx_info) => match tx_info.revert_error {
             // Add sierra contract
             Some(error) => {
@@ -42,7 +40,7 @@ pub fn add_declare_transaction_v2(
 
                 starknet.transactions.insert(&transaction_hash, transaction_to_add);
                 // Revert to previous pending state
-                starknet.state.pending_state = state_before_txn;
+                starknet.state.state = state_before_txn;
             }
             None => {
                 starknet.state.contract_classes.insert(
@@ -62,7 +60,7 @@ pub fn add_declare_transaction_v2(
 
             starknet.transactions.insert(&transaction_hash, transaction_to_add);
             // Revert to previous pending state
-            starknet.state.pending_state = state_before_txn;
+            starknet.state.state = state_before_txn;
         }
     }
 
@@ -81,7 +79,7 @@ pub fn add_declare_transaction_v1(
         ));
     }
 
-    let state_before_txn = starknet.state.pending_state.clone();
+    let state_before_txn = starknet.state.state.clone();
 
     let class_hash = broadcasted_declare_transaction.generate_class_hash()?;
     let transaction_hash = broadcasted_declare_transaction
@@ -94,9 +92,7 @@ pub fn add_declare_transaction_v1(
     let sir_declare_transaction =
         broadcasted_declare_transaction.create_sir_declare(class_hash, transaction_hash)?;
 
-    match sir_declare_transaction
-        .execute(&mut starknet.state.pending_state, &starknet.block_context)
-    {
+    match sir_declare_transaction.execute(&mut starknet.state.state, &starknet.block_context) {
         Ok(tx_info) => match tx_info.revert_error {
             Some(error) => {
                 let transaction_to_add =
@@ -104,7 +100,7 @@ pub fn add_declare_transaction_v1(
 
                 starknet.transactions.insert(&transaction_hash, transaction_to_add);
                 // Revert to previous pending state
-                starknet.state.pending_state = state_before_txn;
+                starknet.state.state = state_before_txn;
             }
             None => {
                 starknet
@@ -124,7 +120,7 @@ pub fn add_declare_transaction_v1(
 
             starknet.transactions.insert(&transaction_hash, transaction_to_add);
             // Revert to previous pending state
-            starknet.state.pending_state = state_before_txn;
+            starknet.state.state = state_before_txn;
         }
     }
 
@@ -195,14 +191,14 @@ mod tests {
     #[test]
     fn add_declare_v2_transaction_should_return_rejected_txn_and_not_be_part_of_pending_state() {
         let (mut starknet, sender) = setup(Some(1));
-        let initial_cached_state = starknet.state.pending_state.contract_classes().len();
+        let initial_cached_state = starknet.state.state.contract_classes().len();
         let declare_txn = dummy_broadcasted_declare_transaction_v2(&sender);
         let (txn_hash, class_hash) = starknet.add_declare_transaction_v2(declare_txn).unwrap();
         let txn = starknet.transactions.get_by_hash_mut(&txn_hash).unwrap();
 
         assert_eq!(txn.finality_status, None);
         assert_eq!(txn.execution_result.status(), TransactionExecutionStatus::Reverted);
-        assert_eq!(initial_cached_state, starknet.state.pending_state.contract_classes().len());
+        assert_eq!(initial_cached_state, starknet.state.state.contract_classes().len());
         assert!(starknet.state.contract_classes.get(&class_hash).is_none())
     }
 
@@ -241,6 +237,7 @@ mod tests {
             !starknet
                 .state
                 .state
+                .state_reader
                 .class_hash_to_compiled_class
                 .contains_key(&expected_compiled_class_hash.bytes())
         );
@@ -283,14 +280,14 @@ mod tests {
     #[test]
     fn add_declare_v1_transaction_should_return_rejected_txn_and_not_be_part_of_pending_state() {
         let (mut starknet, sender) = setup(Some(1));
-        let initial_cached_state = starknet.state.pending_state.contract_classes().len();
+        let initial_cached_state = starknet.state.state.contract_classes().len();
         let declare_txn = broadcasted_declare_transaction_v1(sender);
         let (txn_hash, _) = starknet.add_declare_transaction_v1(declare_txn).unwrap();
         let txn = starknet.transactions.get_by_hash_mut(&txn_hash).unwrap();
 
         assert_eq!(txn.finality_status, None);
         assert_eq!(txn.execution_result.status(), TransactionExecutionStatus::Reverted);
-        assert_eq!(initial_cached_state, starknet.state.pending_state.contract_classes().len());
+        assert_eq!(initial_cached_state, starknet.state.state.contract_classes().len());
     }
 
     #[test]
@@ -374,7 +371,7 @@ mod tests {
         acc.deploy(&mut starknet.state).unwrap();
         acc.set_initial_balance(&mut starknet.state).unwrap();
 
-        starknet.state.synchronize_states();
+        starknet.state.clear_dirty_state();
         starknet.block_context = Starknet::get_block_context(
             1,
             constants::ERC20_CONTRACT_ADDRESS,

--- a/crates/starknet/src/starknet/add_deploy_account_transaction.rs
+++ b/crates/starknet/src/starknet/add_deploy_account_transaction.rs
@@ -34,9 +34,8 @@ pub fn add_deploy_account_transaction(
 
     let transaction = Transaction::DeployAccount(deploy_account_transaction);
 
-    let state_before_txn = starknet.state.pending_state.clone();
-    match sir_deploy_account_transaction
-        .execute(&mut starknet.state.pending_state, &starknet.block_context)
+    let state_before_txn = starknet.state.state.clone();
+    match sir_deploy_account_transaction.execute(&mut starknet.state.state, &starknet.block_context)
     {
         Ok(tx_info) => match tx_info.revert_error {
             Some(error) => {
@@ -45,7 +44,7 @@ pub fn add_deploy_account_transaction(
 
                 starknet.transactions.insert(&transaction_hash, transaction_to_add);
                 // Revert to previous pending state
-                starknet.state.pending_state = state_before_txn;
+                starknet.state.state = state_before_txn;
             }
             None => {
                 starknet.handle_successful_transaction(&transaction_hash, &transaction, &tx_info)?
@@ -57,7 +56,7 @@ pub fn add_deploy_account_transaction(
 
             starknet.transactions.insert(&transaction_hash, transaction_to_add);
             // Revert to previous pending state
-            starknet.state.pending_state = state_before_txn;
+            starknet.state.state = state_before_txn;
         }
     }
 
@@ -153,7 +152,7 @@ mod tests {
             ContractStorageKey::new(fee_token_address, balance_storage_var_address);
 
         starknet.state.change_storage(balance_storage_key, Felt::from(fee_raw)).unwrap();
-        starknet.state.synchronize_states();
+        starknet.state.clear_dirty_state();
 
         let (txn_hash, _) = starknet.add_deploy_account_transaction(transaction).unwrap();
         let txn = starknet.transactions.get_by_hash_mut(&txn_hash).unwrap();
@@ -166,7 +165,7 @@ mod tests {
     }
 
     fn get_accounts_count(starknet: &Starknet) -> usize {
-        starknet.state.state.address_to_class_hash.len()
+        starknet.state.state.state_reader.address_to_class_hash.len()
     }
 
     #[test]
@@ -199,7 +198,7 @@ mod tests {
             .state
             .change_storage(balance_storage_key, account_balance_before_deployment)
             .unwrap();
-        starknet.state.synchronize_states();
+        starknet.state.clear_dirty_state();
 
         // get accounts count before deployment
         let accounts_before_deployment = get_accounts_count(&starknet);
@@ -231,7 +230,7 @@ mod tests {
         let class_hash = contract_class.generate_hash().unwrap();
 
         starknet.state.declare_contract_class(class_hash, contract_class.into()).unwrap();
-        starknet.state.synchronize_states();
+        starknet.state.clear_dirty_state();
         starknet.block_context = Starknet::get_block_context(
             1,
             constants::ERC20_CONTRACT_ADDRESS,

--- a/crates/starknet/src/starknet/add_invoke_transaction.rs
+++ b/crates/starknet/src/starknet/add_invoke_transaction.rs
@@ -26,10 +26,10 @@ pub fn add_invoke_transaction(
         broadcasted_invoke_transaction.create_invoke_transaction(transaction_hash);
     let transaction = Transaction::Invoke(InvokeTransaction::Version1(invoke_transaction));
 
-    let state_before_txn = starknet.state.pending_state.clone();
+    let state_before_txn = starknet.state.state.clone();
 
     match sir_invoke_function.execute(
-        &mut starknet.state.pending_state,
+        &mut starknet.state.state,
         &starknet.block_context,
         INITIAL_GAS_COST,
     ) {
@@ -40,7 +40,7 @@ pub fn add_invoke_transaction(
 
                 starknet.transactions.insert(&transaction_hash, transaction_to_add);
                 // Revert to previous pending state
-                starknet.state.pending_state = state_before_txn;
+                starknet.state.state = state_before_txn;
             }
             None => {
                 starknet.handle_successful_transaction(&transaction_hash, &transaction, &tx_info)?
@@ -52,7 +52,7 @@ pub fn add_invoke_transaction(
 
             starknet.transactions.insert(&transaction_hash, transaction_to_add);
             // Revert to previous pending state
-            starknet.state.pending_state = state_before_txn;
+            starknet.state.state = state_before_txn;
         }
     }
 
@@ -288,7 +288,7 @@ mod tests {
         // change storage of dummy contract
         // starknet.state.change_storage(contract_storage_key, Felt::from(0)).unwrap();
 
-        starknet.state.synchronize_states();
+        starknet.state.clear_dirty_state();
         starknet.block_context = Starknet::get_block_context(
             1,
             constants::ERC20_CONTRACT_ADDRESS,

--- a/crates/starknet/src/starknet/estimations.rs
+++ b/crates/starknet/src/starknet/estimations.rs
@@ -57,7 +57,7 @@ pub fn estimate_fee(
                 }
             })
             .collect::<DevnetResult<Vec<starknet_in_rust::transaction::Transaction>>>()?,
-        state.pending_state.clone(),
+        state.state.clone(),
         &starknet.block_context,
     )?;
 
@@ -95,7 +95,7 @@ pub fn estimate_message_fee(
         estimate_message_fee.create_sir_l1_handler(starknet.config.chain_id.to_felt().into())?;
     let (_, gas_consumed) = starknet_in_rust::estimate_message_fee(
         &sir_l1_handler,
-        state.pending_state.clone(),
+        state.state.clone(),
         &starknet.block_context,
     )?;
 

--- a/crates/starknet/src/starknet/get_class_impls.rs
+++ b/crates/starknet/src/starknet/get_class_impls.rs
@@ -110,7 +110,7 @@ mod tests {
         acc.deploy(&mut starknet.state).unwrap();
         acc.set_initial_balance(&mut starknet.state).unwrap();
 
-        starknet.state.synchronize_states();
+        starknet.state.clear_dirty_state();
         starknet.block_context = Starknet::get_block_context(
             1,
             constants::ERC20_CONTRACT_ADDRESS,

--- a/crates/starknet/src/starknet/mod.rs
+++ b/crates/starknet/src/starknet/mod.rs
@@ -145,7 +145,7 @@ impl Starknet {
         chargeable_account.set_initial_balance(&mut state)?;
 
         // copy already modified state to cached state
-        state.synchronize_states();
+        state.clear_dirty_state();
 
         let mut this = Self {
             state,
@@ -228,7 +228,7 @@ impl Starknet {
         // apply state changes from cached state
         self.state.apply_state_difference(state_difference.clone())?;
         // make cached state part of "persistent" state
-        self.state.synchronize_states();
+        self.state.clear_dirty_state();
         // create new block from pending one
         self.generate_new_block(state_difference, self.state.clone())?;
         // clear pending block information
@@ -357,7 +357,7 @@ impl Starknet {
             contract_address.into(),
             entrypoint_selector.into(),
             calldata.iter().map(|c| c.into()).collect(),
-            &mut state.pending_state.clone(),
+            &mut state.state.clone(),
             self.block_context.clone(),
             // dummy caller_address since there is no account address
             ContractAddress::zero().into(),
@@ -423,8 +423,7 @@ impl Starknet {
     pub async fn mint(&mut self, address: ContractAddress, amount: u128) -> DevnetResult<Felt> {
         let sufficiently_big_max_fee: u128 = self.config.gas_price as u128 * 1_000_000;
         let chargeable_address_felt = Felt::from_prefixed_hex_str(CHARGEABLE_ACCOUNT_ADDRESS)?;
-        let nonce =
-            self.state.pending_state.get_nonce_at(&Address(chargeable_address_felt.into()))?;
+        let nonce = self.state.state.get_nonce_at(&Address(chargeable_address_felt.into()))?;
 
         let calldata = vec![
             Felt::from(address).into(),
@@ -908,7 +907,7 @@ mod tests {
         // add data to state
         starknet
             .state
-            .pending_state
+            .state
             .cache_mut()
             .nonce_writes_mut()
             .insert(dummy_contract_address().try_into().unwrap(), Felt::from(1).into());
@@ -924,7 +923,7 @@ mod tests {
         // add data to state
         starknet
             .state
-            .pending_state
+            .state
             .cache_mut()
             .nonce_writes_mut()
             .insert(dummy_contract_address().try_into().unwrap(), Felt::from(2).into());
@@ -943,6 +942,7 @@ mod tests {
             .get(&second_block)
             .unwrap()
             .state
+            .state_reader
             .address_to_nonce
             .get(&dummy_contract_address().try_into().unwrap())
             .unwrap();
@@ -955,6 +955,7 @@ mod tests {
             .get(&third_block)
             .unwrap()
             .state
+            .state_reader
             .address_to_nonce
             .get(&dummy_contract_address().try_into().unwrap())
             .unwrap();

--- a/crates/starknet/src/starknet/state_update.rs
+++ b/crates/starknet/src/starknet/state_update.rs
@@ -139,7 +139,7 @@ mod tests {
         acc.deploy(&mut starknet.state).unwrap();
         acc.set_initial_balance(&mut starknet.state).unwrap();
 
-        starknet.state.synchronize_states();
+        starknet.state.clear_dirty_state();
         starknet.block_context = Starknet::get_block_context(
             1,
             constants::ERC20_CONTRACT_ADDRESS,

--- a/crates/starknet/src/state/mod.rs
+++ b/crates/starknet/src/state/mod.rs
@@ -45,8 +45,8 @@ impl StateChanger for StarknetState {
         contract_class: ContractClass,
     ) -> DevnetResult<()> {
         self.contract_classes.insert(class_hash, contract_class.clone());
-        
-        let persistent_state = Arc::make_mut(& mut self.state.state_reader);
+
+        let persistent_state = Arc::make_mut(&mut self.state.state_reader);
 
         match contract_class {
             ContractClass::Cairo0(deprecated_contract_class) => {
@@ -436,7 +436,7 @@ mod tests {
         let (state, address) = setup();
         assert_eq!(state.get_nonce(&address).unwrap(), Felt::from(0));
     }
-    
+
     fn setup() -> (StarknetState, ContractAddress) {
         let mut state = StarknetState::default();
         let address = dummy_contract_address();

--- a/crates/starknet/src/state/mod.rs
+++ b/crates/starknet/src/state/mod.rs
@@ -28,8 +28,8 @@ pub(crate) struct StarknetState {
 }
 
 impl StarknetState {
-    // this method clears the state from data that was accumulated in the StateCache
-    // and restores it to the data in the state_reader, which is the "persistent" data
+    /// this method clears the state from data that was accumulated in the StateCache
+    /// and restores it to the data in the state_reader, which is the "persistent" data
     pub(crate) fn clear_dirty_state(&mut self) {
         self.state = CachedState::new(
             self.state.state_reader.clone(),

--- a/crates/starknet/src/state/mod.rs
+++ b/crates/starknet/src/state/mod.rs
@@ -24,7 +24,6 @@ pub mod state_update;
 #[derive(Debug, Clone, Default)]
 pub(crate) struct StarknetState {
     pub state: CachedState<InMemoryStateReader>,
-    // pub pending_state: CachedState<InMemoryStateReader>,
     pub(crate) contract_classes: HashMap<ClassHash, ContractClass>,
 }
 

--- a/crates/starknet/src/state/state_diff.rs
+++ b/crates/starknet/src/state/state_diff.rs
@@ -35,7 +35,6 @@ impl StateDiff {
         let mut class_hash_to_compiled_class_hash = HashMap::<ClassHash, ClassHash>::new();
         let mut declared_contracts = HashMap::<ClassHash, CasmContractClass>::new();
         let mut cairo_0_declared_contracts = HashMap::<ClassHash, DeprecatedContractClass>::new();
-
         // extract differences of class_hash -> compile_class_hash mapping
         let class_hash_to_compiled_class_hash_subtracted_map = subtract_mappings(
             new_state.cache_mut().class_hash_to_compiled_class_hash_mut(),


### PR DESCRIPTION
closes https://github.com/0xSpaceShard/starknet-devnet-rs/issues/22

## Development related changes

- Refactor StarknetState by removing the InMemoryStateReader
- Renamed method synchronize_state, to clear_dirty_state

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [ ] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing - `cargo test`
