### PR TITLE
Update starknet-rs to fix abi event parsing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           # if jobs not limited - fails
           # problem: https://app.circleci.com/pipelines/github/0xSpaceShard/starknet-devnet-rs/339/workflows/97e98c29-1563-4aa0-b716-4bfd023c563e/jobs/335/steps
           # solution: https://stackoverflow.com/questions/71962406/how-to-use-less-memory-when-compiling-to-avoid-killing-the-build
-          command: cargo test --jobs 6
+          command: cargo test --jobs 7
 
   image-build-amd:
     docker:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3582,7 +3582,7 @@ dependencies = [
  "serde",
  "serde_json",
  "starknet-core",
- "starknet-ff",
+ "starknet-ff 0.3.5 (git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c)",
  "starknet-signers",
  "starknet_api",
  "thiserror",
@@ -3593,8 +3593,7 @@ dependencies = [
 [[package]]
 name = "starknet-accounts"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a54da2cb18f8083845c0d3bbe1d68758246b94db4b7171e1cdbdc09cefd4b0c"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c#cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -3607,8 +3606,7 @@ dependencies = [
 [[package]]
 name = "starknet-contract"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d858efc93d85de95065a5732cb3e94d0c746674964c0859aab442ffbb9de76b4"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c#cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c"
 dependencies = [
  "serde",
  "serde_json",
@@ -3621,9 +3619,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-core"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d35a5cd67067c6dee09defa3448d706fac988d58f4f1bef71d50a27d564d9cab"
+version = "0.7.2"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c#cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c"
 dependencies = [
  "base64 0.21.2",
  "flate2",
@@ -3634,7 +3631,7 @@ dependencies = [
  "serde_with",
  "sha3",
  "starknet-crypto 0.6.1",
- "starknet-ff",
+ "starknet-ff 0.3.5 (git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c)",
 ]
 
 [[package]]
@@ -3651,17 +3648,16 @@ dependencies = [
  "num-traits 0.2.15",
  "rfc6979",
  "sha2",
- "starknet-crypto-codegen",
+ "starknet-crypto-codegen 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet-curve 0.3.0",
- "starknet-ff",
+ "starknet-ff 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize",
 ]
 
 [[package]]
 name = "starknet-crypto"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c03f5ac70f9b067f48db7d2d70bdf18ee0f731e8192b6cfa679136becfcdb0"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c#cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c"
 dependencies = [
  "crypto-bigint",
  "hex",
@@ -3671,9 +3667,9 @@ dependencies = [
  "num-traits 0.2.15",
  "rfc6979",
  "sha2",
- "starknet-crypto-codegen",
- "starknet-curve 0.4.0",
- "starknet-ff",
+ "starknet-crypto-codegen 0.3.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c)",
+ "starknet-curve 0.4.0 (git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c)",
+ "starknet-ff 0.3.5 (git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c)",
  "zeroize",
 ]
 
@@ -3683,8 +3679,18 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af6527b845423542c8a16e060ea1bc43f67229848e7cd4c4d80be994a84220ce"
 dependencies = [
- "starknet-curve 0.4.0",
- "starknet-ff",
+ "starknet-curve 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-ff 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 2.0.28",
+]
+
+[[package]]
+name = "starknet-crypto-codegen"
+version = "0.3.2"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c#cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c"
+dependencies = [
+ "starknet-curve 0.4.0 (git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c)",
+ "starknet-ff 0.3.5 (git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c)",
  "syn 2.0.28",
 ]
 
@@ -3694,7 +3700,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252610baff59e4c4332ce3569f7469c5d3f9b415a2240d698fb238b2b4fc0942"
 dependencies = [
- "starknet-ff",
+ "starknet-ff 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3703,7 +3709,15 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68a0d87ae56572abf83ddbfd44259a7c90dbeeee1629a1ffe223e7f9a8f3052"
 dependencies = [
- "starknet-ff",
+ "starknet-ff 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "starknet-curve"
+version = "0.4.0"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c#cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c"
+dependencies = [
+ "starknet-ff 0.3.5 (git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c)",
 ]
 
 [[package]]
@@ -3711,6 +3725,17 @@ name = "starknet-ff"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7584bc732e4d2a8ccebdd1dda8236f7940a79a339e30ebf338d45c329659e36c"
+dependencies = [
+ "ark-ff",
+ "crypto-bigint",
+ "getrandom",
+ "hex",
+]
+
+[[package]]
+name = "starknet-ff"
+version = "0.3.5"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c#cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c"
 dependencies = [
  "ark-ff",
  "bigdecimal",
@@ -3723,8 +3748,7 @@ dependencies = [
 [[package]]
 name = "starknet-providers"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52072c2d258bf692affeccd602613d5f6c61a6ffc84da8f191ab4a1b0a5e24d1"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c#cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -3782,8 +3806,7 @@ dependencies = [
 [[package]]
 name = "starknet-signers"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "347b1bfc09846aafe16d2b3a5bc2d8a2f845e2958602442182d265fbd6011c2e"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c#cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -4289,7 +4312,7 @@ dependencies = [
  "serde_json",
  "starknet-core",
  "starknet-crypto 0.6.1",
- "starknet-ff",
+ "starknet-ff 0.3.5 (git+https://github.com/xJonathanLEI/starknet-rs?rev=cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c)",
  "starknet_api",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,13 +57,13 @@ regex_generate = "0.2.3"
 # Starknet dependencies
 starknet_api = { version = "0.6.0-rc0", features = ["testing"] }
 blockifier = { git = "https://github.com/starkware-libs/blockifier", rev = "v0.4.0-rc3", package = "blockifier" }
-starknet-rs-signers = { version = "0.5.0", package="starknet-signers" }
-starknet-rs-ff = { version = "0.3.5", package = "starknet-ff" }
-starknet-rs-core = {  version = "0.7.1", package = "starknet-core" }
-starknet-rs-providers = {  version = "0.7.0", package = "starknet-providers" }
-starknet-rs-accounts = { version = "0.6.0", package = "starknet-accounts" }
-starknet-rs-contract = { version = "0.6.0", package = "starknet-contract" }
-starknet-rs-crypto = { version = "0.6.1", package = "starknet-crypto" }
+starknet-rs-signers = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c", package="starknet-signers" }
+starknet-rs-ff = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c", package = "starknet-ff" }
+starknet-rs-core = {  git = "https://github.com/xJonathanLEI/starknet-rs", rev = "cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c", package = "starknet-core" }
+starknet-rs-providers = {  git = "https://github.com/xJonathanLEI/starknet-rs", rev = "cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c", package = "starknet-providers" }
+starknet-rs-accounts = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c", package = "starknet-accounts" }
+starknet-rs-contract = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c", package = "starknet-contract" }
+starknet-rs-crypto = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "cfa3c43e4c12ca3a45c471b233fe3eb5a2f31e0c", package = "starknet-crypto" }
 cairo-felt = { version = "0.8.5", package = "cairo-felt" }
 cairo-lang-starknet = { version = "2.3.1", package = "cairo-lang-starknet" }
 url = "2.4"

--- a/crates/starknet-server/tests/test_advancing_time.rs
+++ b/crates/starknet-server/tests/test_advancing_time.rs
@@ -22,7 +22,7 @@ mod advancing_time_tests {
 
     const DUMMY_ADDRESS: u128 = 1;
     const DUMMY_AMOUNT: u128 = 1;
-    const BUFFER_TIME_SECONDS: u64 = 10;
+    const BUFFER_TIME_SECONDS: u64 = 15;
 
     pub fn assert_ge_with_buffer(val1: Option<u64>, val2: Option<u64>) {
         assert!(val1 >= val2);

--- a/crates/starknet/src/starknet/add_invoke_transaction.rs
+++ b/crates/starknet/src/starknet/add_invoke_transaction.rs
@@ -271,8 +271,9 @@ mod tests {
             dummy_contract.clone(),
         )
         .unwrap();
-        let increase_balance_selector: StarkFelt =
-            get_selector_from_name("increase_balance").unwrap().into();
+        let increase_balance_selector =
+            StarkFelt::new(get_selector_from_name("increase_balance").unwrap().to_bytes_be())
+                .unwrap();
 
         // check if increase_balance function is present in the contract class
         blockifier

--- a/crates/starknet/src/utils.rs
+++ b/crates/starknet/src/utils.rs
@@ -20,7 +20,7 @@ pub(crate) fn get_storage_var_address(
 ) -> DevnetResult<StorageKey> {
     let storage_var_name_hash =
         starknet_rs_core::utils::starknet_keccak(storage_var_name.as_bytes());
-    let storage_var_name_hash = StarkFelt::from(storage_var_name_hash);
+    let storage_var_name_hash = StarkFelt::new(storage_var_name_hash.to_bytes_be())?;
 
     let storage_key_hash = args
         .iter()

--- a/crates/types/src/rpc/contract_class/deprecated/json_contract_class.rs
+++ b/crates/types/src/rpc/contract_class/deprecated/json_contract_class.rs
@@ -84,7 +84,8 @@ impl Cairo0Json {
         let mut serializer = JsonSerializer::with_formatter(&mut buffer, StarknetFormatter);
         modified_abi_program_json.serialize(&mut serializer).map_err(JsonError::SerdeJsonError)?;
 
-        Ok(StarkFelt::from(starknet_rs_core::utils::starknet_keccak(&buffer)))
+        let keccak = starknet_rs_core::utils::starknet_keccak(&buffer);
+        Ok(StarkFelt::new(keccak.to_bytes_be())?)
     }
 
     fn compute_cairo_0_contract_class_hash(json_class: &Value) -> crate::error::DevnetResult<Felt> {


### PR DESCRIPTION
## Usage related changes

- Users can declare using the latest version of starknet-py (0.18.3)

## Development related changes

- Update all crates of starknet-rs
- `StarkFelt::from(FieldElement)` not working anymore, I relied on `StarkFelt::new(FieldElement.to_bytes_be())`
- We have a flaky test
  - timestamp advancing test sometimes fails (our buffer time is not enough)
  - Increased buffer time from 10 to 15 s
  - Increased number of test jobs from 6 to 7

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Checked the TODO section in README.md if this PR resolves it
- [x] Updated the tests
- [x] All tests are passing - `cargo test`
