### PR TITLE
Update blockifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.2.0-rc0"
-source = "git+https://github.com/starkware-libs/blockifier?rev=f46101544c54e433adea39c56eeee63d0715e49d#f46101544c54e433adea39c56eeee63d0715e49d"
+source = "git+https://github.com/starkware-libs/blockifier?rev=3bbb037e7cd5c8d235770e5a64310fb9ad902ec5#3bbb037e7cd5c8d235770e5a64310fb9ad902ec5"
 dependencies = [
  "ark-ec",
  "ark-ff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.2.0-rc0"
-source = "git+https://github.com/starkware-libs/blockifier?rev=9314c6712d72a6292705dc30339b56808b72a952#9314c6712d72a6292705dc30339b56808b72a952"
+source = "git+https://github.com/starkware-libs/blockifier?rev=ea6a3f7483d02813066dc03f8f86e0545404a977#ea6a3f7483d02813066dc03f8f86e0545404a977"
 dependencies = [
  "ark-ff",
  "ark-secp256k1",
@@ -3293,18 +3293,18 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,8 +504,8 @@ dependencies = [
 
 [[package]]
 name = "blockifier"
-version = "0.2.0-rc0"
-source = "git+https://github.com/starkware-libs/blockifier?rev=e8ee613d05cf9c55bdb10b871b59365fca04b6ee#e8ee613d05cf9c55bdb10b871b59365fca04b6ee"
+version = "0.2.0-rc1"
+source = "git+https://github.com/starkware-libs/blockifier?rev=d4a3717a0744fb90fb7c01a58e607226a19dd1c9#d4a3717a0744fb90fb7c01a58e607226a19dd1c9"
 dependencies = [
  "ark-ec",
  "ark-ff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.2.0-rc0"
-source = "git+https://github.com/starkware-libs/blockifier?rev=3bbb037e7cd5c8d235770e5a64310fb9ad902ec5#3bbb037e7cd5c8d235770e5a64310fb9ad902ec5"
+source = "git+https://github.com/starkware-libs/blockifier?rev=e8ee613d05cf9c55bdb10b871b59365fca04b6ee#e8ee613d05cf9c55bdb10b871b59365fca04b6ee"
 dependencies = [
  "ark-ec",
  "ark-ff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.2.0-rc0"
-source = "git+https://github.com/starkware-libs/blockifier?rev=v0.2.0-rc0#39730ea3078034367939f1bfa34d5e979ce9f426"
+source = "git+https://github.com/starkware-libs/blockifier?rev=39730ea3078034367939f1bfa34d5e979ce9f426#39730ea3078034367939f1bfa34d5e979ce9f426"
 dependencies = [
  "ark-ff",
  "ark-secp256k1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,8 +504,8 @@ dependencies = [
 
 [[package]]
 name = "blockifier"
-version = "0.2.0-rc1"
-source = "git+https://github.com/starkware-libs/blockifier?rev=d4a3717a0744fb90fb7c01a58e607226a19dd1c9#d4a3717a0744fb90fb7c01a58e607226a19dd1c9"
+version = "0.3.0-rc0"
+source = "git+https://github.com/starkware-libs/blockifier?rev=v0.3.0-rc0#72087fe729a950f284189fa74304824e7c1c99ee"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -531,7 +531,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "starknet-crypto 0.5.1",
- "starknet_api",
+ "starknet_api 0.5.0-rc1",
  "strum 0.24.1",
  "strum_macros 0.24.3",
  "thiserror",
@@ -639,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2be5e37ae499d027c5b5ad0c468f722c249bdc849c9eff9b22e8c40c5d7ef8"
+checksum = "afc7f7cb89bc3f52c2c738f3e87c8f8773bd3456cae1d322d100d4b0da584f3c"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -656,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afe45861a6de179146fcd87bee4ed70f1a6d34e1867ace6b4f33422b291ffa87"
+checksum = "d4f2c54b065f7fd97bf8d5df76cbcbbd01d8a8c319d281796ee20ecc48e16ca8"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -673,6 +673,7 @@ dependencies = [
  "cairo-lang-sierra-generator",
  "cairo-lang-syntax",
  "cairo-lang-utils",
+ "itertools 0.11.0",
  "log",
  "salsa",
  "smol_str",
@@ -681,18 +682,18 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be2490e38d7aef07f6ea355f02945fac1c1fee6d26cb8ee1fd622251deee235"
+checksum = "873ba77d4c3f780c727c7d6c738cded22b3f6d4023e30546dfe14f97a087887e"
 dependencies = [
  "cairo-lang-utils",
 ]
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd55f61525626db924988e28ccdff5d8e1634b44dc6ebdd02a820727279a6ab"
+checksum = "f5031fff038c27ed43769b73a6f5d41aeaea34df9af862e024c23fbb4f076249"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
@@ -708,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1548fd12ba4f30323c41953f49ac0a58321d8694bfafdba5e11cc06ec525e7fc"
+checksum = "7b6cb1492e5784e1076320a5018ce7584f391b2f3b414bc0a8ab7c289fa118ce"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -721,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b95561a2be56cdc81a76010084690ed827638c16bc85a7c3393ed13ea85f429"
+checksum = "c35dddbc63b2a4870891cc74498726aa32bfaa518596352f9bb101411cc4c584"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
@@ -733,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6607c0942e1a03d97bbd53de79670295912f84608bdf3d63c867bdca434b20d"
+checksum = "32ce0b8e66a6085ae157d43b5c162d60166f0027d6f125c50ee74e4dc7916ff6"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-utils",
@@ -747,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f2e31234c63c94f0ac4373e4db4910ab4122579da62beb76246d9fd423326f"
+checksum = "29cc679f501725e03ee703559ed27d084c6f4031bd51ff86378cf845a85ee207"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -766,15 +767,16 @@ dependencies = [
  "log",
  "num-bigint",
  "num-traits 0.2.15",
+ "once_cell",
  "salsa",
  "smol_str",
 ]
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a339848271afad835a202b37e7612a2b24f09786d087b7403c57b18f89438a3"
+checksum = "cdcadb046659134466bc7e11961ea8a56969dae8a54d8f985955ce0b95185c7f"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -793,17 +795,17 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6c969daf780ce66cfa3c80425ec70f286ccbd6eee9de924c20926070b5395c"
+checksum = "4632790cd4ea11d4849934456a400eae7ed419f6d721f24a6b637df67b7e902f"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
  "cairo-lang-parser",
- "cairo-lang-semantic",
  "cairo-lang-syntax",
  "cairo-lang-utils",
+ "indent",
  "indoc",
  "itertools 0.11.0",
  "num-bigint",
@@ -813,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7b79f040017cd2985b8f02b0ccb1a04849f7c011ea8a4610bb6d14120d213c"
+checksum = "170838817fc33ddb65e0a9480526df0b226b148a0fca0a5cd7071be4c6683157"
 dependencies = [
  "cairo-lang-debug",
  "quote",
@@ -824,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98b4d33fee576c6a32ea2173f95b7e15a0173ad53c1dd8d1b7d1ecee389b1416"
+checksum = "4162ee976c61fdeb3b621f4a76fd256e46a5c0890f750a3a9d2c9560a3bc1daf"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
@@ -875,15 +877,16 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e403e8f03d8a052f1e75bcd225bb22dce053e90d070109d7e3b312a1768e56"
+checksum = "13e544fa9a222bf2d007df2b5fc9b21c2a20ab7e17d6fefbcbc193de209451cd"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
  "cairo-lang-parser",
+ "cairo-lang-plugins",
  "cairo-lang-proc-macros",
  "cairo-lang-syntax",
  "cairo-lang-utils",
@@ -892,15 +895,16 @@ dependencies = [
  "log",
  "num-bigint",
  "num-traits 0.2.15",
+ "once_cell",
  "salsa",
  "smol_str",
 ]
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854bfe7e812aac95f37bd78b1b02e21e6597bf766feda1f44213cbc05ad917e4"
+checksum = "d5e136b79e95a14ef38a2be91a67ceb85317407d336a5b0d418c33b23c78596a"
 dependencies = [
  "cairo-lang-utils",
  "const-fnv1a-hash",
@@ -921,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a3d10bde6ccab7e8652b47c28d11f67103cc38ab0b2e35f1e8713330d9f83b4"
+checksum = "511ca7708faa7ba8d14ae26e1d60ead2d02028c8f664baf5ecb0fd6a0d1e20f6"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -935,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd76e6829e8e2358b1c366a745b0842ebd01857bb2380e27cc4504ae82a7ef"
+checksum = "351a25bc010b910919c01d5c57e937b0c3d330fc30d92702c0cb4061819df8df"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -949,9 +953,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb97ef0e55139d2d78506ac00256745dc31dafbdf717b62d502817c69a1a251"
+checksum = "114091bb971c06fd072aca816af1c3f62566cd8a4b1453c786155161a36c7bce"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -969,15 +973,16 @@ dependencies = [
  "indexmap 2.0.0",
  "itertools 0.11.0",
  "num-bigint",
+ "once_cell",
  "salsa",
  "smol_str",
 ]
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c166237c4ae17b6d13f2377212398d059ea53378a08976f59035ab9ded67542"
+checksum = "fa1c799de62972dfd7112d563000695be94305b6f7d9bedd29f347799bf03e1c"
 dependencies = [
  "assert_matches",
  "cairo-felt",
@@ -997,9 +1002,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c52c234a5ee7beb8d22cff1ce219686c80c6a4922b85b6ec94edab349842bd26"
+checksum = "d2fe73d9d58aaf9088f6ba802bcf43ce9ca4bd198190cf5bf91caa7d408dd11a"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-utils",
@@ -1007,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c5cfd1dead7c650db9666e6916c2963808090913d7f2ee40d02c76d9b7aa86a"
+checksum = "75df624e71e33a31a924e799dd2a9a8284204b41d8db9c51803317bd9edff81f"
 dependencies = [
  "anyhow",
  "cairo-felt",
@@ -1048,9 +1053,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35b4e998d615b1cdf470f02933089e6cf563f2364b1a1791403938d06ea37ae1"
+checksum = "0b1af0ae21f9e539f97cfdf56f5ce0934dae5d87f568fd778c3d624a102f8dbb"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -1065,9 +1070,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348834dc857ed9c6cd6b689fa1fe040837771eaead69f8e3758cd35fbc200685"
+checksum = "822ffabf24f6a5506262edcece315260a82d9dfba3abe6548791a6d654563ad0"
 dependencies = [
  "genco",
  "xshell",
@@ -1075,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d31e97e1b6c5308d647ea67b345aad5f5bc8a5aab15c5ecf105b698fb7ac725f"
+checksum = "f974b6e859f0b09c0f13ec8188c96e9e8bbb5da04214f911dbb5bcda67cb812b"
 dependencies = [
  "indexmap 2.0.0",
  "itertools 0.11.0",
@@ -3523,7 +3528,7 @@ dependencies = [
  "starknet-core 0.6.0",
  "starknet-ff",
  "starknet-signers 0.4.0",
- "starknet_api",
+ "starknet_api 0.5.0-rc1",
  "starknet_in_rust",
  "strum 0.25.0",
  "strum_macros 0.25.2",
@@ -3862,6 +3867,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "starknet_api"
+version = "0.5.0-rc1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70f6673391b3f3624651e8692f4e76aab9194abb3d3feeb3a07a6b0546639ee"
+dependencies = [
+ "cairo-lang-starknet",
+ "derive_more",
+ "hex",
+ "indexmap 1.9.3",
+ "once_cell",
+ "primitive-types",
+ "serde",
+ "serde_json",
+ "starknet-crypto 0.5.1",
+ "thiserror",
+]
+
+[[package]]
 name = "starknet_in_rust"
 version = "0.4.0"
 source = "git+https://github.com/lambdaclass/starknet_in_rust?rev=a7e2e56#a7e2e561802051e2acb58e66b282315501d1b6bb"
@@ -3890,7 +3913,7 @@ dependencies = [
  "sha3",
  "starknet 0.5.0",
  "starknet-crypto 0.5.1",
- "starknet_api",
+ "starknet_api 0.4.1",
  "thiserror",
 ]
 
@@ -4385,7 +4408,7 @@ dependencies = [
  "serde_json",
  "starknet-core 0.6.0",
  "starknet-ff",
- "starknet_api",
+ "starknet_api 0.5.0-rc1",
  "starknet_in_rust",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.2.0-rc0"
-source = "git+https://github.com/starkware-libs/blockifier?rev=39730ea3078034367939f1bfa34d5e979ce9f426#39730ea3078034367939f1bfa34d5e979ce9f426"
+source = "git+https://github.com/starkware-libs/blockifier?rev=9314c6712d72a6292705dc30339b56808b72a952#9314c6712d72a6292705dc30339b56808b72a952"
 dependencies = [
  "ark-ff",
  "ark-secp256k1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,10 +505,12 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.2.0-rc0"
-source = "git+https://github.com/starkware-libs/blockifier?rev=ea6a3f7483d02813066dc03f8f86e0545404a977#ea6a3f7483d02813066dc03f8f86e0545404a977"
+source = "git+https://github.com/starkware-libs/blockifier?rev=f46101544c54e433adea39c56eeee63d0715e49d#f46101544c54e433adea39c56eeee63d0715e49d"
 dependencies = [
+ "ark-ec",
  "ark-ff",
  "ark-secp256k1",
+ "ark-secp256r1",
  "cached",
  "cairo-felt",
  "cairo-lang-casm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ strum_macros = "0.25"
 # Starknet dependencies
 starknet_api = { version = "0.4.1", features = ["testing"] }
 starknet-in-rust = { git = "https://github.com/lambdaclass/starknet_in_rust", rev = "a7e2e56", package="starknet_in_rust" }
-blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "39730ea3078034367939f1bfa34d5e979ce9f426", package = "blockifier" }
+blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "9314c6712d72a6292705dc30339b56808b72a952", package = "blockifier" }
 starknet-rs-signers = { version = "0.4.0", package="starknet-signers" }
 starknet-rs-ff = { version = "0.3.4", package = "starknet-ff" }
 starknet-rs-core = {  version = "0.6.0", package = "starknet-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ strum_macros = "0.25"
 # Starknet dependencies
 starknet_api = { version = "0.4.1", features = ["testing"] }
 starknet-in-rust = { git = "https://github.com/lambdaclass/starknet_in_rust", rev = "a7e2e56", package="starknet_in_rust" }
-blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "f46101544c54e433adea39c56eeee63d0715e49d", package = "blockifier" }
+blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "3bbb037e7cd5c8d235770e5a64310fb9ad902ec5", package = "blockifier" }
 starknet-rs-signers = { version = "0.4.0", package="starknet-signers" }
 starknet-rs-ff = { version = "0.3.4", package = "starknet-ff" }
 starknet-rs-core = {  version = "0.6.0", package = "starknet-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 base64 = { version = "0.21.2" }
 clap = { version = "4.3.2", features = ["derive"] }
 flate2 = { version = "1.0.26" }
-serde = { version = "1.0.184", features = ["derive"] }
+serde = { version = "1.0.171", features = ["derive"] }
 serde_json = { version = "1.0.81" }
 thiserror = { version = "1.0.32" }
 anyhow = "1"
@@ -55,7 +55,7 @@ strum_macros = "0.25"
 # Starknet dependencies
 starknet_api = { version = "0.4.1", features = ["testing"] }
 starknet-in-rust = { git = "https://github.com/lambdaclass/starknet_in_rust", rev = "a7e2e56", package="starknet_in_rust" }
-blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "3bbb037e7cd5c8d235770e5a64310fb9ad902ec5", package = "blockifier" }
+blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "e8ee613d05cf9c55bdb10b871b59365fca04b6ee", package = "blockifier" }
 starknet-rs-signers = { version = "0.4.0", package="starknet-signers" }
 starknet-rs-ff = { version = "0.3.4", package = "starknet-ff" }
 starknet-rs-core = {  version = "0.6.0", package = "starknet-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ strum_macros = "0.25"
 # Starknet dependencies
 starknet_api = { version = "0.4.1", features = ["testing"] }
 starknet-in-rust = { git = "https://github.com/lambdaclass/starknet_in_rust", rev = "a7e2e56", package="starknet_in_rust" }
-blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "e8ee613d05cf9c55bdb10b871b59365fca04b6ee", package = "blockifier" }
+blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "d4a3717a0744fb90fb7c01a58e607226a19dd1c9", package = "blockifier" }
 starknet-rs-signers = { version = "0.4.0", package="starknet-signers" }
 starknet-rs-ff = { version = "0.3.4", package = "starknet-ff" }
 starknet-rs-core = {  version = "0.6.0", package = "starknet-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ strum_macros = "0.25"
 # Starknet dependencies
 starknet_api = { version = "0.4.1", features = ["testing"] }
 starknet-in-rust = { git = "https://github.com/lambdaclass/starknet_in_rust", rev = "a7e2e56", package="starknet_in_rust" }
-blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "v0.2.0-rc0", package = "blockifier" }
+blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "39730ea3078034367939f1bfa34d5e979ce9f426", package = "blockifier" }
 starknet-rs-signers = { version = "0.4.0", package="starknet-signers" }
 starknet-rs-ff = { version = "0.3.4", package = "starknet-ff" }
 starknet-rs-core = {  version = "0.6.0", package = "starknet-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ strum_macros = "0.25"
 # Starknet dependencies
 starknet_api = { version = "0.4.1", features = ["testing"] }
 starknet-in-rust = { git = "https://github.com/lambdaclass/starknet_in_rust", rev = "a7e2e56", package="starknet_in_rust" }
-blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "ea6a3f7483d02813066dc03f8f86e0545404a977", package = "blockifier" }
+blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "f46101544c54e433adea39c56eeee63d0715e49d", package = "blockifier" }
 starknet-rs-signers = { version = "0.4.0", package="starknet-signers" }
 starknet-rs-ff = { version = "0.3.4", package = "starknet-ff" }
 starknet-rs-core = {  version = "0.6.0", package = "starknet-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 base64 = { version = "0.21.2" }
 clap = { version = "4.3.2", features = ["derive"] }
 flate2 = { version = "1.0.26" }
-serde = { version = "1.0.171", features = ["derive"] }
+serde = { version = "1.0.184", features = ["derive"] }
 serde_json = { version = "1.0.81" }
 thiserror = { version = "1.0.32" }
 anyhow = "1"
@@ -55,7 +55,7 @@ strum_macros = "0.25"
 # Starknet dependencies
 starknet_api = { version = "0.4.1", features = ["testing"] }
 starknet-in-rust = { git = "https://github.com/lambdaclass/starknet_in_rust", rev = "a7e2e56", package="starknet_in_rust" }
-blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "9314c6712d72a6292705dc30339b56808b72a952", package = "blockifier" }
+blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "ea6a3f7483d02813066dc03f8f86e0545404a977", package = "blockifier" }
 starknet-rs-signers = { version = "0.4.0", package="starknet-signers" }
 starknet-rs-ff = { version = "0.3.4", package = "starknet-ff" }
 starknet-rs-core = {  version = "0.6.0", package = "starknet-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,9 +53,9 @@ strum = "0.25"
 strum_macros = "0.25"
 
 # Starknet dependencies
-starknet_api = { version = "0.4.1", features = ["testing"] }
+starknet_api = { version = "0.5.0-rc1", features = ["testing"] }
 starknet-in-rust = { git = "https://github.com/lambdaclass/starknet_in_rust", rev = "a7e2e56", package="starknet_in_rust" }
-blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "d4a3717a0744fb90fb7c01a58e607226a19dd1c9", package = "blockifier" }
+blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "v0.3.0-rc0", package = "blockifier" }
 starknet-rs-signers = { version = "0.4.0", package="starknet-signers" }
 starknet-rs-ff = { version = "0.3.4", package = "starknet-ff" }
 starknet-rs-core = {  version = "0.6.0", package = "starknet-core" }

--- a/crates/starknet/src/starknet/estimations.rs
+++ b/crates/starknet/src/starknet/estimations.rs
@@ -89,7 +89,7 @@ fn estimate_transaction_fee(
     let total_l1_gas_usage = l1_gas_usage as f64 + l1_gas_by_vm_usage;
     let total_l1_gas_usage = total_l1_gas_usage.ceil() as u64;
 
-    let gas_price = block_context.gas_price as u64;
+    let gas_price = block_context.gas_prices.eth_l1_gas_price as u64;
 
     Ok(FeeEstimateWrapper::new(total_l1_gas_usage, gas_price, total_l1_gas_usage * gas_price))
 }

--- a/crates/starknet/src/starknet/events.rs
+++ b/crates/starknet/src/starknet/events.rs
@@ -123,7 +123,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use blockifier::execution::entry_point::CallInfo;
+    use blockifier::execution::call_info::CallInfo;
     use starknet_rs_core::types::BlockId;
     use starknet_types::contract_address::ContractAddress;
     use starknet_types::emitted_event::Event;
@@ -424,7 +424,7 @@ mod tests {
         // order based on the "order" field of the object when extracting them from
         // transaction execution call info
         for idx in (1..=events_count).rev() {
-            let event = blockifier::execution::entry_point::OrderedEvent {
+            let event = blockifier::execution::call_info::OrderedEvent {
                 order: idx,
                 event: starknet_api::transaction::EventContent {
                     keys: vec![starknet_api::transaction::EventKey(

--- a/crates/starknet/src/starknet/mod.rs
+++ b/crates/starknet/src/starknet/mod.rs
@@ -295,7 +295,8 @@ impl Starknet {
         block_context.block_timestamp = BlockTimestamp(0);
         block_context.gas_prices.eth_l1_gas_price = gas_price as u128;
         block_context.chain_id = chain_id.into();
-        block_context.fee_token_addresses.eth_fee_token_address = contract_address!(fee_token_address);
+        block_context.fee_token_addresses.eth_fee_token_address =
+            contract_address!(fee_token_address);
         // inject cairo resource fee weights from starknet_in_rust
         block_context.vm_resource_fee_cost =
             std::sync::Arc::new(DEFAULT_CAIRO_RESOURCE_FEE_WEIGHTS.clone());
@@ -806,8 +807,8 @@ mod tests {
         let block_ctx = Starknet::init_block_context(10, "0xAA", DEVNET_DEFAULT_CHAIN_ID);
         assert_eq!(block_ctx.block_number, BlockNumber(0));
         assert_eq!(block_ctx.block_timestamp, BlockTimestamp(0));
-        assert_eq!(block_ctx.gas_price, 10);
-        assert_eq!(ContractAddress::from(block_ctx.fee_token_address), fee_token_address);
+        assert_eq!(block_ctx.gas_prices.eth_l1_gas_price, 10);
+        assert_eq!(ContractAddress::from(block_ctx.fee_token_addresses.eth_fee_token_address), fee_token_address);
     }
 
     #[test]
@@ -852,7 +853,7 @@ mod tests {
         let mut starknet = Starknet::new(&config).unwrap();
 
         let initial_block_number = starknet.block_context.block_number;
-        let initial_gas_price = starknet.block_context.gas_price;
+        let initial_gas_price = starknet.block_context.gas_prices.eth_l1_gas_price;
         let initial_block_timestamp = starknet.block_context.block_timestamp;
         let initial_sequencer = starknet.block_context.sequencer_address;
 

--- a/crates/starknet/src/starknet/mod.rs
+++ b/crates/starknet/src/starknet/mod.rs
@@ -293,9 +293,9 @@ impl Starknet {
 
         block_context.block_number = BlockNumber(0);
         block_context.block_timestamp = BlockTimestamp(0);
-        block_context.gas_price = gas_price as u128;
+        block_context.gas_prices.eth_l1_gas_price = gas_price as u128;
         block_context.chain_id = chain_id.into();
-        block_context.fee_token_address = contract_address!(fee_token_address);
+        block_context.fee_token_addresses.eth_fee_token_address = contract_address!(fee_token_address);
         // inject cairo resource fee weights from starknet_in_rust
         block_context.vm_resource_fee_cost =
             std::sync::Arc::new(DEFAULT_CAIRO_RESOURCE_FEE_WEIGHTS.clone());
@@ -324,7 +324,7 @@ impl Starknet {
         let mut block = StarknetBlock::create_pending_block();
 
         block.header.block_number = self.block_context.block_number;
-        block.header.gas_price = GasPrice(self.block_context.gas_price);
+        block.header.gas_price = GasPrice(self.block_context.gas_prices.eth_l1_gas_price);
         block.header.sequencer = self.block_context.sequencer_address;
         block.header.timestamp = self.block_context.block_timestamp;
 

--- a/crates/starknet/src/starknet/mod.rs
+++ b/crates/starknet/src/starknet/mod.rs
@@ -808,7 +808,10 @@ mod tests {
         assert_eq!(block_ctx.block_number, BlockNumber(0));
         assert_eq!(block_ctx.block_timestamp, BlockTimestamp(0));
         assert_eq!(block_ctx.gas_prices.eth_l1_gas_price, 10);
-        assert_eq!(ContractAddress::from(block_ctx.fee_token_addresses.eth_fee_token_address), fee_token_address);
+        assert_eq!(
+            ContractAddress::from(block_ctx.fee_token_addresses.eth_fee_token_address),
+            fee_token_address
+        );
     }
 
     #[test]

--- a/crates/starknet/src/transactions.rs
+++ b/crates/starknet/src/transactions.rs
@@ -94,7 +94,7 @@ impl StarknetTransaction {
         let mut events: Vec<Event> = vec![];
 
         fn get_blockifier_events_recursively(
-            call_info: &blockifier::execution::entry_point::CallInfo,
+            call_info: &blockifier::execution::call_info::CallInfo,
         ) -> Vec<(usize, Event)> {
             let mut events: Vec<(usize, Event)> = vec![];
 

--- a/crates/types/src/rpc/transactions.rs
+++ b/crates/types/src/rpc/transactions.rs
@@ -394,7 +394,7 @@ pub struct SimulatedTransaction {
 
 impl FunctionInvocation {
     pub fn try_from_call_info(
-        mut call_info: blockifier::execution::entry_point::CallInfo,
+        mut call_info: blockifier::execution::call_info::CallInfo,
         address_to_class_hash: &HashMap<ContractAddress, Felt>,
     ) -> DevnetResult<Self> {
         let mut internal_calls: Vec<FunctionInvocation> = vec![];

--- a/crates/types/src/rpc/transactions/broadcasted_deploy_account_transaction.rs
+++ b/crates/types/src/rpc/transactions/broadcasted_deploy_account_transaction.rs
@@ -4,7 +4,6 @@ use cairo_felt::Felt252;
 use serde::{Deserialize, Serialize};
 use starknet_api::core::calculate_contract_address;
 use starknet_api::transaction::Fee;
-use starknet_rs_ff::FieldElement;
 
 use crate::contract_address::ContractAddress;
 use crate::error::DevnetResult;
@@ -14,8 +13,6 @@ use crate::felt::{
 };
 use crate::rpc::transactions::deploy_account_transaction::DeployAccountTransaction;
 use crate::rpc::transactions::BroadcastedTransactionCommon;
-
-const TRANSACTION_VERSION: FieldElement = FieldElement::ONE;
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct BroadcastedDeployAccountTransaction {
@@ -75,9 +72,8 @@ impl BroadcastedDeployAccountTransaction {
             )?
             .into();
 
-        let sn_api_transaction = starknet_api::transaction::DeployAccountTransaction {
+        let sn_api_transaction = starknet_api::transaction::DeployAccountTransactionV1 {
             max_fee: self.common.max_fee,
-            version: starknet_api::transaction::TransactionVersion(TRANSACTION_VERSION.into()),
             signature: starknet_api::transaction::TransactionSignature(
                 self.common.signature.iter().map(|felt| felt.into()).collect(),
             ),
@@ -92,7 +88,7 @@ impl BroadcastedDeployAccountTransaction {
         };
 
         Ok(blockifier::transaction::transactions::DeployAccountTransaction {
-            tx: sn_api_transaction,
+            tx: starknet_api::transaction::DeployAccountTransaction::V1(sn_api_transaction),
             tx_hash: starknet_api::transaction::TransactionHash(transaction_hash.into()),
             contract_address,
         })


### PR DESCRIPTION
## Development related changes

blockifier updated to v0.3.0-rc0
starknet_api updated to 0.5.0-rc1, due to some compilation errors

Introduced new fields in BlockContext:
 - strk_l1_gas_price
 - strk_fee_token_address

Used for V3 Invoke transactions.

Closes #206 

## Checklist:

- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] Performed code self-review
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Documented the changes
- [ ] Linked the issues which this PR resolves
- [ ] Updated the tests
- [ ] All tests are passing - `cargo test`
