### PR TITLE
Support dump/load of L1HandlerTransactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,15 +224,16 @@ Currently, dumping produces a list of received transactions that is stored on di
 Conversely, loading is implemented as the re-execution of transactions from a dump.
 This means that timestamps of `StarknetBlock` will be different.
 
+### Loading disclaimer
+
+Dumping and loading is not guaranteed to work cross-version. I.e. if you dumped one version of Devnet, do not expect it to be loadable with a different version.
+If you dumped a Devnet utilizing one class for account predeployment (e.g. the default `--account-class cairo0`), you should use the same option when loading.
+
 ### Restarting
 
 Devnet can be restarted by making a `POST /restart` request (no body required). All of the deployed contracts (including predeployed), blocks and storage updates will be restarted to the original state, without the transactions and requests from a dump file you may have provided on startup.
 
 If you're using [**the Hardhat plugin**](https://github.com/0xSpaceShard/starknet-hardhat-plugin#restart), restart with `starknet.devnet.restart()`.
-
-### Cross-version disclaimer
-
-Dumping and loading is not guaranteed to work cross-version. I.e. if you dumped one version of Devnet, do not expect it to be loadable with a different version.
 
 ## Blocks
 

--- a/crates/starknet-server/tests/test_advancing_time.rs
+++ b/crates/starknet-server/tests/test_advancing_time.rs
@@ -31,7 +31,7 @@ mod advancing_time_tests {
     }
 
     pub fn assert_gt_with_buffer(val1: Option<u64>, val2: Option<u64>) {
-        assert!(val1 > val2, "Failed inequation: {val1:?} >= {val2:?}");
+        assert!(val1 > val2, "Failed inequation: {val1:?} > {val2:?}");
         let upper_limit = Some(val2.unwrap() + BUFFER_TIME_SECONDS);
         assert!(val1 <= upper_limit, "Failed inequation: {val1:?} < {upper_limit:?}");
     }

--- a/crates/starknet-server/tests/test_advancing_time.rs
+++ b/crates/starknet-server/tests/test_advancing_time.rs
@@ -25,11 +25,13 @@ mod advancing_time_tests {
     const BUFFER_TIME_SECONDS: u64 = 15;
 
     pub fn assert_ge_with_buffer(val1: Option<u64>, val2: Option<u64>) {
+        // TODO add print and use <=
         assert!(val1 >= val2);
         assert!(val1 < Some(val2.unwrap() + BUFFER_TIME_SECONDS));
     }
 
     pub fn assert_gt_with_buffer(val1: Option<u64>, val2: Option<u64>) {
+        // TODO add print and use <=
         assert!(val1 > val2);
         assert!(val1 < Some(val2.unwrap() + BUFFER_TIME_SECONDS));
     }
@@ -323,12 +325,8 @@ mod advancing_time_tests {
         // increase time and assert if it's greater/equal than start-time argument +
         // first_increase_time, check if it's inside buffer limit
         let first_increase_time: u64 = 1000;
-        let first_increase_time_body = Body::from(
-            json!({
-                "time": first_increase_time
-            })
-            .to_string(),
-        );
+        let first_increase_time_body =
+            Body::from(json!({ "time": first_increase_time }).to_string());
         devnet.post_json("/increase_time".into(), first_increase_time_body).await.unwrap();
         let first_increase_time_block = &devnet
             .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
@@ -341,12 +339,8 @@ mod advancing_time_tests {
         // increase the time a second time and assert if it's greater/equal than past_time +
         // first_increase_time + second_increase_time, check if it's inside buffer limit
         let second_increase_time: u64 = 100;
-        let second_increase_time_body = Body::from(
-            json!({
-                "time": second_increase_time
-            })
-            .to_string(),
-        );
+        let second_increase_time_body =
+            Body::from(json!({ "time": second_increase_time }).to_string());
         devnet.post_json("/increase_time".into(), second_increase_time_body).await.unwrap();
         let second_increase_time_block = &devnet
             .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
@@ -358,12 +352,7 @@ mod advancing_time_tests {
 
         // set time to be now and check if the latest block timestamp is greater/equal now, check if
         // it's inside buffer limit
-        let set_time_body = Body::from(
-            json!({
-                "time": now
-            })
-            .to_string(),
-        );
+        let set_time_body = Body::from(json!({ "time": now }).to_string());
         let resp_set_time = devnet.post_json("/set_time".into(), set_time_body).await.unwrap();
         let resp_body_set_time = get_json_body(resp_set_time).await;
         assert_eq!(resp_body_set_time["block_timestamp"], now);
@@ -389,12 +378,8 @@ mod advancing_time_tests {
         // increase the time a third time and assert if it's greater/equal than last empty block
         // timestamp + third_increase_time, check if it's inside buffer limit
         let third_increase_time: u64 = 10000;
-        let third_increase_time_body = Body::from(
-            json!({
-                "time": third_increase_time
-            })
-            .to_string(),
-        );
+        let third_increase_time_body =
+            Body::from(json!({ "time": third_increase_time }).to_string());
         devnet.post_json("/increase_time".into(), third_increase_time_body).await.unwrap();
         let third_increase_time_block = &devnet
             .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))

--- a/crates/starknet-server/tests/test_advancing_time.rs
+++ b/crates/starknet-server/tests/test_advancing_time.rs
@@ -25,15 +25,15 @@ mod advancing_time_tests {
     const BUFFER_TIME_SECONDS: u64 = 15;
 
     pub fn assert_ge_with_buffer(val1: Option<u64>, val2: Option<u64>) {
-        // TODO add print and use <=
-        assert!(val1 >= val2);
-        assert!(val1 < Some(val2.unwrap() + BUFFER_TIME_SECONDS));
+        assert!(val1 >= val2, "Failed inequation: {val1:?} >= {val2:?}");
+        let upper_limit = Some(val2.unwrap() + BUFFER_TIME_SECONDS);
+        assert!(val1 <= upper_limit, "Failed inequation: {val1:?} < {upper_limit:?}");
     }
 
     pub fn assert_gt_with_buffer(val1: Option<u64>, val2: Option<u64>) {
-        // TODO add print and use <=
-        assert!(val1 > val2);
-        assert!(val1 < Some(val2.unwrap() + BUFFER_TIME_SECONDS));
+        assert!(val1 > val2, "Failed inequation: {val1:?} >= {val2:?}");
+        let upper_limit = Some(val2.unwrap() + BUFFER_TIME_SECONDS);
+        assert!(val1 <= upper_limit, "Failed inequation: {val1:?} < {upper_limit:?}");
     }
 
     #[tokio::test]

--- a/crates/starknet-server/tests/test_dump_and_load.rs
+++ b/crates/starknet-server/tests/test_dump_and_load.rs
@@ -220,10 +220,10 @@ mod dump_and_load_tests {
     #[tokio::test]
     async fn dump_without_transaction() {
         // dump on exit
-        let dump_file_name = "dump_without_transaction";
+        let dump_file = UniqueAutoDeletableFile::new("dump_without_transaction");
         let devnet_dump = BackgroundDevnet::spawn_with_additional_args(&[
             "--dump-path",
-            dump_file_name,
+            &dump_file.path,
             "--dump-on",
             "exit",
         ])
@@ -234,10 +234,10 @@ mod dump_and_load_tests {
         std::thread::sleep(std::time::Duration::from_secs(1));
 
         // file should not be created if there are no transactions
-        if Path::new(dump_file_name).exists() {
+        if Path::new(&dump_file.path).exists() {
             panic!(
                 "Could find the dump file but there were no transactions to dump {}",
-                dump_file_name
+                &dump_file.path
             );
         }
     }

--- a/crates/starknet/src/error.rs
+++ b/crates/starknet/src/error.rs
@@ -48,12 +48,12 @@ pub enum Error {
     UnexpectedInternalError { msg: String },
     #[error("Failed to load ContractClass")]
     ContractClassLoadError,
-    #[error("Deserialization error of {obj_name}")]
-    DeserializationError { obj_name: String },
-    #[error("Serialization error of {obj_name}")]
-    SerializationError { obj_name: String },
-    #[error("Serialization not supported")]
-    SerializationNotSupported,
+    #[error("Deserialization error: {origin}")]
+    DeserializationError { origin: String },
+    #[error("Serialization error: {origin}")]
+    SerializationError { origin: String },
+    #[error("Serialization not supported: {obj_name}")]
+    SerializationNotSupported { obj_name: String },
     #[error("{tx_type}: max_fee cannot be zero")]
     MaxFeeZeroError { tx_type: String },
     #[error(transparent)]

--- a/scripts/install_foundry.sh
+++ b/scripts/install_foundry.sh
@@ -13,7 +13,7 @@ if [ -n "$CIRCLE_BRANCH" ]; then
 fi
 
 echo "Installing foundry"
-foundryup --version  nightly-fdad9fb0dde45d3476fc5d1fe6f40e8dc7c17caa
+foundryup --version  nightly-f460583ba4ea5fc7d3917eb071c544c1fbd3eadd
 
 # assert it works
 anvil --version


### PR DESCRIPTION
## Usage related changes

- #234 left this unimplemented

## Development related changes

- Since L1HandlerTransaction does special treatment of `paid_fee_on_l1` property, it required custom serialization and deserialization.
- Minor refactoring of one existing dumping test
- Improve serialization errors (better message)
- Improve testing of tx and tx receipt retrieval for L1HandlerTransaction
- Better error if timestamp tests fail

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Checked the TODO section in README.md if this PR resolves it
- [x] Updated the tests
- [x] All tests are passing - `cargo test`
