### PR TITLE
Custom account support

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,11 @@ The JSON-RPC API is reachable via `/rpc` and `/` (e.g. if spawning Devnet with d
 
 ## Predeployed contracts
 
-Devnet predeploys a [UDC](https://docs.openzeppelin.com/contracts-cairo/0.6.1/udc), an [ERC20 (fee token)](https://docs.openzeppelin.com/contracts/3.x/api/token/erc20) contract and a set of funded accounts. The information on this is logged on Devnet startup. The set of accounts can be controlled via [CLI options](#cli-options): `--accounts`, `--initial-balance`, `--seed`.
+Devnet predeploys a [UDC](https://docs.openzeppelin.com/contracts-cairo/0.6.1/udc), an [ERC20 (fee token)](https://docs.openzeppelin.com/contracts/3.x/api/token/erc20) contract and a set of predeployed funded accounts. The information on this is logged on Devnet startup. The set of accounts can be controlled via [CLI options](#cli-options): `--accounts`, `--initial-balance`, `--seed`.
 
 Retrieve the predeployed accounts in JSON format by sending a `GET` request to `/predeployed_accounts` of your Devnet.
+
+Choose between predeploying Cairo 0 (OpenZeppelin 0.5.1) or Cairo 1 (OpenZeppelin 0.7.0) accounts by using the `--account-class <IMPLEMENTATION>` CLI argument. Alternatively, provide a path to the Sierra artifact of your custom account using `--account-class-custom <SIERRA_PATH>`.
 
 ## Mint token
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This repository is work in progress, please be patient. Please check below the s
 ### TODO to reach feature parity with the Pythonic Devnet
 
 - [ ] Availability as a package (crate)
-- [ ] [Custom accounts implementation](https://0xspaceshard.github.io/starknet-devnet/docs/guide/accounts#custom-implementation)
+- [x] [Custom accounts implementation](#predeployed-contracts)
 - [ ] [Forking](https://0xspaceshard.github.io/starknet-devnet/docs/guide/fork)
 - [ ] [L1-L2 Postman integration](https://0xspaceshard.github.io/starknet-devnet/docs/guide/postman)
 - [ ] [Block manipulation](https://0xspaceshard.github.io/starknet-devnet/docs/guide/blocks)

--- a/README.md
+++ b/README.md
@@ -155,11 +155,13 @@ The JSON-RPC API is reachable via `/rpc` and `/` (e.g. if spawning Devnet with d
 
 ## Predeployed contracts
 
-Devnet predeploys a [UDC](https://docs.openzeppelin.com/contracts-cairo/0.6.1/udc), an [ERC20 (fee token)](https://docs.openzeppelin.com/contracts/3.x/api/token/erc20) contract and a set of predeployed funded accounts. The information on this is logged on Devnet startup. The set of accounts can be controlled via [CLI options](#cli-options): `--accounts`, `--initial-balance`, `--seed`.
+Devnet predeploys a [UDC](https://docs.openzeppelin.com/contracts-cairo/0.6.1/udc), an [ERC20 (fee token)](https://docs.openzeppelin.com/contracts/3.x/api/token/erc20) contract and a set of predeployed funded accounts.
 
-Retrieve the predeployed accounts in JSON format by sending a `GET` request to `/predeployed_accounts` of your Devnet.
+The set of accounts can be controlled via [CLI options](#cli-options): `--accounts <NUMBER_OF>`, `--initial-balance <WEI>`, `--seed <VALUE>`.
 
-Choose between predeploying Cairo 0 (OpenZeppelin 0.5.1) or Cairo 1 (OpenZeppelin 0.7.0) accounts by using the `--account-class <IMPLEMENTATION>` CLI argument. Alternatively, provide a path to the Sierra artifact of your custom account using `--account-class-custom <SIERRA_PATH>`.
+Choose between predeploying Cairo 0 (OpenZeppelin 0.5.1) or Cairo 1 (OpenZeppelin 0.7.0) accounts by using `--account-class [cairo0 | cairo1]`. Alternatively, provide a path to the [Sierra artifact](https://github.com/starkware-libs/cairo#compiling-and-running-cairo-files) of your custom account using `--account-class-custom <SIERRA_PATH>`.
+
+The predeployment information is logged on Devnet startup. Predeployed accounts can be retrieved in JSON format by sending a `GET` request to `/predeployed_accounts` of your Devnet.
 
 ## Mint token
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This repository is work in progress, please be patient. Please check below the s
 - [x] RPC v0.4.0
 - [x] [Dump & Load](https://github.com/0xSpaceShard/starknet-devnet-rs#dumping--loading)
 - [x] [Mint token - Local faucet](https://0xspaceshard.github.io/starknet-devnet/docs/guide/mint-token)
+- [x] [Customizable predeployed accounts](#predeployed-contracts)
 - [x] Starknet.js test suite passes 100%
 
 ### TODO
@@ -32,7 +33,6 @@ This repository is work in progress, please be patient. Please check below the s
 ### TODO to reach feature parity with the Pythonic Devnet
 
 - [ ] Availability as a package (crate)
-- [x] [Custom accounts implementation](#predeployed-contracts)
 - [ ] [Forking](https://0xspaceshard.github.io/starknet-devnet/docs/guide/fork)
 - [ ] [L1-L2 Postman integration](https://0xspaceshard.github.io/starknet-devnet/docs/guide/postman)
 - [ ] [Block manipulation](https://0xspaceshard.github.io/starknet-devnet/docs/guide/blocks)

--- a/crates/starknet-server/src/cli.rs
+++ b/crates/starknet-server/src/cli.rs
@@ -208,13 +208,30 @@ mod tests {
     }
 
     #[test]
-    fn not_allowing_regular_contract_as_custom_account() {
-        match Args::try_parse_from(["--", "--account-class-custom", ERC20_CONTRACT_PATH]) {
+    fn not_allowing_regular_cairo0_contract_as_custom_account() {
+        let custom_path = ERC20_CONTRACT_PATH;
+        match Args::try_parse_from(["--", "--account-class-custom", custom_path]) {
             Err(err) => assert_eq!(
                 get_first_line(&err.to_string()),
                 format!(
-                    "error: invalid value '{ERC20_CONTRACT_PATH}' for '--account-class-custom \
-                     <PATH>': missing field `kind` at line 1 column 292"
+                    "error: invalid value '{custom_path}' for '--account-class-custom <PATH>': \
+                     missing field `kind` at line 1 column 292"
+                )
+            ),
+            Ok(parsed) => panic!("Should have failed; got: {parsed:?}"),
+        }
+    }
+
+    #[test]
+    fn not_allowing_regular_cairo1_contract_as_custom_account() {
+        let custom_path = "test_data/rpc/contract_cairo_v1/output.json";
+        match Args::try_parse_from(["--", "--account-class-custom", custom_path]) {
+            Err(err) => assert_eq!(
+                get_first_line(&err.to_string()),
+                format!(
+                    "error: invalid value '{custom_path}' for '--account-class-custom <PATH>': \
+                     Not a valid Sierra account artifact; has __execute__: false; has \
+                     __validate__: false"
                 )
             ),
             Ok(parsed) => panic!("Should have failed; got: {parsed:?}"),

--- a/crates/starknet-server/src/cli.rs
+++ b/crates/starknet-server/src/cli.rs
@@ -186,7 +186,7 @@ mod tests {
     }
 
     #[test]
-    fn allowing_only_account_class() {
+    fn allowing_if_only_account_class() {
         match Args::try_parse_from(["--", "--account-class", "cairo1"]) {
             Ok(_) => (),
             Err(err) => panic!("Should have passed; got: {err}"),
@@ -194,7 +194,7 @@ mod tests {
     }
 
     #[test]
-    fn allowing_only_account_class_path() {
+    fn allowing_if_only_account_class_path() {
         match Args::try_parse_from([
             "--",
             "--account-class-custom",
@@ -222,6 +222,7 @@ mod tests {
 
     #[test]
     fn not_allowing_regular_cairo1_contract_as_custom_account() {
+        // path to a regular cairo1 contract (not an account)
         let custom_path = "test_data/rpc/contract_cairo_v1/output.json";
         match Args::try_parse_from(["--", "--account-class-custom", custom_path]) {
             Err(err) => assert_eq!(

--- a/crates/starknet-server/src/cli.rs
+++ b/crates/starknet-server/src/cli.rs
@@ -6,7 +6,7 @@ use starknet_core::constants::{
 use starknet_core::starknet::starknet_config::{DumpOn, StarknetConfig};
 use starknet_types::chain_id::ChainId;
 
-use crate::contract_class_choice::AccountContractClassChoice;
+use crate::contract_class_choice::{AccountClassPathWrapper, AccountContractClassChoice};
 use crate::initial_balance_wrapper::InitialBalanceWrapper;
 use crate::ip_addr_wrapper::IpAddrWrapper;
 
@@ -28,6 +28,12 @@ pub(crate) struct Args {
     #[arg(default_value = "cairo0")]
     #[arg(help = "Specify the class used by predeployed accounts;")]
     account_class: AccountContractClassChoice,
+
+    #[arg(long = "account-class-path")]
+    #[arg(value_name = "PATH")]
+    #[arg(conflicts_with = "account_class")]
+    #[arg(help = "Specify the path to a Cairo Sierra artifact to be used by predeployed accounts;")]
+    account_class_path: AccountClassPathWrapper,
 
     /// Initial balance of predeployed accounts
     #[arg(long = "initial-balance")]
@@ -145,6 +151,36 @@ mod tests {
         match Args::try_parse_from(["--", "--host", "invalid"]) {
             Err(_) => (),
             Ok(parsed) => panic!("Should have failed; got: {parsed:?}"),
+        }
+    }
+
+    #[test]
+    fn not_allowing_account_class_and_account_class_path() {
+        match Args::try_parse_from([
+            "--",
+            "--account-class",
+            "cairo1",
+            "--account-class-path",
+            "/path/to/account.sierra",
+        ]) {
+            Err(_) => (),
+            Ok(parsed) => panic!("Should have failed; got: {parsed:?}"),
+        }
+    }
+
+    #[test]
+    fn allowing_only_account_class() {
+        match Args::try_parse_from(["--", "--account-class", "cairo1"]) {
+            Ok(_) => (),
+            Err(err) => panic!("Should have passed; got: {err:?}"),
+        }
+    }
+
+    #[test]
+    fn allowing_only_account_class_path() {
+        match Args::try_parse_from(["--", "--account-class-path", "/path/to/account.sierra"]) {
+            Ok(_) => (),
+            Err(err) => panic!("Should have passed; got: {err:?}"),
         }
     }
 }

--- a/crates/starknet-server/src/contract_class_choice.rs
+++ b/crates/starknet-server/src/contract_class_choice.rs
@@ -15,41 +15,27 @@ pub enum AccountContractClassChoice {
     Cairo1,
 }
 
-// TODO refactor to rely on AccountClassWrapper
 impl AccountContractClassChoice {
-    fn get_path(&self) -> &str {
-        match self {
-            AccountContractClassChoice::Cairo0 => CAIRO_0_ACCOUNT_CONTRACT_PATH,
-            AccountContractClassChoice::Cairo1 => CAIRO_1_ACCOUNT_CONTRACT_SIERRA_PATH,
-        }
-    }
-
-    pub fn get_class(&self) -> Result<ContractClass, anyhow::Error> {
-        let contract_class = match self {
-            Self::Cairo0 => ContractClass::Cairo0(Cairo0ContractClass::RawJson(
-                Cairo0Json::raw_json_from_path(self.get_path())?,
-            )),
-            Self::Cairo1 => ContractClass::Cairo1(ContractClass::cairo_1_from_sierra_json_str(
-                std::fs::read_to_string(self.get_path())?.as_str(),
-            )?),
-        };
-        Ok(contract_class)
-    }
-
-    pub fn get_hash(&self) -> Result<Felt, anyhow::Error> {
-        let hash = match self {
+    pub(crate) fn get_class_wrapper(&self) -> Result<AccountClassWrapper, anyhow::Error> {
+        Ok(match self {
             AccountContractClassChoice::Cairo0 => {
-                Cairo0Json::raw_json_from_path(self.get_path())?.generate_hash()?
+                let contract_class = Cairo0ContractClass::RawJson(Cairo0Json::raw_json_from_path(
+                    CAIRO_0_ACCOUNT_CONTRACT_PATH,
+                )?);
+                AccountClassWrapper {
+                    class_hash: contract_class.generate_hash()?,
+                    contract_class: ContractClass::Cairo0(contract_class),
+                }
             }
             AccountContractClassChoice::Cairo1 => {
-                let contract_class_str = std::fs::read_to_string(self.get_path())?;
-                let account_contract_class = ContractClass::Cairo1(
+                let contract_class_str =
+                    std::fs::read_to_string(CAIRO_1_ACCOUNT_CONTRACT_SIERRA_PATH)?;
+                let contract_class = ContractClass::Cairo1(
                     ContractClass::cairo_1_from_sierra_json_str(&contract_class_str)?,
                 );
-                account_contract_class.generate_hash()?
+                AccountClassWrapper { class_hash: contract_class.generate_hash()?, contract_class }
             }
-        };
-        Ok(hash)
+        })
     }
 }
 
@@ -106,25 +92,27 @@ mod tests {
     use starknet_types::traits::HashProducer;
 
     use super::AccountContractClassChoice;
+    use crate::contract_class_choice::AccountClassWrapper;
 
     #[test]
     fn all_methods_work_with_all_options() {
         for implementation in AccountContractClassChoice::value_variants().iter() {
-            let contract_class = implementation.get_class().unwrap();
+            let AccountClassWrapper { contract_class, class_hash } =
+                implementation.get_class_wrapper().unwrap();
             let generated_hash = contract_class.generate_hash().unwrap();
-            assert_eq!(generated_hash, implementation.get_hash().unwrap());
+            assert_eq!(generated_hash, class_hash);
         }
     }
 
     #[test]
     fn correct_hash_calculated() {
         assert_eq!(
-            AccountContractClassChoice::Cairo0.get_hash().unwrap(),
+            AccountContractClassChoice::Cairo0.get_class_wrapper().unwrap().class_hash,
             Felt::from_prefixed_hex_str(CAIRO_0_ACCOUNT_CONTRACT_HASH).unwrap()
         );
 
         assert_eq!(
-            AccountContractClassChoice::Cairo1.get_hash().unwrap(),
+            AccountContractClassChoice::Cairo1.get_class_wrapper().unwrap().class_hash,
             Felt::from_prefixed_hex_str(CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH).unwrap()
         )
     }

--- a/crates/starknet-server/src/contract_class_choice.rs
+++ b/crates/starknet-server/src/contract_class_choice.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use starknet_core::constants::{
     CAIRO_0_ACCOUNT_CONTRACT_PATH, CAIRO_1_ACCOUNT_CONTRACT_SIERRA_PATH,
 };
@@ -45,6 +47,20 @@ impl AccountContractClassChoice {
             }
         };
         Ok(hash)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct AccountClassPathWrapper {
+    contract_class: ContractClass,
+    class_hash: Felt,
+}
+
+impl FromStr for AccountClassPathWrapper {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        todo!()
     }
 }
 

--- a/crates/starknet-server/src/main.rs
+++ b/crates/starknet-server/src/main.rs
@@ -50,6 +50,8 @@ fn log_predeployed_accounts(predeployed_accounts: &Vec<Account>, seed: u32, init
 
     if !predeployed_accounts.is_empty() {
         println!();
+        let class_hash = predeployed_accounts.get(0).unwrap().class_hash.to_prefixed_hex_str();
+        println!("Predeployed accounts using class with hash: {class_hash}");
         println!("Initial balance of each account: {} WEI", initial_balance.to_decimal_string());
         println!("Seed to replicate this account sequence: {seed}");
     }

--- a/crates/starknet/src/account.rs
+++ b/crates/starknet/src/account.rs
@@ -30,7 +30,7 @@ pub struct Account {
     pub private_key: Key,
     pub account_address: ContractAddress,
     pub initial_balance: Balance,
-    pub(crate) class_hash: ClassHash,
+    pub class_hash: ClassHash,
     pub(crate) contract_class: ContractClass,
     pub(crate) fee_token_address: ContractAddress,
 }

--- a/crates/starknet/src/constants.rs
+++ b/crates/starknet/src/constants.rs
@@ -16,7 +16,7 @@ pub const CAIRO_1_ACCOUNT_CONTRACT_SIERRA_PATH: &str = concat!(
 pub const CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH: &str =
     "0x04c6d6cf894f8bc96bb9c525e6853e5483177841f7388f74a46cfda6f028c755";
 
-pub(crate) const ERC20_CONTRACT_PATH: &str =
+pub const ERC20_CONTRACT_PATH: &str =
     concat!(env!("CARGO_MANIFEST_DIR"), "/accounts_artifacts/ERC20_Mintable_OZ_0.2.0.json");
 
 pub const ERC20_CONTRACT_CLASS_HASH: &str =


### PR DESCRIPTION
## Usage related changes

- Introduces new CLI option `--account-class-custom <SIERRA_PATH>`
  - Mutually exclusive with `--account-class [cairo0 | cairo1]`
  - `--account-class-custom` doesn't have a default value, and if no value is provided, we use `--account-class` (which has a default value of `cairo0`)
  - Since Cairo 0 is deprecated, I decided not to have this new CLI option support both custom Cairo 0 and Cairo 1 accounts, but just Cairo 1.
  - There are runtime checks that assert the provided artifact is indeed a Sierra representation of an account (existence of `__execute__` and `__validate__` is asserted).
- Add logging of predeployed accounts class hash to Devnet startup
- Closes #183

## Development related changes

- Simplifies `AccountContractClassChoice` by relying on the newly introduced `AccountClassWrapper` (wrapper of class and hash).
  - `AccountContractClassChoice` is needed because it implements `clap::ValueEnum` and allows us to utilize clap's pretty exiting.
- Implements e2e testing by relying on `--account-class cairo1` tests:
  - The existing tests were extracted to functions (with suffix `_body`) which were then used in pairs of tests (one testing `--account-class cairo1`, other testing `--account-class-custom <SIERRA_PATH>`)
  - This is done so because we don't have test parametrization.

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Checked the TODO section in README.md if this PR resolves it
- [x] Updated the tests
- [x] All tests are passing - `cargo test`
