### PR TITLE
Update CircleCI config.yml to use docker23

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.7
+          version: docker23
       - run:
           name: Build amd images
           command: ./docker/image_build.sh
@@ -104,7 +104,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.7
+          version: docker23
       - run:
           name: Create and push joint image manifest
           command: ./docker/create_joint_image_manifest.sh


### PR DESCRIPTION
## Usage related changes

- None

## Development related changes

- After looking at a recent CircleCI run, I realized our current Docker version is [deprecated](https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176) so I updated it, according to the linked instructions, to docker23.

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Checked the TODO section in README.md if this PR resolves it
- [x] Updated the tests
- [x] All tests are passing - `cargo test`
