### PR TITLE
Use create_trace in simulate_transactions

### DIFF
--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -370,13 +370,11 @@ impl Starknet {
     ) -> DevnetResult<()> {
         let state_diff = self.state.extract_state_diff_from_pending_state()?;
 
-        let address_to_class_hash = &self.state.state.state.address_to_class_hash;
-
         let trace = Self::create_trace(
             transaction.get_type(),
             &tx_info,
             state_diff.clone().into(),
-            address_to_class_hash,
+            &self.state.state.state.address_to_class_hash,
         )?;
         let transaction_to_add = StarknetTransaction::create_accepted(transaction, tx_info, trace);
 
@@ -984,12 +982,11 @@ impl Starknet {
             )?;
 
             let state_diff: ThinStateDiff = state.extract_state_diff_from_pending_state()?.into();
-            let address_to_class_hash = &state.state.state.address_to_class_hash;
             let trace = Self::create_trace(
                 broadcasted_transaction.get_type(),
                 &tx_execution_info,
                 state_diff,
-                address_to_class_hash,
+                &state.state.state.address_to_class_hash,
             )?;
             transactions_traces.push(trace);
         }

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -984,53 +984,13 @@ impl Starknet {
             )?;
 
             let state_diff: ThinStateDiff = state.extract_state_diff_from_pending_state()?.into();
-            let state_diff =
-                if state_diff == ThinStateDiff::default() { None } else { Some(state_diff) };
-
-            let address_to_class_hash_map = &state.state.state.address_to_class_hash;
-
-            let validate_invocation = Self::get_call_info_invocation(
-                &tx_execution_info.validate_call_info,
-                address_to_class_hash_map,
+            let address_to_class_hash = &state.state.state.address_to_class_hash;
+            let trace = Self::create_trace(
+                broadcasted_transaction.get_type(),
+                &tx_execution_info,
+                state_diff,
+                address_to_class_hash,
             )?;
-
-            let fee_transfer_invocation = Self::get_call_info_invocation(
-                &tx_execution_info.fee_transfer_call_info,
-                address_to_class_hash_map,
-            )?;
-
-            let trace = match broadcasted_transaction {
-                BroadcastedTransaction::Declare(_) => {
-                    TransactionTrace::Declare(DeclareTransactionTrace {
-                        validate_invocation,
-                        fee_transfer_invocation,
-                        state_diff,
-                    })
-                }
-                BroadcastedTransaction::DeployAccount(_) => {
-                    TransactionTrace::DeployAccount(DeployAccountTransactionTrace {
-                        validate_invocation,
-                        constructor_invocation: Self::get_call_info_invocation(
-                            &tx_execution_info.execute_call_info,
-                            address_to_class_hash_map,
-                        )?,
-                        fee_transfer_invocation,
-                        state_diff,
-                    })
-                }
-                BroadcastedTransaction::Invoke(_) => {
-                    TransactionTrace::Invoke(InvokeTransactionTrace {
-                        fee_transfer_invocation,
-                        validate_invocation,
-                        state_diff,
-                        execute_invocation: Self::get_execute_call_info(
-                            &tx_execution_info,
-                            address_to_class_hash_map,
-                        )?,
-                    })
-                }
-            };
-
             transactions_traces.push(trace);
         }
 

--- a/crates/starknet-devnet-types/src/rpc/transactions.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions.rs
@@ -512,6 +512,14 @@ impl BroadcastedTransaction {
 
         Ok(blockifier_transaction)
     }
+
+    pub fn get_type(&self) -> TransactionType {
+        match self {
+            BroadcastedTransaction::Invoke(_) => TransactionType::Invoke,
+            BroadcastedTransaction::Declare(_) => TransactionType::Declare,
+            BroadcastedTransaction::DeployAccount(_) => TransactionType::DeployAccount,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/scripts/clippy_check.sh
+++ b/scripts/clippy_check.sh
@@ -1,2 +1,6 @@
+#!/bin/bash
+
+set -eu
+
 cargo clippy --all -- -D warnings
 cargo clippy --tests -- -D warnings

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,2 +1,5 @@
-cargo +nightly fmt --all
+#!/bin/bash
 
+set -eu
+
+cargo +nightly fmt --all


### PR DESCRIPTION
## Usage related changes

- None

## Development related changes

- #321 didn't apply the refactor on the trace creation part of transaction simulation. This PR does it.
- Fix format and clippy scripts

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Checked the TODO section in README.md if this PR resolves it
- [x] Updated the tests
- [x] All tests are passing - `cargo test`
