### PR TITLE
Fix invoke transaction hash computation when estimating fee

### DIFF
--- a/crates/types/src/rpc/transactions/broadcasted_invoke_transaction.rs
+++ b/crates/types/src/rpc/transactions/broadcasted_invoke_transaction.rs
@@ -50,14 +50,14 @@ impl BroadcastedInvokeTransaction {
         &self,
         chain_id: Felt,
     ) -> DevnetResult<InvokeTransaction> {
-        let entry_point_selector_field = Felt::default();
+        let entry_point_selector_field = Felt252::from(0u8);
         let additional_data = vec![self.common.nonce];
 
         let txn_hash: Felt = calculate_transaction_hash_common(
             TransactionHashPrefix::Invoke,
             self.common.version.into(),
             &self.sender_address.into(),
-            entry_point_selector_field.into(),
+            entry_point_selector_field,
             self.calldata.iter().map(Felt252::from).collect::<Vec<Felt252>>().as_slice(),
             self.common.max_fee.0,
             chain_id.into(),

--- a/crates/types/src/rpc/transactions/broadcasted_invoke_transaction.rs
+++ b/crates/types/src/rpc/transactions/broadcasted_invoke_transaction.rs
@@ -8,8 +8,6 @@ use starknet_api::transaction::Fee;
 use starknet_in_rust::core::transaction_hash::{
     calculate_transaction_hash_common, TransactionHashPrefix,
 };
-use starknet_in_rust::definitions::constants::EXECUTE_ENTRY_POINT_SELECTOR;
-use starknet_rs_ff::FieldElement;
 
 use crate::contract_address::ContractAddress;
 use crate::error::DevnetResult;
@@ -18,15 +16,6 @@ use crate::felt::{
 };
 use crate::rpc::transactions::invoke_transaction_v1::InvokeTransactionV1;
 use crate::rpc::transactions::BroadcastedTransactionCommon;
-
-const QUERY_VERSION_OFFSET: FieldElement = FieldElement::from_mont([
-    18446744073700081665,
-    17407,
-    18446744073709551584,
-    576460752142434320,
-]);
-
-const SUPPORTED_TX_VERSION: FieldElement = FieldElement::ONE;
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct BroadcastedInvokeTransaction {
@@ -61,15 +50,8 @@ impl BroadcastedInvokeTransaction {
         &self,
         chain_id: Felt,
     ) -> DevnetResult<InvokeTransaction> {
-        let (entry_point_selector_field, additional_data) = if (QUERY_VERSION_OFFSET
-            + SUPPORTED_TX_VERSION)
-            == FieldElement::from(self.common.version)
-        {
-            (Felt::from(EXECUTE_ENTRY_POINT_SELECTOR.clone()), Vec::<Felt>::new())
-        } else {
-            let additional_data = vec![self.common.nonce];
-            (Felt::default(), additional_data)
-        };
+        let entry_point_selector_field = Felt::default();
+        let additional_data = vec![self.common.nonce];
 
         let txn_hash: Felt = calculate_transaction_hash_common(
             TransactionHashPrefix::Invoke,


### PR DESCRIPTION
Removed unnecessary check for Invoke V0, because it was producing wrong transaction hash when estimating fee of the transaction.

## Checklist:

- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] Performed code self-review
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Documented the changes
- [ ] Linked the issues which this PR resolves
- [ ] Updated the tests
- [ ] All tests are passing - `cargo test`
