### PR TITLE
Use flate2 >=1.0.26, <1.0.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2194,9 +2194,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
  "miniz_oxide",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 # misc
 base64 = { version = "0.21.2" }
 clap = { version = "4.3.2", features = ["derive"] }
-flate2 = { version = "1.0.26" }
+flate2 = { version = ">= 1.0.26, < 1.0.27" }
 serde = { version = "1.0.171", features = ["derive"] }
 serde_json = { version = "1.0.81" }
 serde_yaml = { version = "0.9.27" }


### PR DESCRIPTION
## Usage related changes

- Close #293 

## Development related changes

- Change version of flate2 (used in gzipping cairo0 artifacts)

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Checked the TODO section in README.md if this PR resolves it
- [x] Updated the tests
- [ ] All tests are passing - `cargo test`
