### PR TITLE
Use starknet_rs BlockId implementation

### DIFF
--- a/crates/starknet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-server/src/api/json_rpc/mod.rs
@@ -229,7 +229,7 @@ impl JsonRpcHandler {
                 invoke_transaction,
             }) => self.add_invoke_transaction(invoke_transaction).await.to_rpc_result(),
             StarknetRequest::EstimateMessageFee(request) => self
-                .estimate_message_fee(request.get_block_id(), request.get_raw_message().clone())
+                .estimate_message_fee(*request.get_block_id(), request.get_raw_message().clone())
                 .await
                 .to_rpc_result(),
             StarknetRequest::SimulateTransactions(SimulateTransactionsInput {

--- a/crates/starknet/src/starknet/estimations.rs
+++ b/crates/starknet/src/starknet/estimations.rs
@@ -45,7 +45,7 @@ pub fn estimate_message_fee(
     message: MsgFromL1,
 ) -> DevnetResult<FeeEstimateWrapper> {
     let estimate_message_fee = EstimateMessageFeeRequestWrapper::new(block_id, message);
-    let mut state = starknet.get_state_at(estimate_message_fee.get_raw_block_id())?.clone();
+    let mut state = starknet.get_state_at(estimate_message_fee.get_block_id())?.clone();
 
     match starknet
         .get_class_hash_at(block_id, ContractAddress::new(estimate_message_fee.get_to_address())?)

--- a/crates/types/src/rpc/block.rs
+++ b/crates/types/src/rpc/block.rs
@@ -1,80 +1,10 @@
 use serde::{Deserialize, Serialize};
 use starknet_api::block::{BlockNumber, BlockStatus, BlockTimestamp};
-use starknet_rs_core::types::{BlockId as ImportedBlockId, BlockTag as ImportedBlockTag};
 
 use crate::contract_address::ContractAddress;
 use crate::felt::{BlockHash, Felt};
 use crate::rpc::transactions::Transactions;
 pub type GlobalRootHex = Felt;
-
-#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub enum Tag {
-    /// The most recent fully constructed block
-    #[serde(rename = "latest")]
-    Latest,
-    /// Currently constructed block
-    #[serde(rename = "pending")]
-    Pending,
-}
-
-impl From<Tag> for ImportedBlockTag {
-    fn from(value: Tag) -> Self {
-        match value {
-            Tag::Latest => ImportedBlockTag::Latest,
-            Tag::Pending => ImportedBlockTag::Pending,
-        }
-    }
-}
-
-impl From<ImportedBlockTag> for Tag {
-    fn from(value: ImportedBlockTag) -> Self {
-        match value {
-            ImportedBlockTag::Latest => Tag::Latest,
-            ImportedBlockTag::Pending => Tag::Pending,
-        }
-    }
-}
-
-#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub enum BlockHashOrNumber {
-    #[serde(rename = "block_hash")]
-    Hash(Felt),
-    #[serde(rename = "block_number")]
-    Number(BlockNumber),
-}
-
-#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(untagged)]
-pub enum BlockId {
-    HashOrNumber(BlockHashOrNumber),
-    Tag(Tag),
-}
-
-impl From<BlockId> for ImportedBlockId {
-    fn from(block_id: BlockId) -> Self {
-        match block_id {
-            BlockId::HashOrNumber(hash_or_number) => match hash_or_number {
-                BlockHashOrNumber::Hash(hash) => ImportedBlockId::Hash(hash.into()),
-                BlockHashOrNumber::Number(number) => ImportedBlockId::Number(number.0),
-            },
-            BlockId::Tag(tag) => ImportedBlockId::Tag(tag.into()),
-        }
-    }
-}
-
-impl From<ImportedBlockId> for BlockId {
-    fn from(block_id: ImportedBlockId) -> Self {
-        match block_id {
-            ImportedBlockId::Tag(tag) => BlockId::Tag(tag.into()),
-            ImportedBlockId::Number(number) => {
-                BlockId::HashOrNumber(BlockHashOrNumber::Number(BlockNumber(number)))
-            }
-            ImportedBlockId::Hash(hash) => {
-                BlockId::HashOrNumber(BlockHashOrNumber::Hash(hash.into()))
-            }
-        }
-    }
-}
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct Block {

--- a/crates/types/src/rpc/estimate_message_fee.rs
+++ b/crates/types/src/rpc/estimate_message_fee.rs
@@ -4,13 +4,10 @@ use blockifier::transaction::transactions::L1HandlerTransaction;
 use starknet_api::core::EntryPointSelector;
 use starknet_api::transaction::Calldata;
 use starknet_rs_core::types::requests::EstimateMessageFeeRequest;
-use starknet_rs_core::types::{
-    BlockId as SrBlockId, FeeEstimate, MsgFromL1 as SrMsgFromL1, MsgFromL1,
-};
+use starknet_rs_core::types::{BlockId, FeeEstimate, MsgFromL1 as SrMsgFromL1, MsgFromL1};
 
 use crate::error::DevnetResult;
 use crate::felt::Felt;
-use crate::rpc::block::BlockId;
 use crate::rpc::eth_address::EthAddressWrapper;
 use crate::{impl_wrapper_deserialize, impl_wrapper_serialize};
 
@@ -34,7 +31,7 @@ pub struct EstimateMessageFeeRequestWrapper {
 }
 
 impl EstimateMessageFeeRequestWrapper {
-    pub fn new(block_id: SrBlockId, msg_from_l1: MsgFromL1) -> Self {
+    pub fn new(block_id: BlockId, msg_from_l1: MsgFromL1) -> Self {
         Self { inner: EstimateMessageFeeRequest { message: msg_from_l1, block_id } }
     }
 
@@ -55,11 +52,7 @@ impl EstimateMessageFeeRequestWrapper {
         self.inner.message.payload.iter().map(|el| (*el).into()).collect()
     }
 
-    pub fn get_block_id(&self) -> BlockId {
-        self.inner.block_id.into()
-    }
-
-    pub fn get_raw_block_id(&self) -> &SrBlockId {
+    pub fn get_block_id(&self) -> &BlockId {
         &self.inner.block_id
     }
 


### PR DESCRIPTION
## Development related changes

Remove BlockId implementation from types crate and use starknet_rs instead

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Documented the changes
- [ ] Linked the issues which this PR resolves
- [ ] Updated the tests
- [ ] All tests are passing - `cargo test`
