### PR TITLE
Update starknet-rs to fix offset serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3528,9 +3528,9 @@ dependencies = [
  "random-number-generator",
  "serde",
  "serde_json",
- "starknet-core 0.6.0",
+ "starknet-core 0.7.1",
  "starknet-ff",
- "starknet-signers 0.4.0",
+ "starknet-signers 0.5.0",
  "starknet_api 0.5.0-rc1",
  "thiserror",
  "tracing",
@@ -3546,7 +3546,7 @@ dependencies = [
  "starknet-accounts 0.4.0",
  "starknet-contract 0.4.0",
  "starknet-core 0.5.1",
- "starknet-crypto 0.6.0",
+ "starknet-crypto 0.6.1",
  "starknet-ff",
  "starknet-macros",
  "starknet-providers 0.5.0",
@@ -3568,15 +3568,15 @@ dependencies = [
 
 [[package]]
 name = "starknet-accounts"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e97edc480348dca300e5a8234e6c4e6f2f1ac028f2b16fcce294ebe93d07f4"
+checksum = "5a54da2cb18f8083845c0d3bbe1d68758246b94db4b7171e1cdbdc09cefd4b0c"
 dependencies = [
  "async-trait",
  "auto_impl",
- "starknet-core 0.6.0",
- "starknet-providers 0.6.0",
- "starknet-signers 0.4.0",
+ "starknet-core 0.7.1",
+ "starknet-providers 0.7.0",
+ "starknet-signers 0.5.0",
  "thiserror",
 ]
 
@@ -3597,16 +3597,16 @@ dependencies = [
 
 [[package]]
 name = "starknet-contract"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b86e3f6b3ca9a5c45271ab10871c99f7dc82fee3199d9f8c7baa2a1829947d"
+checksum = "d858efc93d85de95065a5732cb3e94d0c746674964c0859aab442ffbb9de76b4"
 dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "starknet-accounts 0.5.0",
- "starknet-core 0.6.0",
- "starknet-providers 0.6.0",
+ "starknet-accounts 0.6.0",
+ "starknet-core 0.7.1",
+ "starknet-providers 0.7.0",
  "thiserror",
 ]
 
@@ -3624,15 +3624,15 @@ dependencies = [
  "serde_json_pythonic",
  "serde_with",
  "sha3",
- "starknet-crypto 0.6.0",
+ "starknet-crypto 0.6.1",
  "starknet-ff",
 ]
 
 [[package]]
 name = "starknet-core"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b796a32a7400f7d85e95d3900b5cee7a392b2adbf7ad16093ed45ec6f8d85de6"
+checksum = "d35a5cd67067c6dee09defa3448d706fac988d58f4f1bef71d50a27d564d9cab"
 dependencies = [
  "base64 0.21.2",
  "flate2",
@@ -3642,7 +3642,7 @@ dependencies = [
  "serde_json_pythonic",
  "serde_with",
  "sha3",
- "starknet-crypto 0.6.0",
+ "starknet-crypto 0.6.1",
  "starknet-ff",
 ]
 
@@ -3668,9 +3668,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dbb308033b5c60c5677645f7ba3b012b4e3e81f773480d27fb5f342d50621e6"
+checksum = "33c03f5ac70f9b067f48db7d2d70bdf18ee0f731e8192b6cfa679136becfcdb0"
 dependencies = [
  "crypto-bigint",
  "hex",
@@ -3717,9 +3717,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-ff"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2cb1d9c0a50380cddab99cb202c6bfb3332728a2769bd0ca2ee80b0b390dd4"
+checksum = "7584bc732e4d2a8ccebdd1dda8236f7940a79a339e30ebf338d45c329659e36c"
 dependencies = [
  "ark-ff",
  "bigdecimal",
@@ -3762,9 +3762,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-providers"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b136c26b72ff1756f0844e0aa80bab680ceb99d63921826facbb8e7340ff82"
+checksum = "52072c2d258bf692affeccd602613d5f6c61a6ffc84da8f191ab4a1b0a5e24d1"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -3775,7 +3775,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "starknet-core 0.6.0",
+ "starknet-core 0.7.1",
  "thiserror",
  "url",
 ]
@@ -3799,11 +3799,11 @@ dependencies = [
  "serde_json",
  "server",
  "starknet 0.1.0",
- "starknet-accounts 0.5.0",
- "starknet-contract 0.5.0",
- "starknet-core 0.6.0",
- "starknet-providers 0.6.0",
- "starknet-signers 0.4.0",
+ "starknet-accounts 0.6.0",
+ "starknet-contract 0.6.0",
+ "starknet-core 0.7.1",
+ "starknet-providers 0.7.0",
+ "starknet-signers 0.5.0",
  "thiserror",
  "tokio",
  "tokio-graceful-shutdown",
@@ -3827,23 +3827,23 @@ dependencies = [
  "eth-keystore",
  "rand",
  "starknet-core 0.5.1",
- "starknet-crypto 0.6.0",
+ "starknet-crypto 0.6.1",
  "thiserror",
 ]
 
 [[package]]
 name = "starknet-signers"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9386015d2e6dc3df285bfb33a3afd8ad7596c70ed38ab57019de4d2dfc7826f"
+checksum = "347b1bfc09846aafe16d2b3a5bc2d8a2f845e2958602442182d265fbd6011c2e"
 dependencies = [
  "async-trait",
  "auto_impl",
  "crypto-bigint",
  "eth-keystore",
  "rand",
- "starknet-core 0.6.0",
- "starknet-crypto 0.6.0",
+ "starknet-core 0.7.1",
+ "starknet-crypto 0.6.1",
  "thiserror",
 ]
 
@@ -4388,8 +4388,8 @@ dependencies = [
  "num-integer",
  "serde",
  "serde_json",
- "starknet-core 0.6.0",
- "starknet-crypto 0.6.0",
+ "starknet-core 0.7.1",
+ "starknet-crypto 0.6.1",
  "starknet-ff",
  "starknet_api 0.5.0-rc1",
  "starknet_in_rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,13 +54,13 @@ indexmap = "2.0.0"
 starknet_api = { version = "0.5.0-rc1", features = ["testing"] }
 starknet-in-rust = { git = "https://github.com/lambdaclass/starknet_in_rust", rev = "a7e2e56", package="starknet_in_rust" }
 blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "v0.3.0-rc0", package = "blockifier" }
-starknet-rs-signers = { version = "0.4.0", package="starknet-signers" }
-starknet-rs-ff = { version = "0.3.4", package = "starknet-ff" }
-starknet-rs-core = {  version = "0.6.0", package = "starknet-core" }
-starknet-rs-providers = {  version = "0.6.0", package = "starknet-providers" }
-starknet-rs-accounts = { version = "0.5.0", package = "starknet-accounts" }
-starknet-rs-contract = { version = "0.5.0", package = "starknet-contract" }
-starknet-rs-crypto = { version = "0.6.0", package = "starknet-crypto" }
+starknet-rs-signers = { version = "0.5.0", package="starknet-signers" }
+starknet-rs-ff = { version = "0.3.5", package = "starknet-ff" }
+starknet-rs-core = {  version = "0.7.1", package = "starknet-core" }
+starknet-rs-providers = {  version = "0.7.0", package = "starknet-providers" }
+starknet-rs-accounts = { version = "0.6.0", package = "starknet-accounts" }
+starknet-rs-contract = { version = "0.6.0", package = "starknet-contract" }
+starknet-rs-crypto = { version = "0.6.1", package = "starknet-crypto" }
 cairo-felt = { version = "0.8.5", package = "cairo-felt" }
 cairo-lang-starknet = { version = "2.2.0", package = "cairo-lang-starknet" }
 url = "2.4"

--- a/crates/starknet-server/tests/get_transaction_receipt_by_hash.rs
+++ b/crates/starknet-server/tests/get_transaction_receipt_by_hash.rs
@@ -276,7 +276,7 @@ mod get_transaction_receipt_by_hash_integration_tests {
             .unwrap();
         for entry_point in entry_points {
             // We are assuming hex string format in the loaded artifact;
-            // Converting it to numeric value to test what the title says
+            // Converting it to numeric value to test that case
             let offset_hex_string = entry_point["offset"].as_str().unwrap();
             entry_point["offset"] =
                 u32::from_str_radix(&offset_hex_string[2..], 16).unwrap().into();

--- a/crates/starknet-server/tests/get_transaction_receipt_by_hash.rs
+++ b/crates/starknet-server/tests/get_transaction_receipt_by_hash.rs
@@ -260,6 +260,45 @@ mod get_transaction_receipt_by_hash_integration_tests {
     }
 
     #[tokio::test]
+    async fn declare_v1_accepted_with_numeric_entrypoint_offset() {
+        let devnet = BackgroundDevnet::spawn().await.unwrap();
+
+        let declare_file_content = std::fs::File::open(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_data/rpc/declare_v1.json"
+        ))
+        .unwrap();
+        let mut declare_rpc_body: serde_json::Value =
+            serde_json::from_reader(declare_file_content).unwrap();
+
+        let entry_points = declare_rpc_body["contract_class"]["entry_points_by_type"]["EXTERNAL"]
+            .as_array_mut()
+            .unwrap();
+        for entry_point in entry_points {
+            // We are assuming hex string format in the loaded artifact;
+            // Converting it to numeric value to test what the title says
+            let offset_hex_string = entry_point["offset"].as_str().unwrap();
+            entry_point["offset"] =
+                u32::from_str_radix(&offset_hex_string[2..], 16).unwrap().into();
+        }
+
+        let resp = &devnet
+            .send_custom_rpc(
+                "starknet_addDeclareTransaction",
+                serde_json::json!({ "declare_transaction": declare_rpc_body }),
+            )
+            .await;
+
+        match resp["error"]["code"].as_u64() {
+            Some(53) => {
+                // We got error code corresponding to insufficient balance, which is ok;
+                // it's important we didn't get failed JSON schema matching with error -32602
+            }
+            _ => panic!("Unexpected response: {resp}"),
+        }
+    }
+
+    #[tokio::test]
     async fn get_non_existing_transaction() {
         let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
         let result = devnet

--- a/crates/starknet-server/tests/test_simulate_transactions.rs
+++ b/crates/starknet-server/tests/test_simulate_transactions.rs
@@ -87,7 +87,7 @@ mod estimate_fee_tests {
             .nonce(nonce)
             .prepared()
             .unwrap()
-            .get_declare_request()
+            .get_declare_request(false)
             .await
             .unwrap()
             .signature;
@@ -154,7 +154,7 @@ mod estimate_fee_tests {
             .nonce(nonce)
             .prepared()
             .unwrap()
-            .get_declare_request()
+            .get_declare_request(false)
             .await
             .unwrap()
             .signature;
@@ -353,7 +353,7 @@ mod estimate_fee_tests {
             .nonce(nonce)
             .prepared()
             .unwrap()
-            .get_invoke_request()
+            .get_invoke_request(false)
             .await
             .unwrap();
         let signature_hex: Vec<String> = iter_to_hex_felt(&invoke_request.signature);


### PR DESCRIPTION
## Usage related changes

- After https://github.com/xJonathanLEI/starknet-rs/pull/491 has been merged, we can rely on starknet-rs to accept Declaration V1 transactions that have numeric entrypoint offset.
  - Closes #179 

## Development related changes

- Updates starknet-rs crates to latest versions
  - In `test_simulate_transactions.rs` this required introducing a new necessary boolean argument to some functions.

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Checked the TODO section in README.md if this PR resolves it
- [x] Updated the tests
- [x] All tests are passing - `cargo test`
