### PR TITLE
Invalid version of DeployAccount transaction

### DIFF
--- a/crates/types/src/rpc/transactions/broadcasted_deploy_account_transaction.rs
+++ b/crates/types/src/rpc/transactions/broadcasted_deploy_account_transaction.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use cairo_felt::Felt252;
 use serde::{Deserialize, Serialize};
 use starknet_api::core::calculate_contract_address;
+use starknet_api::hash::StarkFelt;
 use starknet_api::transaction::Fee;
 
 use crate::contract_address::ContractAddress;
@@ -74,7 +75,7 @@ impl BroadcastedDeployAccountTransaction {
 
         let sn_api_transaction = starknet_api::transaction::DeployAccountTransaction {
             max_fee: self.common.max_fee,
-            version: starknet_api::transaction::TransactionVersion(self.common.version.into()),
+            version: starknet_api::transaction::TransactionVersion(StarkFelt::from(1u8)),
             signature: starknet_api::transaction::TransactionSignature(
                 self.common.signature.iter().map(|felt| felt.into()).collect(),
             ),

--- a/crates/types/src/rpc/transactions/broadcasted_deploy_account_transaction.rs
+++ b/crates/types/src/rpc/transactions/broadcasted_deploy_account_transaction.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use cairo_felt::Felt252;
 use serde::{Deserialize, Serialize};
 use starknet_api::core::calculate_contract_address;
-use starknet_api::hash::StarkFelt;
 use starknet_api::transaction::Fee;
+use starknet_rs_ff::FieldElement;
 
 use crate::contract_address::ContractAddress;
 use crate::error::DevnetResult;
@@ -14,6 +14,8 @@ use crate::felt::{
 };
 use crate::rpc::transactions::deploy_account_transaction::DeployAccountTransaction;
 use crate::rpc::transactions::BroadcastedTransactionCommon;
+
+const TRANSACTION_VERSION: FieldElement = FieldElement::ONE;
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct BroadcastedDeployAccountTransaction {
@@ -75,7 +77,7 @@ impl BroadcastedDeployAccountTransaction {
 
         let sn_api_transaction = starknet_api::transaction::DeployAccountTransaction {
             max_fee: self.common.max_fee,
-            version: starknet_api::transaction::TransactionVersion(StarkFelt::from(1u8)),
+            version: starknet_api::transaction::TransactionVersion(TRANSACTION_VERSION.into()),
             signature: starknet_api::transaction::TransactionSignature(
                 self.common.signature.iter().map(|felt| felt.into()).collect(),
             ),


### PR DESCRIPTION
Estimating fee of DeployAccount transactions was failing, because blockifier approves only version 1 for DeployAccount transaction. In our implementation the version that is coming from the BroadcastedTransaction is being used. Which for estimate_fee is offset + transaction version. So the fix is to hardcode the version of deploy account transaction to 1, when creating the starknet_api object.

This error is not present in the other types of transaction, because we are not able to assign value to the transaction version.

## Checklist:

- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] Performed code self-review
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Documented the changes
- [ ] Linked the issues which this PR resolves
- [ ] Updated the tests
- [ ] All tests are passing - `cargo test`
