### PR TITLE
In trace creation, read from state instead of map

### DIFF
--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -370,12 +370,8 @@ impl Starknet {
     ) -> DevnetResult<()> {
         let state_diff = self.state.extract_state_diff_from_pending_state()?;
 
-        let trace = Self::create_trace(
-            transaction.get_type(),
-            &tx_info,
-            state_diff.clone().into(),
-            &self.state.state.state.address_to_class_hash,
-        )?;
+        let trace =
+            self.create_trace(transaction.get_type(), &tx_info, state_diff.clone().into())?;
         let transaction_to_add = StarknetTransaction::create_accepted(transaction, tx_info, trace);
 
         // add accepted transaction to pending block
@@ -806,14 +802,14 @@ impl Starknet {
     }
 
     fn get_execute_call_info(
+        &mut self,
         execution_info: &TransactionExecutionInfo,
-        address_to_class_hash_map: &HashMap<ContractAddress, ClassHash>,
     ) -> DevnetResult<ExecutionInvocation> {
         Ok(match &execution_info.execute_call_info {
             Some(call_info) => match call_info.execution.failed {
                 false => ExecutionInvocation::Succeeded(FunctionInvocation::try_from_call_info(
                     call_info,
-                    address_to_class_hash_map,
+                    &mut self.state.state,
                 )?),
                 true => {
                     ExecutionInvocation::Reverted(starknet_types::rpc::transactions::Reversion {
@@ -840,21 +836,17 @@ impl Starknet {
     }
 
     pub(crate) fn create_trace(
+        &mut self,
         tx_type: TransactionType,
         execution_info: &TransactionExecutionInfo,
         state_diff: ThinStateDiff,
-        address_to_class_hash: &HashMap<ContractAddress, ClassHash>,
     ) -> DevnetResult<TransactionTrace> {
         let state_diff = Some(state_diff);
-        let validate_invocation = Self::get_call_info_invocation(
-            &execution_info.validate_call_info,
-            address_to_class_hash,
-        )?;
+        let validate_invocation =
+            self.get_call_info_invocation(&execution_info.validate_call_info)?;
 
-        let fee_transfer_invocation = Self::get_call_info_invocation(
-            &execution_info.fee_transfer_call_info,
-            address_to_class_hash,
-        )?;
+        let fee_transfer_invocation =
+            self.get_call_info_invocation(&execution_info.fee_transfer_call_info)?;
 
         match tx_type {
             TransactionType::Declare => Ok(TransactionTrace::Declare(DeclareTransactionTrace {
@@ -865,28 +857,20 @@ impl Starknet {
             TransactionType::DeployAccount => {
                 Ok(TransactionTrace::DeployAccount(DeployAccountTransactionTrace {
                     validate_invocation,
-                    constructor_invocation: Self::get_call_info_invocation(
-                        &execution_info.execute_call_info,
-                        address_to_class_hash,
-                    )?,
+                    constructor_invocation: self
+                        .get_call_info_invocation(&execution_info.execute_call_info)?,
                     fee_transfer_invocation,
                     state_diff,
                 }))
             }
             TransactionType::Invoke => Ok(TransactionTrace::Invoke(InvokeTransactionTrace {
                 validate_invocation,
-                execute_invocation: Self::get_execute_call_info(
-                    execution_info,
-                    address_to_class_hash,
-                )?,
+                execute_invocation: self.get_execute_call_info(execution_info)?,
                 fee_transfer_invocation,
                 state_diff,
             })),
             TransactionType::L1Handler => {
-                match Self::get_call_info_invocation(
-                    &execution_info.execute_call_info,
-                    address_to_class_hash,
-                )? {
+                match self.get_call_info_invocation(&execution_info.execute_call_info)? {
                     Some(function_invocation) => {
                         Ok(TransactionTrace::L1Handler(L1HandlerTransactionTrace {
                             function_invocation,
@@ -901,11 +885,11 @@ impl Starknet {
     }
 
     fn get_call_info_invocation(
+        &mut self,
         call_info_invocation: &Option<CallInfo>,
-        address_to_class_hash_map: &HashMap<ContractAddress, ClassHash>,
     ) -> DevnetResult<Option<FunctionInvocation>> {
         Ok(if let Some(call_info) = call_info_invocation {
-            Some(FunctionInvocation::try_from_call_info(call_info, address_to_class_hash_map)?)
+            Some(FunctionInvocation::try_from_call_info(call_info, &mut self.state.state)?)
         } else {
             None
         })
@@ -950,7 +934,7 @@ impl Starknet {
     }
 
     pub fn simulate_transactions(
-        &self,
+        &mut self,
         block_id: BlockId,
         transactions: &[BroadcastedTransaction],
         simulation_flags: Vec<SimulationFlag>,
@@ -982,11 +966,10 @@ impl Starknet {
             )?;
 
             let state_diff: ThinStateDiff = state.extract_state_diff_from_pending_state()?.into();
-            let trace = Self::create_trace(
+            let trace = self.create_trace(
                 broadcasted_transaction.get_type(),
                 &tx_execution_info,
                 state_diff,
-                &state.state.state.address_to_class_hash,
             )?;
             transactions_traces.push(trace);
         }

--- a/crates/starknet-devnet-core/src/transactions.rs
+++ b/crates/starknet-devnet-core/src/transactions.rs
@@ -287,10 +287,10 @@ mod tests {
 
     fn dummy_trace(tx: &Transaction) -> TransactionTrace {
         Starknet::create_trace(
+            &mut Default::default(),
             tx.get_type(),
             &Default::default(),
             Default::default(),
-            &Default::default(),
         )
         .unwrap()
     }

--- a/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
@@ -363,7 +363,8 @@ impl JsonRpcHandler {
         transactions: Vec<BroadcastedTransaction>,
         simulation_flags: Vec<SimulationFlag>,
     ) -> StrictRpcResult {
-        let starknet = self.api.starknet.read().await;
+        // borrowing as write/mutable because trace calculation requires so
+        let mut starknet = self.api.starknet.write().await;
         match starknet.simulate_transactions(block_id.into(), &transactions, simulation_flags) {
             Ok(result) => Ok(StarknetResponse::SimulateTransactions(result)),
             Err(Error::ContractNotFound) => Err(ApiError::ContractNotFound),


### PR DESCRIPTION
## Usage related changes

- None

## Development related changes

- Need it for #195
- Tx simulation now requires locking/borrowing Starknet as mutable. This is because reading from StateReader requires passing a `&mut self`. We need this because we need to read from the state, and not from state properties, because with forking, different reader implementations (regular and forked) will have different internal properties, so we can't rely on that.

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Checked the TODO section in README.md if this PR resolves it
- [x] Updated the tests
- [ ] All tests are passing - `cargo test`
