### PR TITLE
JSON-RPC get_class, get_class_at, get_class_hash_at errors handlers

### DIFF
--- a/crates/starknet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-server/src/api/json_rpc/endpoints.rs
@@ -184,11 +184,9 @@ impl JsonRpcHandler {
         match self.api.starknet.read().await.get_class(block_id.into(), class_hash) {
             Ok(contract_class) => Ok(contract_class.try_into()?),
             Err(Error::NoBlock) => Err(ApiError::BlockNotFound),
-            Err(
-                Error::ContractNotFound
-                | Error::StateError(StateError::NoneContractState(_))
-                | Error::NoStateAtBlock { block_number: _ },
-            ) => Err(ApiError::ContractNotFound),
+            Err(Error::StateError(_) | Error::NoStateAtBlock { block_number: _ }) => {
+                Err(ApiError::ClassHashNotFound)
+            }
             Err(unknown_error) => Err(ApiError::StarknetDevnetError(unknown_error)),
         }
     }
@@ -204,7 +202,7 @@ impl JsonRpcHandler {
             Err(Error::NoBlock) => Err(ApiError::BlockNotFound),
             Err(
                 Error::ContractNotFound
-                | Error::StateError(StateError::NoneContractState(_))
+                | Error::StateError(_)
                 | Error::NoStateAtBlock { block_number: _ },
             ) => Err(ApiError::ContractNotFound),
             Err(unknown_error) => Err(ApiError::StarknetDevnetError(unknown_error)),
@@ -220,11 +218,9 @@ impl JsonRpcHandler {
         match self.api.starknet.read().await.get_class_hash_at(block_id.into(), contract_address) {
             Ok(class_hash) => Ok(class_hash),
             Err(Error::NoBlock) => Err(ApiError::BlockNotFound),
-            Err(
-                Error::ContractNotFound
-                | Error::StateError(StateError::NoneContractState(_))
-                | Error::NoStateAtBlock { block_number: _ },
-            ) => Err(ApiError::ContractNotFound),
+            Err(Error::ContractNotFound | Error::NoStateAtBlock { block_number: _ }) => {
+                Err(ApiError::ContractNotFound)
+            }
             Err(unknown_error) => Err(ApiError::StarknetDevnetError(unknown_error)),
         }
     }


### PR DESCRIPTION
## Usage related changes

closes https://github.com/0xSpaceShard/starknet-devnet-rs/issues/145

## Development related changes

After migrating to blockifier some of the errors were replaced, so new error handlers for the starknet_getClass, starknet_getClassAt, starknet_getClassHashAt methods

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] Performed code self-review
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Documented the changes
- [ ] Linked the issues which this PR resolves
- [ ] Updated the tests
- [ ] All tests are passing - `cargo test`
