### PR TITLE
Increase buffer in advancing time tests to 30s

### DIFF
--- a/crates/starknet-server/tests/test_advancing_time.rs
+++ b/crates/starknet-server/tests/test_advancing_time.rs
@@ -22,18 +22,18 @@ mod advancing_time_tests {
 
     const DUMMY_ADDRESS: u128 = 1;
     const DUMMY_AMOUNT: u128 = 1;
-    const BUFFER_TIME_SECONDS: u64 = 15;
+    const BUFFER_TIME_SECONDS: u64 = 30;
 
     pub fn assert_ge_with_buffer(val1: Option<u64>, val2: Option<u64>) {
         assert!(val1 >= val2, "Failed inequation: {val1:?} >= {val2:?}");
         let upper_limit = Some(val2.unwrap() + BUFFER_TIME_SECONDS);
-        assert!(val1 <= upper_limit, "Failed inequation: {val1:?} < {upper_limit:?}");
+        assert!(val1 <= upper_limit, "Failed inequation: {val1:?} <= {upper_limit:?}");
     }
 
     pub fn assert_gt_with_buffer(val1: Option<u64>, val2: Option<u64>) {
         assert!(val1 > val2, "Failed inequation: {val1:?} > {val2:?}");
         let upper_limit = Some(val2.unwrap() + BUFFER_TIME_SECONDS);
-        assert!(val1 <= upper_limit, "Failed inequation: {val1:?} < {upper_limit:?}");
+        assert!(val1 <= upper_limit, "Failed inequation: {val1:?} <= {upper_limit:?}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Usage related changes

N/A

## Development related changes

- Fix error message
- Hopefully closes #279

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Checked the TODO section in README.md if this PR resolves it
- [x] Updated the tests
- [x] All tests are passing - `cargo test`
