### PR TITLE
Add restarting functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ This means that timestamps of `StarknetBlock` will be different.
 
 ### Restarting
 
-Devnet can be restarted by making a `POST /restart` request. All of the deployed contracts (including predeployed), blocks and storage updates will be restarted to the original state, without the transactions and requests from a dump file you may have provided on startup.
+Devnet can be restarted by making a `POST /restart` request (no body required). All of the deployed contracts (including predeployed), blocks and storage updates will be restarted to the original state, without the transactions and requests from a dump file you may have provided on startup.
 
 If you're using [**the Hardhat plugin**](https://github.com/0xSpaceShard/starknet-hardhat-plugin#restart), restart with `starknet.devnet.restart()`.
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,12 @@ Currently, dumping produces a list of received transactions that is stored on di
 Conversely, loading is implemented as the re-execution of transactions from a dump.
 This means that timestamps of `StarknetBlock` will be different.
 
+### Restarting
+
+Devnet can be restarted by making a `POST /restart` request. All of the deployed contracts (including predeployed), blocks and storage updates will be restarted to the startup state. If you loaded from a dump file, it will be reloaded; otherwise you will get a fresh Devnet.
+
+If you're using [**the Hardhat plugin**](https://github.com/0xSpaceShard/starknet-hardhat-plugin#restart), restart with `await starknet.devnet.restart()`.
+
 ### Cross-version disclaimer
 
 Dumping and loading is not guaranteed to work cross-version. I.e. if you dumped one version of Devnet, do not expect it to be loadable with a different version.
@@ -235,6 +241,7 @@ Block timestamp can be manipulated by setting the exact time or setting the time
 ### Set time
 
 Sets the exact time and generates a new block.
+
 ```
 POST /set_time
 {
@@ -247,6 +254,7 @@ Warning: block time can be set in the past which might lead to unexpected behavi
 ### Increase time
 
 Increases the block timestamp by the provided amount and generates a new block. All subsequent blocks will keep this increment.
+
 ```
 POST /increase_time
 {

--- a/README.md
+++ b/README.md
@@ -212,9 +212,9 @@ This means that timestamps of `StarknetBlock` will be different.
 
 ### Restarting
 
-Devnet can be restarted by making a `POST /restart` request. All of the deployed contracts (including predeployed), blocks and storage updates will be restarted to the startup state. If you loaded from a dump file, it will be reloaded; otherwise you will get a fresh Devnet.
+Devnet can be restarted by making a `POST /restart` request. All of the deployed contracts (including predeployed), blocks and storage updates will be restarted to the original state, without the transactions and requests from a dump file you may have provided on startup.
 
-If you're using [**the Hardhat plugin**](https://github.com/0xSpaceShard/starknet-hardhat-plugin#restart), restart with `await starknet.devnet.restart()`.
+If you're using [**the Hardhat plugin**](https://github.com/0xSpaceShard/starknet-hardhat-plugin#restart), restart with `starknet.devnet.restart()`.
 
 ### Cross-version disclaimer
 

--- a/crates/starknet-server/src/api/http/endpoints/mod.rs
+++ b/crates/starknet-server/src/api/http/endpoints/mod.rs
@@ -1,8 +1,8 @@
-use axum::Json;
+use axum::{Extension, Json};
 
 use super::error::HttpApiError;
 use super::models::ForkStatus;
-use super::HttpApiResult;
+use super::{HttpApiHandler, HttpApiResult};
 
 /// Dumping and loading
 pub(crate) mod dump_load;
@@ -28,8 +28,9 @@ pub(crate) async fn is_alive() -> HttpApiResult<String> {
 }
 
 /// Restart
-pub(crate) async fn restart() -> HttpApiResult<()> {
-    Err(HttpApiError::GeneralError)
+pub(crate) async fn restart(Extension(mut state): Extension<HttpApiHandler>) -> HttpApiResult<()> {
+    state.api.restart().await.map_err(|err| HttpApiError::RestartError { msg: err.to_string() })?;
+    Ok(())
 }
 
 /// Fork

--- a/crates/starknet-server/src/api/http/endpoints/mod.rs
+++ b/crates/starknet-server/src/api/http/endpoints/mod.rs
@@ -28,8 +28,14 @@ pub(crate) async fn is_alive() -> HttpApiResult<String> {
 }
 
 /// Restart
-pub(crate) async fn restart(Extension(mut state): Extension<HttpApiHandler>) -> HttpApiResult<()> {
-    state.api.restart().await.map_err(|err| HttpApiError::RestartError { msg: err.to_string() })?;
+pub(crate) async fn restart(Extension(state): Extension<HttpApiHandler>) -> HttpApiResult<()> {
+    state
+        .api
+        .starknet
+        .write()
+        .await
+        .restart()
+        .map_err(|err| HttpApiError::RestartError { msg: err.to_string() })?;
     Ok(())
 }
 

--- a/crates/starknet-server/src/api/http/error.rs
+++ b/crates/starknet-server/src/api/http/error.rs
@@ -18,6 +18,8 @@ pub enum HttpApiError {
     LoadError,
     #[error("The re-execution operation failed")]
     ReExecutionError,
+    #[error("Could not restart: {msg}")]
+    RestartError { msg: String },
 }
 
 impl IntoResponse for HttpApiError {
@@ -29,15 +31,16 @@ impl IntoResponse for HttpApiError {
             HttpApiError::FileNotFound => {
                 (StatusCode::BAD_REQUEST, String::from("file does not exist"))
             }
-            err @ HttpApiError::DumpError { msg: _ } => (StatusCode::BAD_REQUEST, err.to_string()),
+            err @ HttpApiError::DumpError { .. } => (StatusCode::BAD_REQUEST, err.to_string()),
             HttpApiError::LoadError => {
                 (StatusCode::BAD_REQUEST, String::from("load operation failed"))
             }
             HttpApiError::ReExecutionError => {
                 (StatusCode::BAD_REQUEST, String::from("re-execution operation failed"))
             }
-            err @ HttpApiError::MintingError { msg: _ } => {
-                (StatusCode::BAD_REQUEST, err.to_string())
+            err @ HttpApiError::MintingError { .. } => (StatusCode::BAD_REQUEST, err.to_string()),
+            err @ HttpApiError::RestartError { .. } => {
+                (StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
             }
         };
 

--- a/crates/starknet-server/src/api/mod.rs
+++ b/crates/starknet-server/src/api/mod.rs
@@ -5,7 +5,6 @@ pub(crate) mod serde_helpers;
 
 use std::sync::Arc;
 
-use starknet_core::error::DevnetResult;
 use starknet_core::starknet::Starknet;
 use tokio::sync::RwLock;
 
@@ -20,11 +19,5 @@ pub struct Api {
 impl Api {
     pub fn new(starknet: Starknet) -> Self {
         Self { starknet: Arc::new(RwLock::new(starknet)) }
-    }
-
-    pub async fn restart(&mut self) -> DevnetResult<()> {
-        let config = self.starknet.read().await.config.clone();
-        self.starknet = Arc::new(RwLock::new(Starknet::new(&config)?));
-        Ok(())
     }
 }

--- a/crates/starknet-server/src/api/mod.rs
+++ b/crates/starknet-server/src/api/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod serde_helpers;
 
 use std::sync::Arc;
 
+use starknet_core::error::DevnetResult;
 use starknet_core::starknet::Starknet;
 use tokio::sync::RwLock;
 
@@ -19,5 +20,11 @@ pub struct Api {
 impl Api {
     pub fn new(starknet: Starknet) -> Self {
         Self { starknet: Arc::new(RwLock::new(starknet)) }
+    }
+
+    pub async fn restart(&mut self) -> DevnetResult<()> {
+        let config = self.starknet.read().await.config.clone();
+        self.starknet = Arc::new(RwLock::new(Starknet::new(&config)?));
+        Ok(())
     }
 }

--- a/crates/starknet-server/src/cli.rs
+++ b/crates/starknet-server/src/cli.rs
@@ -121,6 +121,7 @@ impl Args {
             chain_id: self.chain_id,
             dump_on: self.dump_on,
             dump_path: self.dump_path.clone(),
+            re_execute_on_init: true,
         })
     }
 }

--- a/crates/starknet-server/tests/common/devnet.rs
+++ b/crates/starknet-server/tests/common/devnet.rs
@@ -85,12 +85,13 @@ impl BackgroundDevnet {
     /// Takes user specified args and adds default values for args that are missing
     fn add_default_args<'a>(user_args: &[&'a str]) -> Vec<&'a str> {
         let mut substituted_args: Vec<&'a str> = vec![];
-        for (arg, default_value) in CLI_MAP.iter() {
-            substituted_args.push(arg);
+        for (arg_name, default_value) in CLI_MAP.iter() {
+            substituted_args.push(arg_name);
 
             let value = user_args
                 .iter()
-                .position(|arg_candidate| arg_candidate == arg)
+                .position(|arg_candidate| arg_candidate == arg_name)
+                // arg value comes after name
                 .map(|pos| user_args[pos + 1])
                 .unwrap_or(default_value);
             substituted_args.push(value);

--- a/crates/starknet-server/tests/common/devnet.rs
+++ b/crates/starknet-server/tests/common/devnet.rs
@@ -211,6 +211,10 @@ impl BackgroundDevnet {
 
         (signer, account_address)
     }
+
+    pub async fn restart(&self) -> Result<Response<Body>, hyper::Error> {
+        self.post_json("/restart".into(), Body::empty()).await
+    }
 }
 
 /// By implementing Drop, we ensure there are no zombie background Devnet processes

--- a/crates/starknet-server/tests/common/utils.rs
+++ b/crates/starknet-server/tests/common/utils.rs
@@ -1,6 +1,7 @@
 use std::fmt::LowerHex;
 use std::fs;
 use std::path::Path;
+use std::process::{Child, Command};
 
 use cairo_lang_starknet::casm_contract_class::CasmContractClass;
 use hyper::{Body, Response};
@@ -103,4 +104,25 @@ pub fn get_unix_timestamp_as_seconds() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .expect("should get current UNIX timestamp")
         .as_secs()
+}
+
+pub async fn send_ctrl_c_signal(process: &Child) {
+    #[cfg(windows)]
+    {
+        // To send SIGINT signal on windows, windows-kill is needed
+        let mut kill = Command::new("windows-kill")
+            .args(["-SIGINT", process.id().to_string().as_str()])
+            .spawn()
+            .unwrap();
+        kill.wait().unwrap();
+    }
+
+    #[cfg(unix)]
+    {
+        let mut kill = Command::new("kill")
+            .args(["-s", "SIGINT", process.id().to_string().as_str()])
+            .spawn()
+            .unwrap();
+        kill.wait().unwrap();
+    }
 }

--- a/crates/starknet-server/tests/get_transaction_by_hash.rs
+++ b/crates/starknet-server/tests/get_transaction_by_hash.rs
@@ -24,12 +24,6 @@ mod get_transaction_by_hash_integration_tests {
     use crate::common::devnet::BackgroundDevnet;
     use crate::common::utils::{get_deployable_account_signer, resolve_path};
 
-    pub const DECLARE_V1_TRANSACTION_HASH: &str =
-        "0x03260006dbb34ad0c3b70a39c9eaf84aade3d289a5a5517fc37b303f5f01ac1a";
-
-    pub const INVOKE_V1_TRANSACTION_HASH: &str =
-        "0x008aa91514421bb9826d6821789580ff8fe2f9eb225f7b3bc79ec0c81d9eb58c";
-
     #[tokio::test]
     async fn get_declare_v1_transaction_by_hash_happy_path() {
         let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
@@ -69,10 +63,8 @@ mod get_transaction_by_hash_integration_tests {
             starknet_rs_core::types::DeclareTransaction::V1(declare_v1),
         ) = result
         {
-            assert_eq!(
-                declare_v1.transaction_hash,
-                FieldElement::from_hex_be(DECLARE_V1_TRANSACTION_HASH).unwrap()
-            );
+            let expected = "0x03260006dbb34ad0c3b70a39c9eaf84aade3d289a5a5517fc37b303f5f01ac1a";
+            assert_eq!(declare_v1.transaction_hash, FieldElement::from_hex_be(expected).unwrap());
         } else {
             panic!("Could not unpack the transaction from {result:?}");
         }
@@ -211,10 +203,8 @@ mod get_transaction_by_hash_integration_tests {
             starknet_rs_core::types::InvokeTransaction::V1(invoke_v1),
         ) = result
         {
-            assert_eq!(
-                invoke_v1.transaction_hash,
-                FieldElement::from_hex_be(INVOKE_V1_TRANSACTION_HASH).unwrap()
-            );
+            let expected = "0x008aa91514421bb9826d6821789580ff8fe2f9eb225f7b3bc79ec0c81d9eb58c";
+            assert_eq!(invoke_v1.transaction_hash, FieldElement::from_hex_be(expected).unwrap());
         } else {
             panic!("Could not unpack the transaction from {result:?}");
         }

--- a/crates/starknet-server/tests/get_transaction_receipt_by_hash.rs
+++ b/crates/starknet-server/tests/get_transaction_receipt_by_hash.rs
@@ -184,7 +184,6 @@ mod get_transaction_receipt_by_hash_integration_tests {
         let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
 
         let (signer, account_address) = devnet.get_first_predeployed_account().await;
-
         let predeployed_account = SingleOwnerAccount::new(
             devnet.clone_provider(),
             signer,

--- a/crates/starknet-server/tests/test_account_selection.rs
+++ b/crates/starknet-server/tests/test_account_selection.rs
@@ -88,7 +88,7 @@ mod test_account_selection {
         let account_factory = OpenZeppelinAccountFactory::new(
             FieldElement::from_hex_be(CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH).unwrap(),
             CHAIN_ID,
-            signer.clone(),
+            signer,
             devnet.clone_provider(),
         )
         .await

--- a/crates/starknet-server/tests/test_dump_and_load.rs
+++ b/crates/starknet-server/tests/test_dump_and_load.rs
@@ -17,11 +17,10 @@ mod dump_and_load_tests {
 
     use std::sync::Arc;
 
-    use starknet_core::constants::ERC20_CONTRACT_ADDRESS;
     use starknet_rs_accounts::{Account, ExecutionEncoding, SingleOwnerAccount};
     use starknet_rs_contract::ContractFactory;
     use starknet_rs_core::chain_id;
-    use starknet_rs_core::types::{BlockId, BlockTag, FieldElement, FunctionCall};
+    use starknet_rs_core::types::FieldElement;
 
     use crate::common::utils::get_events_contract_in_sierra_and_compiled_class_hash;
 
@@ -313,12 +312,7 @@ mod dump_and_load_tests {
     async fn load_endpoint_fail_with_wrong_path() {
         let load_file_name = "load_file_name";
         let devnet_load = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
-        let load_body = Body::from(
-            json!({
-                "path": load_file_name
-            })
-            .to_string(),
-        );
+        let load_body = Body::from(json!({ "path": load_file_name }).to_string());
         let result = devnet_load.post_json("/load".into(), load_body).await.unwrap();
         assert_eq!(result.status(), 400);
     }
@@ -338,41 +332,20 @@ mod dump_and_load_tests {
         let dump_body = Body::from(json!({}).to_string());
         devnet_dump.post_json("/dump".into(), dump_body).await.unwrap();
         assert!(Path::new(dump_file_name).exists());
-        let dump_body_custom_path = Body::from(
-            json!({
-                "path": dump_file_name_custom_path
-            })
-            .to_string(),
-        );
+        let dump_body_custom_path =
+            Body::from(json!({ "path": dump_file_name_custom_path }).to_string());
         devnet_dump.post_json("/dump".into(), dump_body_custom_path).await.unwrap();
         assert!(Path::new(dump_file_name_custom_path).exists());
 
         // load and re-execute from "dump_endpoint" file and check if transaction and state of the
         // blockchain is valid
         let devnet_load = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
-        let load_body = Body::from(
-            json!({
-                "path": dump_file_name
-            })
-            .to_string(),
-        );
+        let load_body = Body::from(json!({ "path": dump_file_name }).to_string());
         devnet_load.post_json("/load".into(), load_body).await.unwrap();
 
-        let entry_point_selector =
-            starknet_rs_core::utils::get_selector_from_name("balanceOf").unwrap();
-        let balance_result = devnet_load
-            .json_rpc_client
-            .call(
-                FunctionCall {
-                    contract_address: FieldElement::from_hex_be(ERC20_CONTRACT_ADDRESS).unwrap(),
-                    entry_point_selector,
-                    calldata: vec![DUMMY_ADDRESS.into()],
-                },
-                BlockId::Tag(BlockTag::Latest),
-            )
-            .await
-            .expect("Failed to call contract");
-        assert_eq!(balance_result[0], DUMMY_AMOUNT.into());
+        let balance_result =
+            devnet_load.get_balance(&FieldElement::from(DUMMY_ADDRESS)).await.unwrap();
+        assert_eq!(balance_result, DUMMY_AMOUNT.into());
 
         let loaded_transaction =
             devnet_load.json_rpc_client.get_transaction_by_hash(mint_tx_hash).await.unwrap();

--- a/crates/starknet-server/tests/test_restart.rs
+++ b/crates/starknet-server/tests/test_restart.rs
@@ -186,4 +186,9 @@ mod test_restart {
         let balance_after = devnet.get_balance(&predeployed_account_addresss).await.unwrap();
         assert_eq!(balance_before, balance_after);
     }
+
+    #[tokio::test]
+    async fn assert_reloaded_from_dump_on_restart() {
+        todo!();
+    }
 }

--- a/crates/starknet-server/tests/test_restart.rs
+++ b/crates/starknet-server/tests/test_restart.rs
@@ -13,5 +13,23 @@ mod test_restart {
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
-    // TODO add more
+    #[tokio::test]
+    async fn assert_tx_not_present_after_restart() {
+        todo!();
+    }
+
+    #[tokio::test]
+    async fn assert_storage_restarted() {
+        todo!();
+    }
+
+    #[tokio::test]
+    async fn assert_gas_price_unaffected_by_restart() {
+        todo!();
+    }
+
+    #[tokio::test]
+    async fn assert_predeployed_account_still_prefunded() {
+        todo!();
+    }
 }

--- a/crates/starknet-server/tests/test_restart.rs
+++ b/crates/starknet-server/tests/test_restart.rs
@@ -31,7 +31,7 @@ mod test_restart {
     }
 
     #[tokio::test]
-    async fn assert_tx_not_present_after_restart() {
+    async fn assert_tx_and_block_not_present_after_restart() {
         let devnet = BackgroundDevnet::spawn().await.unwrap();
 
         // generate dummy tx
@@ -44,6 +44,14 @@ mod test_restart {
         match devnet.json_rpc_client.get_transaction_by_hash(mint_hash).await {
             Err(ProviderError::StarknetError(StarknetErrorWithMessage {
                 code: MaybeUnknownErrorCode::Known(StarknetError::TransactionHashNotFound),
+                ..
+            })) => (),
+            other => panic!("Unexpected result: {other:?}"),
+        }
+
+        match devnet.json_rpc_client.get_block_with_txs(BlockId::Tag(BlockTag::Latest)).await {
+            Err(ProviderError::StarknetError(StarknetErrorWithMessage {
+                code: MaybeUnknownErrorCode::Known(StarknetError::BlockNotFound),
                 ..
             })) => (),
             other => panic!("Unexpected result: {other:?}"),

--- a/crates/starknet-server/tests/test_restart.rs
+++ b/crates/starknet-server/tests/test_restart.rs
@@ -2,20 +2,39 @@
 pub mod common;
 
 mod test_restart {
-    use hyper::{Body, StatusCode};
+    use hyper::StatusCode;
+    use starknet_rs_core::types::{FieldElement, StarknetError};
+    use starknet_rs_providers::{
+        MaybeUnknownErrorCode, Provider, ProviderError, StarknetErrorWithMessage,
+    };
 
     use crate::common::devnet::BackgroundDevnet;
 
     #[tokio::test]
     async fn assert_restartable() {
         let devnet = BackgroundDevnet::spawn().await.unwrap();
-        let resp = devnet.post_json("/restart".into(), Body::empty()).await.unwrap();
+        let resp = devnet.restart().await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
     #[tokio::test]
     async fn assert_tx_not_present_after_restart() {
-        todo!();
+        // generate tx
+        let devnet = BackgroundDevnet::spawn().await.unwrap();
+        let dummy_address = FieldElement::from_hex_be("0x1").unwrap();
+        let mint_hash = devnet.mint(dummy_address, 100).await;
+        assert!(devnet.json_rpc_client.get_transaction_by_hash(mint_hash).await.is_ok());
+
+        let restart_resp = devnet.restart().await.unwrap();
+        assert_eq!(restart_resp.status(), StatusCode::OK);
+
+        match devnet.json_rpc_client.get_transaction_by_hash(mint_hash).await.unwrap_err() {
+            ProviderError::StarknetError(StarknetErrorWithMessage {
+                code: MaybeUnknownErrorCode::Known(StarknetError::TransactionHashNotFound),
+                ..
+            }) => (),
+            other => panic!("Invalid error: {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/starknet-server/tests/test_restart.rs
+++ b/crates/starknet-server/tests/test_restart.rs
@@ -168,7 +168,7 @@ mod test_restart {
 
     #[tokio::test]
     async fn assert_predeployed_account_is_prefunded_after_restart() {
-        let initial_balance = 1_000_000;
+        let initial_balance = 1_000_000_u32;
         let devnet = BackgroundDevnet::spawn_with_additional_args(&[
             "--initial-balance",
             &initial_balance.to_string(),
@@ -177,16 +177,13 @@ mod test_restart {
         .unwrap();
 
         let predeployed_account_addresss = devnet.get_first_predeployed_account().await.1;
-        let get_balance = || {
-            // check balance by minting 0
-            devnet.mint(predeployed_account_addresss, 0)
-        };
 
-        let balance_before = get_balance().await;
+        let balance_before = devnet.get_balance(&predeployed_account_addresss).await.unwrap();
+        assert_eq!(balance_before, FieldElement::from(initial_balance));
 
         devnet.restart().await.unwrap();
 
-        let balance_after = get_balance().await;
+        let balance_after = devnet.get_balance(&predeployed_account_addresss).await.unwrap();
         assert_eq!(balance_before, balance_after);
     }
 }

--- a/crates/starknet-server/tests/test_restart.rs
+++ b/crates/starknet-server/tests/test_restart.rs
@@ -1,0 +1,17 @@
+// must use `pub`: https://github.com/rust-lang/rust/issues/46379#issuecomment-548787629
+pub mod common;
+
+mod test_restart {
+    use hyper::{Body, StatusCode};
+
+    use crate::common::devnet::BackgroundDevnet;
+
+    #[tokio::test]
+    async fn assert_restartable() {
+        let devnet = BackgroundDevnet::spawn().await.unwrap();
+        let resp = devnet.post_json("/restart".into(), Body::empty()).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    // TODO add more
+}

--- a/crates/starknet/src/starknet/mod.rs
+++ b/crates/starknet/src/starknet/mod.rs
@@ -158,7 +158,7 @@ impl Starknet {
     }
 
     pub fn restart(&mut self) -> DevnetResult<()> {
-        self.config.re_execute_on_init = false; // TODO try with true
+        self.config.re_execute_on_init = false;
         *self = Starknet::new(&self.config)?;
         Ok(())
     }

--- a/crates/starknet/src/starknet/mod.rs
+++ b/crates/starknet/src/starknet/mod.rs
@@ -145,7 +145,7 @@ impl Starknet {
         this.restart_pending_block()?;
 
         // Load starknet transactions
-        if this.config.dump_path.is_some() {
+        if this.config.dump_path.is_some() && this.config.re_execute_on_init {
             // Try to load transactions from dump_path, if there is no file skip this step
             match this.load_transactions() {
                 Ok(txs) => this.re_execute(txs)?,
@@ -158,6 +158,7 @@ impl Starknet {
     }
 
     pub fn restart(&mut self) -> DevnetResult<()> {
+        self.config.re_execute_on_init = false; // TODO try with true
         *self = Starknet::new(&self.config)?;
         Ok(())
     }

--- a/crates/starknet/src/starknet/mod.rs
+++ b/crates/starknet/src/starknet/mod.rs
@@ -157,6 +157,11 @@ impl Starknet {
         Ok(this)
     }
 
+    pub fn restart(&mut self) -> DevnetResult<()> {
+        *self = Starknet::new(&self.config)?;
+        Ok(())
+    }
+
     pub fn get_predeployed_accounts(&self) -> Vec<Account> {
         self.predeployed_accounts.get_accounts().to_vec()
     }

--- a/crates/starknet/src/starknet/starknet_config.rs
+++ b/crates/starknet/src/starknet/starknet_config.rs
@@ -29,6 +29,8 @@ pub struct StarknetConfig {
     pub chain_id: ChainId,
     pub dump_on: Option<DumpOn>,
     pub dump_path: Option<String>,
+    /// on initialization, re-execute loaded txs (if any)
+    pub re_execute_on_init: bool,
 }
 
 impl Default for StarknetConfig {
@@ -50,6 +52,7 @@ impl Default for StarknetConfig {
             chain_id: DEVNET_DEFAULT_CHAIN_ID,
             dump_on: None,
             dump_path: None,
+            re_execute_on_init: true,
         }
     }
 }

--- a/crates/starknet/src/utils.rs
+++ b/crates/starknet/src/utils.rs
@@ -76,6 +76,7 @@ pub(crate) mod test_utils {
             chain_id: DEVNET_DEFAULT_CHAIN_ID,
             dump_on: None,
             dump_path: None,
+            re_execute_on_init: true,
         }
     }
 


### PR DESCRIPTION
## Usage related changes

- Closes #232 

## Development related changes

- Refactor BackgroundDevnet CLI parsing to allow custom arguments in array/slice form, but also to use default values for those needed and not provided
- Remove TODOs from old tests
  - By changing how max_fee is specified in one test, its tx hash was changed, so I took the chance to remove some of the unnecessary constants that are used in just one place.
- Introduce `devnet.get_balance(address)` and use it in old and new tests
- Move `send_ctrl_c_signal` to utils and make it more general (accept any process, not necessarily BackgroundDevnet)

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Checked the TODO section in README.md if this PR resolves it
- [x] Updated the tests
- [x] All tests are passing - `cargo test`
