### PR TITLE
Add test case for deploying with invalid constructor args

### DIFF
--- a/crates/starknet-server/tests/get_transaction_receipt_by_hash.rs
+++ b/crates/starknet-server/tests/get_transaction_receipt_by_hash.rs
@@ -90,6 +90,7 @@ mod get_transaction_receipt_by_hash_integration_tests {
         let contract_factory =
             ContractFactory::new(declaration_result.class_hash, predeployed_account.clone());
 
+        // deploy the contract
         let salt = FieldElement::ZERO;
         let constructor_args = Vec::<FieldElement>::new();
         let deployment_result = contract_factory

--- a/crates/starknet-server/tests/get_transaction_receipt_by_hash.rs
+++ b/crates/starknet-server/tests/get_transaction_receipt_by_hash.rs
@@ -87,10 +87,10 @@ mod get_transaction_receipt_by_hash_integration_tests {
             .await
             .unwrap();
 
+        // deploy the contract
         let contract_factory =
             ContractFactory::new(declaration_result.class_hash, predeployed_account.clone());
 
-        // deploy the contract
         let salt = FieldElement::ZERO;
         let constructor_args = Vec::<FieldElement>::new();
         let deployment_result = contract_factory
@@ -144,10 +144,10 @@ mod get_transaction_receipt_by_hash_integration_tests {
             .await
             .unwrap();
 
+        // try deploying with invalid constructor args - none are expected, we are providing [1]
         let contract_factory =
             ContractFactory::new(declaration_result.class_hash, predeployed_account.clone());
 
-        // try deploying with invalid constructor args - none are expected, we are providing [1]
         let salt = FieldElement::ZERO;
         let invalid_constructor_args = vec![FieldElement::ONE];
         let invalid_deployment_result = contract_factory


### PR DESCRIPTION
## Usage related changes

N/A

## Development related changes

- Close #190
- Minor code improvements of existing test:
  - Earlier wrapping of account in `Arc`
  - Extracting deployment data to variables (ctor args, salt)
  - Calculating deployment address just before it's needed

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Checked the TODO section in README.md if this PR resolves it
- [x] Updated the tests
- [x] All tests are passing - `cargo test`
