### PR TITLE
Refactor config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,8 +532,8 @@ dependencies = [
  "sha3",
  "starknet-crypto 0.5.1",
  "starknet_api 0.5.0-rc1",
- "strum 0.24.1",
- "strum_macros 0.24.3",
+ "strum",
+ "strum_macros",
  "thiserror",
 ]
 
@@ -3520,6 +3520,7 @@ name = "starknet"
 version = "0.1.0"
 dependencies = [
  "blockifier",
+ "clap",
  "indexmap 2.0.0",
  "jsonschema",
  "random-number-generator",
@@ -3530,8 +3531,6 @@ dependencies = [
  "starknet-signers 0.4.0",
  "starknet_api 0.5.0-rc1",
  "starknet_in_rust",
- "strum 0.25.0",
- "strum_macros 0.25.2",
  "thiserror",
  "tracing",
  "types",
@@ -3804,7 +3803,6 @@ dependencies = [
  "starknet-providers 0.6.0",
  "starknet-signers 0.4.0",
  "starknet_in_rust",
- "strum 0.25.0",
  "thiserror",
  "tokio",
  "tokio-graceful-shutdown",
@@ -3949,12 +3947,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
-name = "strum"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
-
-[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3965,19 +3957,6 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.28",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4380,6 +4380,7 @@ dependencies = [
  "base64 0.21.2",
  "blockifier",
  "cairo-felt",
+ "clap",
  "flate2",
  "num-bigint",
  "num-integer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,6 @@ thiserror = { version = "1.0.32" }
 anyhow = "1"
 tokio-graceful-shutdown = "0.13.0"
 indexmap = "2.0.0"
-strum = "0.25"
-strum_macros = "0.25"
 
 # Starknet dependencies
 starknet_api = { version = "0.5.0-rc1", features = ["testing"] }

--- a/crates/server/src/builder.rs
+++ b/crates/server/src/builder.rs
@@ -7,7 +7,7 @@ use axum::routing::{post, IntoMakeService};
 use axum::{Extension, Router};
 use hyper::server::conn::AddrIncoming;
 use hyper::{header, Method, Request, Server};
-use starknet_core::starknet::StarknetConfig;
+use starknet_core::starknet::starknet_config::StarknetConfig;
 use tower::Service;
 use tower_http::cors::CorsLayer;
 use tower_http::timeout::TimeoutLayer;

--- a/crates/starknet-server/Cargo.toml
+++ b/crates/starknet-server/Cargo.toml
@@ -47,7 +47,6 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 tokio-graceful-shutdown = { workspace = true }
-strum = { workspace = true }
 
 [dev-dependencies]
 lazy_static = { workspace = true }

--- a/crates/starknet-server/src/cli.rs
+++ b/crates/starknet-server/src/cli.rs
@@ -1,4 +1,3 @@
-use core::panic;
 use std::net::{IpAddr, Ipv4Addr};
 
 use clap::Parser;
@@ -67,17 +66,16 @@ pub(crate) struct Args {
     #[arg(help = "Specify the gas price in wei per gas unit;")]
     gas_price: u64,
 
-    // Chain id as string
     #[arg(long = "chain-id")]
     #[arg(value_name = "CHAIN_ID")]
     #[arg(default_value = "TESTNET")]
-    #[arg(help = "Specify the chain id as one of: {MAINNET, TESTNET, TESTNET2};")]
-    chain_id: String,
+    #[arg(help = "Specify the chain ID;")]
+    chain_id: ChainId,
 
     #[arg(long = "dump-on")]
     #[arg(value_name = "WHEN")]
     #[arg(help = "Specify when to dump the state of Devnet;")]
-    #[arg(requires = "dump_path")] // TODO not working
+    #[arg(requires = "dump_path")]
     dump_on: Option<DumpOn>,
 
     // Dump path as string
@@ -104,12 +102,7 @@ impl Args {
             port: self.port,
             timeout: self.timeout,
             gas_price: self.gas_price,
-            chain_id: match self.chain_id.as_str() {
-                "MAINNET" => ChainId::MainNet,
-                "TESTNET" => ChainId::TestNet,
-                "TESTNET2" => ChainId::TestNet2,
-                _ => panic!("Invalid value for chain-id"),
-            },
+            chain_id: self.chain_id,
             dump_on: self.dump_on,
             dump_path: self.dump_path.clone(),
         }

--- a/crates/starknet-server/src/cli.rs
+++ b/crates/starknet-server/src/cli.rs
@@ -6,7 +6,7 @@ use starknet_core::constants::{
     DEVNET_DEFAULT_GAS_PRICE, DEVNET_DEFAULT_INITIAL_BALANCE, DEVNET_DEFAULT_PORT,
     DEVNET_DEFAULT_TIMEOUT, DEVNET_DEFAULT_TOTAL_ACCOUNTS,
 };
-use starknet_core::starknet::{DumpMode, StarknetConfig};
+use starknet_core::starknet::starknet_config::{DumpMode, StarknetConfig};
 use starknet_types::chain_id::ChainId;
 use starknet_types::num_bigint::BigUint;
 use strum::IntoEnumIterator;

--- a/crates/starknet-server/src/cli.rs
+++ b/crates/starknet-server/src/cli.rs
@@ -6,10 +6,9 @@ use starknet_core::constants::{
     DEVNET_DEFAULT_GAS_PRICE, DEVNET_DEFAULT_INITIAL_BALANCE, DEVNET_DEFAULT_PORT,
     DEVNET_DEFAULT_TIMEOUT, DEVNET_DEFAULT_TOTAL_ACCOUNTS,
 };
-use starknet_core::starknet::starknet_config::{DumpMode, StarknetConfig};
+use starknet_core::starknet::starknet_config::{DumpOn, StarknetConfig};
 use starknet_types::chain_id::ChainId;
 use starknet_types::num_bigint::BigUint;
-use strum::IntoEnumIterator;
 
 use crate::ip_addr_wrapper::IpAddrWrapper;
 
@@ -75,11 +74,11 @@ pub(crate) struct Args {
     #[arg(help = "Specify the chain id as one of: {MAINNET, TESTNET, TESTNET2};")]
     chain_id: String,
 
-    // Dump on exit or after transaction
     #[arg(long = "dump-on")]
-    #[arg(value_name = "DUMP_ON")]
-    #[arg(help = "Specify when to dump; can dump on: exit, transaction;")]
-    dump_on: Option<String>,
+    #[arg(value_name = "WHEN")]
+    #[arg(help = "Specify when to dump the state of Devnet;")]
+    #[arg(requires = "dump_path")] // TODO not working
+    dump_on: Option<DumpOn>,
 
     // Dump path as string
     #[arg(long = "dump-path")]
@@ -111,35 +110,8 @@ impl Args {
                 "TESTNET2" => ChainId::TestNet2,
                 _ => panic!("Invalid value for chain-id"),
             },
-            dump_on: self.parse_dump_on(),
+            dump_on: self.dump_on,
             dump_path: self.dump_path.clone(),
-        }
-    }
-
-    pub(crate) fn parse_dump_on(&self) -> Option<DumpMode> {
-        let dump_on = self.dump_on.clone().unwrap_or_default();
-
-        if self.dump_path.is_some() && !dump_on.as_str().is_empty() {
-            match dump_on.as_str() {
-                "exit" => Some(DumpMode::OnExit),
-                "transaction" => Some(DumpMode::OnTransaction),
-                _ => {
-                    let mut options = String::new();
-                    for mode in DumpMode::iter() {
-                        options.push_str((mode.to_string() + ", ").as_str());
-                    }
-
-                    panic!(
-                        "--dump_on Should be one of: {}; got: {}",
-                        &options[0..options.len() - 2],
-                        dump_on.as_str()
-                    )
-                }
-            }
-        } else if !dump_on.as_str().is_empty() {
-            panic!("--dump-path required if --dump-on is present")
-        } else {
-            None
         }
     }
 }

--- a/crates/starknet-server/src/main.rs
+++ b/crates/starknet-server/src/main.rs
@@ -10,7 +10,8 @@ use starknet_core::constants::{
     ERC20_CONTRACT_ADDRESS, ERC20_CONTRACT_CLASS_HASH, UDC_CONTRACT_ADDRESS,
     UDC_CONTRACT_CLASS_HASH,
 };
-use starknet_core::starknet::{DumpMode, Starknet};
+use starknet_core::starknet::starknet_config::DumpMode;
+use starknet_core::starknet::Starknet;
 use starknet_types::felt::Felt;
 use starknet_types::traits::{ToDecimalString, ToHexString};
 use tracing::info;

--- a/crates/starknet-server/src/main.rs
+++ b/crates/starknet-server/src/main.rs
@@ -10,7 +10,7 @@ use starknet_core::constants::{
     ERC20_CONTRACT_ADDRESS, ERC20_CONTRACT_CLASS_HASH, UDC_CONTRACT_ADDRESS,
     UDC_CONTRACT_CLASS_HASH,
 };
-use starknet_core::starknet::starknet_config::DumpMode;
+use starknet_core::starknet::starknet_config::DumpOn;
 use starknet_core::starknet::Starknet;
 use starknet_types::felt::Felt;
 use starknet_types::traits::{ToDecimalString, ToHexString};
@@ -94,7 +94,7 @@ async fn main() -> Result<(), anyhow::Error> {
     info!("Starknet Devnet listening on {}", addr);
 
     // spawn the server on a new task
-    let serve = if starknet_config.dump_on == Some(DumpMode::OnExit) {
+    let serve = if starknet_config.dump_on == Some(DumpOn::Exit) {
         tokio::task::spawn(server.with_graceful_shutdown(shutdown_signal(api.clone())))
     } else {
         tokio::task::spawn(server)

--- a/crates/starknet-server/src/server.rs
+++ b/crates/starknet-server/src/server.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 use axum::routing::{get, post};
 use server::builder::StarknetDevnetServer;
 use server::ServerConfig;
-use starknet_core::starknet::StarknetConfig;
+use starknet_core::starknet::starknet_config::StarknetConfig;
 
 use crate::api::http::{endpoints as http, HttpApiHandler};
 use crate::api::json_rpc::JsonRpcHandler;

--- a/crates/starknet/Cargo.toml
+++ b/crates/starknet/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 
 [dependencies]
 blockifier = { workspace = true, features = ["testing"]}
+clap = { workspace = true }
 starknet_api = { workspace = true, features = ["testing"] }
 thiserror = { workspace = true }
 starknet-in-rust = { workspace = true }
@@ -20,8 +21,6 @@ starknet-types = { workspace = true }
 random-number-generator = { workspace = true }
 tracing = { workspace = true }
 indexmap = { workspace = true }
-strum = { workspace = true }
-strum_macros = { workspace = true }
 
 [dev-dependencies]
 jsonschema = "0.16.0"

--- a/crates/starknet/src/constants.rs
+++ b/crates/starknet/src/constants.rs
@@ -36,7 +36,7 @@ pub const DEVNET_DEFAULT_GAS_PRICE: u64 = 100_000_000_000;
 pub const DEVNET_DEFAULT_HOST: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 pub const DEVNET_DEFAULT_PORT: u16 = 5050;
 pub const DEVNET_DEFAULT_TIMEOUT: u16 = 120;
-pub const DEVNET_DEFAULT_CHAIN_ID: ChainId = ChainId::TestNet;
+pub const DEVNET_DEFAULT_CHAIN_ID: ChainId = ChainId::Testnet;
 
 pub const SUPPORTED_TX_VERSION: u32 = 1;
 

--- a/crates/starknet/src/starknet/dump.rs
+++ b/crates/starknet/src/starknet/dump.rs
@@ -8,7 +8,7 @@ use starknet_types::rpc::transactions::broadcasted_deploy_account_transaction::B
 use starknet_types::rpc::transactions::broadcasted_invoke_transaction::BroadcastedInvokeTransaction;
 use starknet_types::rpc::transactions::{DeclareTransaction, InvokeTransaction, Transaction};
 
-use super::{DumpMode, Starknet};
+use super::{DumpOn, Starknet};
 use crate::error::{DevnetResult, Error};
 
 impl Starknet {
@@ -176,7 +176,7 @@ impl Starknet {
 
                     // to avoid doublets in transaction mode during load, we need to remove the file
                     // because they will be re-executed and saved again
-                    if self.config.dump_on == Some(DumpMode::OnTransaction) {
+                    if self.config.dump_on == Some(DumpOn::Transaction) {
                         fs::remove_file(file_path).map_err(Error::IoError)?;
                     }
 

--- a/crates/starknet/src/starknet/mod.rs
+++ b/crates/starknet/src/starknet/mod.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-use std::net::IpAddr;
 use std::time::SystemTime;
 
 use blockifier::block_context::BlockContext;
@@ -35,15 +33,15 @@ use starknet_types::rpc::transactions::{
     TransactionTrace, Transactions,
 };
 use starknet_types::traits::HashProducer;
-use strum_macros::EnumIter;
 use tracing::{error, warn};
 
 use self::predeployed::initialize_erc20;
+use self::starknet_config::{DumpMode, StarknetConfig};
 use crate::account::Account;
 use crate::blocks::{StarknetBlock, StarknetBlocks};
 use crate::constants::{
     CAIRO_0_ACCOUNT_CONTRACT_PATH, CHARGEABLE_ACCOUNT_ADDRESS, CHARGEABLE_ACCOUNT_PRIVATE_KEY,
-    DEVNET_DEFAULT_CHAIN_ID, DEVNET_DEFAULT_HOST, ERC20_CONTRACT_ADDRESS,
+    DEVNET_DEFAULT_CHAIN_ID, ERC20_CONTRACT_ADDRESS,
 };
 use crate::error::{DevnetResult, Error, TransactionValidationError};
 use crate::predeployed_accounts::PredeployedAccounts;
@@ -65,53 +63,8 @@ mod estimations;
 mod events;
 mod get_class_impls;
 mod predeployed;
+pub mod starknet_config;
 mod state_update;
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq, EnumIter)]
-pub enum DumpMode {
-    OnExit,
-    OnTransaction,
-}
-
-impl fmt::Display for DumpMode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self {
-            DumpMode::OnExit => write!(f, "exit"),
-            DumpMode::OnTransaction => write!(f, "transaction"),
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct StarknetConfig {
-    pub seed: u32,
-    pub total_accounts: u8,
-    pub predeployed_accounts_initial_balance: Felt,
-    pub host: IpAddr,
-    pub port: u16,
-    pub timeout: u16,
-    pub gas_price: u64,
-    pub chain_id: ChainId,
-    pub dump_on: Option<DumpMode>,
-    pub dump_path: Option<String>,
-}
-
-impl Default for StarknetConfig {
-    fn default() -> Self {
-        Self {
-            seed: u32::default(),
-            total_accounts: u8::default(),
-            predeployed_accounts_initial_balance: Felt::default(),
-            host: DEVNET_DEFAULT_HOST,
-            port: u16::default(),
-            timeout: u16::default(),
-            gas_price: Default::default(),
-            chain_id: DEVNET_DEFAULT_CHAIN_ID,
-            dump_on: None,
-            dump_path: None,
-        }
-    }
-}
 
 pub struct Starknet {
     pub(in crate::starknet) state: StarknetState,

--- a/crates/starknet/src/starknet/mod.rs
+++ b/crates/starknet/src/starknet/mod.rs
@@ -36,7 +36,7 @@ use starknet_types::traits::HashProducer;
 use tracing::{error, warn};
 
 use self::predeployed::initialize_erc20;
-use self::starknet_config::{DumpMode, StarknetConfig};
+use self::starknet_config::{DumpOn, StarknetConfig};
 use crate::account::Account;
 use crate::blocks::{StarknetBlock, StarknetBlocks};
 use crate::constants::{
@@ -292,7 +292,7 @@ impl Starknet {
         // clear pending block information
         self.generate_pending_block()?;
 
-        if self.config.dump_on == Some(DumpMode::OnTransaction) {
+        if self.config.dump_on == Some(DumpOn::Transaction) {
             self.dump_transaction(transaction)?;
         }
 

--- a/crates/starknet/src/starknet/starknet_config.rs
+++ b/crates/starknet/src/starknet/starknet_config.rs
@@ -3,21 +3,20 @@ use std::net::IpAddr;
 
 use starknet_types::chain_id::ChainId;
 use starknet_types::felt::Felt;
-use strum_macros::EnumIter;
 
 use crate::constants::{DEVNET_DEFAULT_CHAIN_ID, DEVNET_DEFAULT_HOST};
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, EnumIter)]
-pub enum DumpMode {
-    OnExit,
-    OnTransaction,
+#[derive(Copy, Clone, Debug, Eq, PartialEq, clap::ValueEnum)]
+pub enum DumpOn {
+    Exit,
+    Transaction,
 }
 
-impl fmt::Display for DumpMode {
+impl fmt::Display for DumpOn {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
-            DumpMode::OnExit => write!(f, "exit"),
-            DumpMode::OnTransaction => write!(f, "transaction"),
+            DumpOn::Exit => write!(f, "exit"),
+            DumpOn::Transaction => write!(f, "transaction"),
         }
     }
 }
@@ -32,7 +31,7 @@ pub struct StarknetConfig {
     pub timeout: u16,
     pub gas_price: u64,
     pub chain_id: ChainId,
-    pub dump_on: Option<DumpMode>,
+    pub dump_on: Option<DumpOn>,
     pub dump_path: Option<String>,
 }
 

--- a/crates/starknet/src/starknet/starknet_config.rs
+++ b/crates/starknet/src/starknet/starknet_config.rs
@@ -1,4 +1,3 @@
-use std::fmt;
 use std::net::IpAddr;
 
 use starknet_types::chain_id::ChainId;
@@ -10,15 +9,6 @@ use crate::constants::{DEVNET_DEFAULT_CHAIN_ID, DEVNET_DEFAULT_HOST};
 pub enum DumpOn {
     Exit,
     Transaction,
-}
-
-impl fmt::Display for DumpOn {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self {
-            DumpOn::Exit => write!(f, "exit"),
-            DumpOn::Transaction => write!(f, "transaction"),
-        }
-    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/starknet/src/starknet/starknet_config.rs
+++ b/crates/starknet/src/starknet/starknet_config.rs
@@ -1,0 +1,54 @@
+use std::fmt;
+use std::net::IpAddr;
+
+use starknet_types::chain_id::ChainId;
+use starknet_types::felt::Felt;
+use strum_macros::EnumIter;
+
+use crate::constants::{DEVNET_DEFAULT_CHAIN_ID, DEVNET_DEFAULT_HOST};
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, EnumIter)]
+pub enum DumpMode {
+    OnExit,
+    OnTransaction,
+}
+
+impl fmt::Display for DumpMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self {
+            DumpMode::OnExit => write!(f, "exit"),
+            DumpMode::OnTransaction => write!(f, "transaction"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct StarknetConfig {
+    pub seed: u32,
+    pub total_accounts: u8,
+    pub predeployed_accounts_initial_balance: Felt,
+    pub host: IpAddr,
+    pub port: u16,
+    pub timeout: u16,
+    pub gas_price: u64,
+    pub chain_id: ChainId,
+    pub dump_on: Option<DumpMode>,
+    pub dump_path: Option<String>,
+}
+
+impl Default for StarknetConfig {
+    fn default() -> Self {
+        Self {
+            seed: u32::default(),
+            total_accounts: u8::default(),
+            predeployed_accounts_initial_balance: Felt::default(),
+            host: DEVNET_DEFAULT_HOST,
+            port: u16::default(),
+            timeout: u16::default(),
+            gas_price: Default::default(),
+            chain_id: DEVNET_DEFAULT_CHAIN_ID,
+            dump_on: None,
+            dump_path: None,
+        }
+    }
+}

--- a/crates/starknet/src/utils.rs
+++ b/crates/starknet/src/utils.rs
@@ -53,7 +53,7 @@ pub(crate) mod test_utils {
         DEVNET_DEFAULT_INITIAL_BALANCE, DEVNET_DEFAULT_PORT, DEVNET_DEFAULT_TEST_SEED,
         DEVNET_DEFAULT_TIMEOUT, DEVNET_DEFAULT_TOTAL_ACCOUNTS,
     };
-    use crate::starknet::StarknetConfig;
+    use crate::starknet::starknet_config::StarknetConfig;
     use crate::utils::exported_test_utils::dummy_cairo_0_contract_class;
 
     pub fn starknet_config_for_test() -> StarknetConfig {

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 base64 = { workspace = true }
 blockifier = { workspace = true }
+clap = { workspace = true }
 flate2 = { workspace = true }
 starknet_api = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/types/src/chain_id.rs
+++ b/crates/types/src/chain_id.rs
@@ -1,16 +1,15 @@
 use std::fmt::Display;
 
 use starknet_in_rust::definitions::block_context::StarknetChainId;
-use starknet_rs_core::chain_id::{MAINNET, TESTNET, TESTNET2};
+use starknet_rs_core::chain_id::{MAINNET, TESTNET};
 use starknet_rs_ff::FieldElement;
 
 use crate::felt::Felt;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, clap::ValueEnum)]
 pub enum ChainId {
-    MainNet,
-    TestNet,
-    TestNet2,
+    Mainnet,
+    Testnet,
 }
 
 impl ChainId {
@@ -22,9 +21,8 @@ impl ChainId {
 impl Display for ChainId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ChainId::MainNet => write!(f, "SN_MAIN"),
-            ChainId::TestNet => write!(f, "SN_GOERLI"),
-            ChainId::TestNet2 => write!(f, "SN_GOERLI2"),
+            ChainId::Mainnet => write!(f, "SN_MAIN"),
+            ChainId::Testnet => write!(f, "SN_GOERLI"),
         }
     }
 }
@@ -32,9 +30,8 @@ impl Display for ChainId {
 impl From<ChainId> for FieldElement {
     fn from(value: ChainId) -> Self {
         match value {
-            ChainId::MainNet => MAINNET,
-            ChainId::TestNet => TESTNET,
-            ChainId::TestNet2 => TESTNET2,
+            ChainId::Mainnet => MAINNET,
+            ChainId::Testnet => TESTNET,
         }
     }
 }
@@ -42,9 +39,8 @@ impl From<ChainId> for FieldElement {
 impl From<&ChainId> for FieldElement {
     fn from(value: &ChainId) -> Self {
         match value {
-            ChainId::MainNet => MAINNET,
-            ChainId::TestNet => TESTNET,
-            ChainId::TestNet2 => TESTNET2,
+            ChainId::Mainnet => MAINNET,
+            ChainId::Testnet => TESTNET,
         }
     }
 }
@@ -52,9 +48,8 @@ impl From<&ChainId> for FieldElement {
 impl From<ChainId> for StarknetChainId {
     fn from(value: ChainId) -> Self {
         match value {
-            ChainId::MainNet => StarknetChainId::MainNet,
-            ChainId::TestNet => StarknetChainId::TestNet,
-            ChainId::TestNet2 => StarknetChainId::TestNet2,
+            ChainId::Mainnet => StarknetChainId::MainNet,
+            ChainId::Testnet => StarknetChainId::TestNet,
         }
     }
 }
@@ -74,7 +69,7 @@ mod tests {
 
     #[test]
     fn check_conversion_to_starknet_in_rust_and_starknet_api() {
-        let t = ChainId::TestNet;
+        let t = ChainId::Testnet;
         let st: StarknetChainId = t.into();
         let sat: starknet_api::core::ChainId = t.into();
 

--- a/crates/types/src/rpc/transactions/broadcasted_declare_transaction_v1.rs
+++ b/crates/types/src/rpc/transactions/broadcasted_declare_transaction_v1.rs
@@ -171,7 +171,7 @@ mod tests {
 
         let class_hash = broadcasted_tx.generate_class_hash().unwrap();
         let transaction_hash = broadcasted_tx
-            .calculate_transaction_hash(&ChainId::TestNet.to_felt(), &class_hash)
+            .calculate_transaction_hash(&ChainId::Testnet.to_felt(), &class_hash)
             .unwrap();
 
         let blockifier_declare_transaction =

--- a/crates/types/src/rpc/transactions/broadcasted_declare_transaction_v2.rs
+++ b/crates/types/src/rpc/transactions/broadcasted_declare_transaction_v2.rs
@@ -185,7 +185,7 @@ mod tests {
         );
 
         let blockifier_declare_transaction = broadcasted_declare_transaction
-            .create_blockifier_declare(ChainId::TestNet.to_felt())
+            .create_blockifier_declare(ChainId::Testnet.to_felt())
             .unwrap();
 
         assert_eq!(

--- a/crates/types/src/rpc/transactions/broadcasted_deploy_account_transaction.rs
+++ b/crates/types/src/rpc/transactions/broadcasted_deploy_account_transaction.rs
@@ -164,7 +164,7 @@ mod tests {
             feeder_gateway_transaction.version,
         );
 
-        let chain_id = ChainId::TestNet.to_felt();
+        let chain_id = ChainId::Testnet.to_felt();
 
         let blockifier_deploy_account_transaction =
             broadcasted_tx.create_blockifier_deploy_account(chain_id).unwrap();

--- a/crates/types/src/rpc/transactions/broadcasted_invoke_transaction.rs
+++ b/crates/types/src/rpc/transactions/broadcasted_invoke_transaction.rs
@@ -149,7 +149,7 @@ mod tests {
             feeder_gateway_transaction.version,
         );
 
-        let chain_id = ChainId::TestNet.to_felt();
+        let chain_id = ChainId::Testnet.to_felt();
         let blockifier_transaction =
             transaction.create_blockifier_invoke_transaction(chain_id).unwrap();
 


### PR DESCRIPTION
## Usage related changes

- Improve the look of error messages (rely on clap instead of panic)

## Development related changes

- Move StarknetConfig to separate file
- Derive `clap::ValueEnum` for:
  - `DumpOn` (renamed from `DumpMode` for parsing simplicity)
  - `ChainId` (renamed enum options to have lowercase n for parsing simplicity: `MainNet` -> `Mainnet`)
- Remove `strum` dependencies (replaced by functionality present in `clap`)
- Removed the option to select Testnet2 chain ID (Starknet already deprecated it)

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [ ] Linked the issues which this PR resolves
- [x] Checked the TODO section in README.md if this PR resolves it
- [ ] Updated the tests
- [x] All tests are passing - `cargo test`
