### PR TITLE
Refactor transaction trace creation and fetching

### DIFF
--- a/crates/starknet-devnet-cli/tests/test_messaging.rs
+++ b/crates/starknet-devnet-cli/tests/test_messaging.rs
@@ -179,7 +179,7 @@ mod test_messaging {
         );
         assert_eq!(traces["function_invocation"]["entry_point_selector"], L1_HANDLER_SELECTOR);
         assert_eq!(traces["function_invocation"]["calldata"][0], MESSAGING_L1_CONTRACT_ADDRESS);
-        assert!(traces["state_diff"].is_null());
+        assert!(traces["state_diff"].is_object());
     }
 
     #[tokio::test]

--- a/crates/starknet-devnet-core/src/error.rs
+++ b/crates/starknet-devnet-core/src/error.rs
@@ -66,8 +66,8 @@ pub enum Error {
     TransactionFeeError(#[from] blockifier::transaction::errors::TransactionFeeError),
     #[error(transparent)]
     MessagingError(#[from] MessagingError),
-    #[error("Missing L1 handler transaction trace.")]
-    MissingL1HandlerTransactionTrace,
+    #[error("Transaction has no trace")]
+    NoTransactionTrace,
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
## Usage related changes

- None

## Development related changes

- Create trace upon tx execution, instead of on request.
- Important for #195 
- This will only create the trace once, instead of creating it on each request. So it will also create the trace of the txs whose trace might never be requested.
- Store `trace` as property of our `StarknetTransaction`.
- Renamed `MissingL1HandlerTransactionTrace` to `NoTransactionTrace`

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Checked the TODO section in README.md if this PR resolves it
- [x] Updated the tests
- [x] All tests are passing - `cargo test`
