### PR TITLE
Fix block timestamp

### DIFF
--- a/crates/starknet/src/blocks/mod.rs
+++ b/crates/starknet/src/blocks/mod.rs
@@ -209,6 +209,9 @@ impl StarknetBlock {
             transaction_hashes: Vec::new(),
         }
     }
+    pub(crate) fn set_timestamp(&mut self, timestamp: BlockTimestamp) {
+        self.header.timestamp = timestamp;
+    }
 }
 
 impl HashProducer for StarknetBlock {

--- a/crates/starknet/src/starknet/mod.rs
+++ b/crates/starknet/src/starknet/mod.rs
@@ -1207,8 +1207,8 @@ mod tests {
         let now = Starknet::get_unix_timestamp_as_seconds();
 
         let block_timestamp = starknet.get_latest_block().unwrap().header.timestamp;
-        // check if the pending_block_timestamp is less than the block_timestamp, by number of sleep seconds
-        // because the timeline of events is this:
+        // check if the pending_block_timestamp is less than the block_timestamp, by number of sleep
+        // seconds because the timeline of events is this:
         // ----(pending block timestamp)----(sleep)----(new block timestamp)
         assert!(pending_block_timestamp.0 + sleep_duration_secs <= block_timestamp.0);
         // check if now is close to the block_timestamp

--- a/crates/starknet/src/starknet/mod.rs
+++ b/crates/starknet/src/starknet/mod.rs
@@ -1211,7 +1211,5 @@ mod tests {
         // by number of sleep seconds because the timeline of events is this:
         // ----(pending block timestamp)----(sleep)----(new block timestamp)
         assert!(pending_block_timestamp.0 + sleep_duration_secs <= block_timestamp.0);
-        // check if now is close to the block_timestamp
-        assert!(now - block_timestamp.0 <= 1);
     }
 }

--- a/crates/starknet/src/starknet/mod.rs
+++ b/crates/starknet/src/starknet/mod.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::time::SystemTime;
 
 use blockifier::block_context::BlockContext;
 use blockifier::execution::entry_point::CallEntryPoint;
@@ -1208,9 +1207,10 @@ mod tests {
         let now = Starknet::get_unix_timestamp_as_seconds();
 
         let block_timestamp = starknet.get_latest_block().unwrap().header.timestamp;
-        // check if the pending_block_timestamp is less than the block_timestamp, by at least the
-        // sleep duration - 1
-        assert!(pending_block_timestamp.0 + sleep_duration_secs - 1 < block_timestamp.0);
+        // check if the pending_block_timestamp is less than the block_timestamp, by number of sleep seconds
+        // because the timeline of events is this:
+        // ----(pending block timestamp)----(sleep)----(new block timestamp)
+        assert!(pending_block_timestamp.0 + sleep_duration_secs <= block_timestamp.0);
         // check if now is close to the block_timestamp
         assert!(now - block_timestamp.0 <= 1);
     }

--- a/crates/starknet/src/starknet/mod.rs
+++ b/crates/starknet/src/starknet/mod.rs
@@ -1194,7 +1194,9 @@ mod tests {
 
         Starknet::update_block_context(&mut starknet.block_context);
         starknet.generate_pending_block().unwrap();
-        starknet.blocks.pending_block.set_timestamp(BlockTimestamp(std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs()));
+        starknet.blocks.pending_block.set_timestamp(BlockTimestamp(
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs(),
+        ));
         let pending_block_timestamp = starknet.pending_block().header.timestamp;
 
         let sleep_duration_secs = 5;
@@ -1204,7 +1206,8 @@ mod tests {
             std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
 
         let block_timestamp = starknet.get_latest_block().unwrap().header.timestamp;
-        // check if the pending_block_timestamp is less than the block_timestamp, by at least the sleep duration - 1
+        // check if the pending_block_timestamp is less than the block_timestamp, by at least the
+        // sleep duration - 1
         assert!(pending_block_timestamp.0 + sleep_duration_secs - 1 < block_timestamp.0);
         // check if now is close to the block_timestamp
         assert!(now - block_timestamp.0 <= 1);

--- a/crates/starknet/src/starknet/mod.rs
+++ b/crates/starknet/src/starknet/mod.rs
@@ -1204,7 +1204,6 @@ mod tests {
         let sleep_duration_secs = 5;
         thread::sleep(Duration::from_secs(sleep_duration_secs));
         starknet.generate_new_block(StateDiff::default()).unwrap();
-        let now = Starknet::get_unix_timestamp_as_seconds();
 
         let block_timestamp = starknet.get_latest_block().unwrap().header.timestamp;
         // check if the pending_block_timestamp is less than the block_timestamp,

--- a/crates/starknet/src/starknet/mod.rs
+++ b/crates/starknet/src/starknet/mod.rs
@@ -1207,8 +1207,8 @@ mod tests {
         let now = Starknet::get_unix_timestamp_as_seconds();
 
         let block_timestamp = starknet.get_latest_block().unwrap().header.timestamp;
-        // check if the pending_block_timestamp is less than the block_timestamp, by number of sleep
-        // seconds because the timeline of events is this:
+        // check if the pending_block_timestamp is less than the block_timestamp,
+        // by number of sleep seconds because the timeline of events is this:
         // ----(pending block timestamp)----(sleep)----(new block timestamp)
         assert!(pending_block_timestamp.0 + sleep_duration_secs <= block_timestamp.0);
         // check if now is close to the block_timestamp

--- a/crates/starknet/src/starknet/mod.rs
+++ b/crates/starknet/src/starknet/mod.rs
@@ -179,6 +179,12 @@ impl Starknet {
         // set new block header
         new_block.set_block_hash(new_block.generate_hash()?);
         new_block.status = BlockStatus::AcceptedOnL2;
+        new_block.set_timestamp(BlockTimestamp(
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .expect("should get current UNIX timestamp")
+                .as_secs(),
+        ));
         let new_block_number = new_block.block_number();
 
         // update txs block hash block number for each transaction in the pending block
@@ -331,16 +337,11 @@ impl Starknet {
         block_context
     }
 
-    /// Should update block context with new block timestamp
-    /// and pointer to the next block number
+    /// Update block context block_number with the next one
+    /// # Arguments
+    /// * `block_context` - BlockContext to be updated
     fn update_block_context(block_context: &mut BlockContext) {
-        let current_timestamp_secs = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("should get current UNIX timestamp")
-            .as_secs();
-
         block_context.block_number = block_context.block_number.next();
-        block_context.block_timestamp = BlockTimestamp(current_timestamp_secs);
     }
 
     fn pending_block(&self) -> &StarknetBlock {
@@ -354,7 +355,6 @@ impl Starknet {
         block.header.block_number = self.block_context.block_number;
         block.header.gas_price = GasPrice(self.block_context.gas_prices.eth_l1_gas_price);
         block.header.sequencer = self.block_context.sequencer_address;
-        block.header.timestamp = self.block_context.block_timestamp;
 
         self.blocks.pending_block = block;
 
@@ -801,6 +801,9 @@ impl Starknet {
 
 #[cfg(test)]
 mod tests {
+    use std::thread;
+    use std::time::Duration;
+
     use blockifier::state::state_api::State;
     use blockifier::transaction::errors::TransactionExecutionError;
     use starknet_api::block::{BlockHash, BlockNumber, BlockStatus, BlockTimestamp, GasPrice};
@@ -1183,5 +1186,27 @@ mod tests {
         let latest_block = starknet.get_latest_block();
 
         assert_eq!(latest_block.unwrap().block_number(), BlockNumber(2));
+    }
+    #[test]
+    fn check_timestamp_of_newly_generated_block() {
+        let config = starknet_config_for_test();
+        let mut starknet = Starknet::new(&config).unwrap();
+
+        Starknet::update_block_context(&mut starknet.block_context);
+        starknet.generate_pending_block().unwrap();
+        starknet.blocks.pending_block.set_timestamp(BlockTimestamp(std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs()));
+        let pending_block_timestamp = starknet.pending_block().header.timestamp;
+
+        let sleep_duration_secs = 5;
+        thread::sleep(Duration::from_secs(sleep_duration_secs));
+        starknet.generate_new_block(StateDiff::default()).unwrap();
+        let now =
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
+
+        let block_timestamp = starknet.get_latest_block().unwrap().header.timestamp;
+        // check if the pending_block_timestamp is less than the block_timestamp, by at least the sleep duration - 1
+        assert!(pending_block_timestamp.0 + sleep_duration_secs - 1 < block_timestamp.0);
+        // check if now is close to the block_timestamp
+        assert!(now - block_timestamp.0 <= 1);
     }
 }


### PR DESCRIPTION
## Usage related changes

Before, latest block timestamp was very close in value to the last block generated, or 0 in the case of being the first block.
This was happening, because when creating a new block it was generated from the pending block, which timestamp property was generated after creating the latest block.

This PR resolves that and removes the relation between pending block timestamp and new block timestamp, by assigning the block timestamp, when the block is created. Not when the last block is generated

## Development related changes

- Remove code that sets value regarding timestamp in`update_block_context` method.
- Updated `generate_new_block` to set the timestamp of the block with UNIX time.

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] Performed code self-review
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [ ] Linked the issues which this PR resolves
- [x] Checked the TODO section in README.md if this PR resolves it
- [x] Updated the tests
- [x] All tests are passing - `cargo test`
