### PR TITLE
Fix reverted tx

### DIFF
--- a/crates/starknet/src/starknet/add_deploy_account_transaction.rs
+++ b/crates/starknet/src/starknet/add_deploy_account_transaction.rs
@@ -42,17 +42,9 @@ pub fn add_deploy_account_transaction(
         .execute(&mut starknet.state.state, &starknet.block_context, true, true);
 
     match blockifier_execution_result {
-        Ok(tx_info) => match tx_info.revert_error {
-            Some(error) => {
-                let transaction_to_add =
-                    StarknetTransaction::create_rejected(&transaction, None, &error);
-
-                starknet.transactions.insert(&transaction_hash, transaction_to_add);
-            }
-            None => {
-                starknet.handle_successful_transaction(&transaction_hash, &transaction, tx_info)?
-            }
-        },
+        Ok(tx_info) => {
+            starknet.handle_accepted_transaction(&transaction_hash, &transaction, tx_info)?
+        }
         Err(tx_err) => {
             let transaction_to_add =
                 StarknetTransaction::create_rejected(&transaction, None, &tx_err.to_string());

--- a/crates/starknet/src/starknet/add_invoke_transaction.rs
+++ b/crates/starknet/src/starknet/add_invoke_transaction.rs
@@ -32,17 +32,9 @@ pub fn add_invoke_transaction(
         .execute(&mut starknet.state.state, &starknet.block_context, true, true);
 
     match blockifier_execution_result {
-        Ok(tx_info) => match tx_info.revert_error {
-            Some(error) => {
-                let transaction_to_add =
-                    StarknetTransaction::create_rejected(&transaction, None, &error);
-
-                starknet.transactions.insert(&transaction_hash, transaction_to_add);
-            }
-            None => {
-                starknet.handle_successful_transaction(&transaction_hash, &transaction, tx_info)?
-            }
-        },
+        Ok(tx_info) => {
+            starknet.handle_accepted_transaction(&transaction_hash, &transaction, tx_info)?
+        }
         Err(tx_err) => {
             let transaction_to_add =
                 StarknetTransaction::create_rejected(&transaction, None, &tx_err.to_string());
@@ -224,6 +216,40 @@ mod tests {
                 .unwrap()
                 .contains("Invalid transaction nonce")
         );
+    }
+
+    #[test]
+    fn nonce_should_be_incremented_if_invoke_reverted() {
+        let (mut starknet, account_address, contract_address, increase_balance_selector, _) =
+            setup();
+
+        let initial_nonce = starknet.state.get_nonce(&account_address).unwrap();
+        assert_eq!(initial_nonce, Felt::from(0));
+
+        let calldata = vec![
+            Felt::from(contract_address), // contract address
+            increase_balance_selector,    // function selector
+            Felt::from(1),                // calldata len
+            Felt::from(10),               // calldata
+        ];
+
+        let insufficient_max_fee = 2482; // this is minimum fee (enough for passing validation), anything lower than that is bounced back
+        let invoke_transaction = BroadcastedInvokeTransaction::new(
+            account_address,
+            Fee(insufficient_max_fee),
+            &vec![],
+            initial_nonce,
+            &calldata,
+            Felt::from(1),
+        );
+
+        let transaction_hash = starknet.add_invoke_transaction(invoke_transaction).unwrap();
+        let transaction = starknet.transactions.get_by_hash_mut(&transaction_hash).unwrap();
+        assert_eq!(transaction.finality_status, Some(TransactionFinalityStatus::AcceptedOnL2));
+        assert_eq!(transaction.execution_result.status(), TransactionExecutionStatus::Reverted);
+
+        let nonce_after_reverted = starknet.state.get_nonce(&account_address).unwrap();
+        assert_eq!(nonce_after_reverted, Felt::from(1));
     }
 
     /// Initialize starknet object with: erc20 contract, account contract and  simple contract that

--- a/crates/starknet/src/starknet/events.rs
+++ b/crates/starknet/src/starknet/events.rs
@@ -404,7 +404,7 @@ mod tests {
             let transaction_hash = Felt::from(idx as u128 + 100);
 
             starknet
-                .handle_successful_transaction(&transaction_hash, &transaction, txn_info)
+                .handle_accepted_transaction(&transaction_hash, &transaction, txn_info)
                 .unwrap();
         }
 

--- a/crates/starknet/src/starknet/mod.rs
+++ b/crates/starknet/src/starknet/mod.rs
@@ -250,13 +250,16 @@ impl Starknet {
         Ok(new_block_number)
     }
 
-    pub(crate) fn handle_successful_transaction(
+    /// Handles suceeded and reverted transactions.
+    /// The tx is stored and potentially dumped.
+    /// A new block is generated.
+    pub(crate) fn handle_accepted_transaction(
         &mut self,
         transaction_hash: &TransactionHash,
         transaction: &Transaction,
         tx_info: TransactionExecutionInfo,
     ) -> DevnetResult<()> {
-        let transaction_to_add = StarknetTransaction::create_successful(transaction, None, tx_info);
+        let transaction_to_add = StarknetTransaction::create_accepted(transaction, tx_info);
 
         // add accepted transaction to pending block
         self.blocks.pending_block.add_transaction(*transaction_hash);

--- a/crates/starknet/src/transactions.rs
+++ b/crates/starknet/src/transactions.rs
@@ -75,14 +75,21 @@ impl StarknetTransaction {
         }
     }
 
-    pub fn create_successful(
+    pub fn create_accepted(
         transaction: &Transaction,
-        finality_status: Option<TransactionFinalityStatus>,
         execution_info: TransactionExecutionInfo,
     ) -> Self {
         Self {
-            finality_status,
-            execution_result: ExecutionResult::Succeeded,
+            finality_status: Some(TransactionFinalityStatus::AcceptedOnL2),
+            execution_result: match execution_info.is_reverted() {
+                true => ExecutionResult::Reverted {
+                    reason: execution_info
+                        .revert_error
+                        .clone()
+                        .unwrap_or("No revert error".to_string()),
+                },
+                false => ExecutionResult::Succeeded,
+            },
             inner: transaction.clone(),
             block_hash: None,
             block_number: None,
@@ -209,7 +216,7 @@ impl StarknetTransaction {
 #[cfg(test)]
 mod tests {
     use blockifier::transaction::objects::TransactionExecutionInfo;
-    use starknet_rs_core::types::TransactionExecutionStatus;
+    use starknet_rs_core::types::{TransactionExecutionStatus, TransactionFinalityStatus};
     use starknet_types::rpc::transactions::{DeclareTransaction, Transaction};
     use starknet_types::traits::HashProducer;
 
@@ -223,12 +230,11 @@ mod tests {
         let hash = declare_transaction.generate_hash().unwrap();
         let tx = Transaction::Declare(DeclareTransaction::Version1(declare_transaction));
 
-        let sn_tx =
-            StarknetTransaction::create_successful(&tx, None, TransactionExecutionInfo::default());
+        let sn_tx = StarknetTransaction::create_accepted(&tx, TransactionExecutionInfo::default());
         let mut sn_txs = StarknetTransactions::default();
         sn_txs.insert(
             &hash,
-            StarknetTransaction::create_successful(&tx, None, TransactionExecutionInfo::default()),
+            StarknetTransaction::create_accepted(&tx, TransactionExecutionInfo::default()),
         );
 
         let extracted_tran = sn_txs.get_by_hash_mut(&hash).unwrap();
@@ -254,12 +260,9 @@ mod tests {
 
     fn check_correct_transaction_properties(tran: Transaction, is_success: bool) {
         let sn_tran = if is_success {
-            let tx = StarknetTransaction::create_successful(
-                &tran,
-                None,
-                TransactionExecutionInfo::default(),
-            );
-            assert_eq!(tx.finality_status, None);
+            let tx =
+                StarknetTransaction::create_accepted(&tran, TransactionExecutionInfo::default());
+            assert_eq!(tx.finality_status, Some(TransactionFinalityStatus::AcceptedOnL2));
             assert_eq!(tx.execution_result.status(), TransactionExecutionStatus::Succeeded);
 
             tx
@@ -269,8 +272,8 @@ mod tests {
                     .to_string();
             let tx = StarknetTransaction::create_rejected(&tran, None, &error_str);
 
-            assert_eq!(tx.execution_result.revert_reason(), Some(error_str.as_str()));
             assert_eq!(tx.finality_status, None);
+            assert_eq!(tx.execution_result.revert_reason(), Some(error_str.as_str()));
 
             tx
         };


### PR DESCRIPTION
## Usage related changes

- #150 still not closeable - we need to bounce back invalid txs, not revert them
- Closes #203

## Development related changes

- This will also allow me to continue with #178
- In a few places I renamed `successful` to `accepted` since I believe this is more appropriate (given that we accept even the reverted txs, which aren't successful in the same way as those whose execution has status succeeded).
- In this PR, I can deal with proposed refactoring of commonalities in tx handling.
  - Will not be handled in this PR

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Updated the tests
- [x] All tests are passing - `cargo test`
