### PR TITLE
Update README.md: old rpc support [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,13 +156,17 @@ $ docker run -e RUST_LOG=<LEVEL> shardlabs/starknet-devnet-rs
 
 ## API
 
-Unlike Pythonic Devnet, which supported the gateway and feeder gateway API, Devnet in Rust only supports JSON-RPC, which at the time of writing this is synchronized with [specification v0.4.0](https://github.com/starkware-libs/starknet-specs/tree/v0.4.0/api).
+Unlike Pythonic Devnet, which supported the gateway and feeder gateway API, Devnet in Rust only supports JSON-RPC, which at the time of writing this is synchronized with [specification v0.6.0](https://github.com/starkware-libs/starknet-specs/tree/v0.6.0/api).
+
+Below is the list of old RPC versions supported by Devnet, usable as git tags or branches. A `branch` indicates the revision is maintained with bugfix support.
+
+- `json-rpc-v0.4.0` - tag
+- `json-rpc-v0.5.0` - tag
+- `json-rpc-v0.5.1` - branch
+
+These revisions should be used with `git checkout <REVISION>`.
 
 The JSON-RPC API is reachable via `/rpc` and `/` (e.g. if spawning Devnet with default settings, these URLs have the equivalent functionality: `http://127.0.0.1:5050/rpc` and `http://127.0.0.1:5050/`)
-
-> **Note:**
->
-> Out of Starknet **trace** API RPC methods, only `starknet_simulateTransactions` is supported.
 
 ## Predeployed contracts
 


### PR DESCRIPTION
## Usage related changes

- Document old RPC version support

## Development related changes

N/A

## Checklist:

- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
- [ ] Performed code self-review
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Documented the changes
- [ ] Linked the issues which this PR resolves
- [ ] Checked the TODO section in README.md if this PR resolves it
- [ ] Updated the tests
- [ ] All tests are passing - `cargo test`
