### PR TITLE
Move trace calculation; refactor from method to function

### DIFF
--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use blockifier::block_context::BlockContext;
 use blockifier::execution::call_info::CallInfo;
 use blockifier::execution::entry_point::CallEntryPoint;
+use blockifier::state::cached_state::CachedState;
 use blockifier::state::state_api::StateReader;
 use blockifier::transaction::errors::TransactionPreValidationError;
 use blockifier::transaction::objects::TransactionExecutionInfo;
@@ -391,8 +392,12 @@ impl Starknet {
     ) -> DevnetResult<()> {
         let state_diff = self.state.extract_state_diff_from_pending_state()?;
 
-        let trace =
-            self.create_trace(transaction.get_type(), &tx_info, state_diff.clone().into())?;
+        let trace = Self::create_trace(
+            &mut self.state.state,
+            transaction.get_type(),
+            &tx_info,
+            state_diff.clone().into(),
+        )?;
         let transaction_to_add = StarknetTransaction::create_accepted(transaction, tx_info, trace);
 
         // add accepted transaction to pending block
@@ -822,15 +827,14 @@ impl Starknet {
         transaction_to_map.get_receipt()
     }
 
-    fn get_execute_call_info(
-        &mut self,
+    fn get_execute_call_info<S: StateReader>(
+        state: &mut CachedState<S>,
         execution_info: &TransactionExecutionInfo,
     ) -> DevnetResult<ExecutionInvocation> {
         Ok(match &execution_info.execute_call_info {
             Some(call_info) => match call_info.execution.failed {
                 false => ExecutionInvocation::Succeeded(FunctionInvocation::try_from_call_info(
-                    call_info,
-                    &mut self.state.state,
+                    call_info, state,
                 )?),
                 true => {
                     ExecutionInvocation::Reverted(starknet_types::rpc::transactions::Reversion {
@@ -856,18 +860,18 @@ impl Starknet {
         })
     }
 
-    pub(crate) fn create_trace(
-        &mut self,
+    pub(crate) fn create_trace<S: StateReader>(
+        state: &mut CachedState<S>,
         tx_type: TransactionType,
         execution_info: &TransactionExecutionInfo,
         state_diff: ThinStateDiff,
     ) -> DevnetResult<TransactionTrace> {
         let state_diff = Some(state_diff);
         let validate_invocation =
-            self.get_call_info_invocation(&execution_info.validate_call_info)?;
+            Self::get_call_info_invocation(state, &execution_info.validate_call_info)?;
 
         let fee_transfer_invocation =
-            self.get_call_info_invocation(&execution_info.fee_transfer_call_info)?;
+            Self::get_call_info_invocation(state, &execution_info.fee_transfer_call_info)?;
 
         match tx_type {
             TransactionType::Declare => Ok(TransactionTrace::Declare(DeclareTransactionTrace {
@@ -878,20 +882,22 @@ impl Starknet {
             TransactionType::DeployAccount => {
                 Ok(TransactionTrace::DeployAccount(DeployAccountTransactionTrace {
                     validate_invocation,
-                    constructor_invocation: self
-                        .get_call_info_invocation(&execution_info.execute_call_info)?,
+                    constructor_invocation: Self::get_call_info_invocation(
+                        state,
+                        &execution_info.execute_call_info,
+                    )?,
                     fee_transfer_invocation,
                     state_diff,
                 }))
             }
             TransactionType::Invoke => Ok(TransactionTrace::Invoke(InvokeTransactionTrace {
                 validate_invocation,
-                execute_invocation: self.get_execute_call_info(execution_info)?,
+                execute_invocation: Self::get_execute_call_info(state, execution_info)?,
                 fee_transfer_invocation,
                 state_diff,
             })),
             TransactionType::L1Handler => {
-                match self.get_call_info_invocation(&execution_info.execute_call_info)? {
+                match Self::get_call_info_invocation(state, &execution_info.execute_call_info)? {
                     Some(function_invocation) => {
                         Ok(TransactionTrace::L1Handler(L1HandlerTransactionTrace {
                             function_invocation,
@@ -905,12 +911,12 @@ impl Starknet {
         }
     }
 
-    fn get_call_info_invocation(
-        &mut self,
+    fn get_call_info_invocation<S: StateReader>(
+        state: &mut CachedState<S>,
         call_info_invocation: &Option<CallInfo>,
     ) -> DevnetResult<Option<FunctionInvocation>> {
         Ok(if let Some(call_info) = call_info_invocation {
-            Some(FunctionInvocation::try_from_call_info(call_info, &mut self.state.state)?)
+            Some(FunctionInvocation::try_from_call_info(call_info, state)?)
         } else {
             None
         })
@@ -987,7 +993,8 @@ impl Starknet {
             )?;
 
             let state_diff: ThinStateDiff = state.extract_state_diff_from_pending_state()?.into();
-            let trace = self.create_trace(
+            let trace = Self::create_trace(
+                &mut state.state,
                 broadcasted_transaction.get_type(),
                 &tx_execution_info,
                 state_diff,

--- a/crates/starknet-devnet-core/src/starknet/transaction_trace.rs
+++ b/crates/starknet-devnet-core/src/starknet/transaction_trace.rs
@@ -1,0 +1,104 @@
+use blockifier::execution::call_info::CallInfo;
+use blockifier::state::cached_state::CachedState;
+use blockifier::state::state_api::StateReader;
+use blockifier::transaction::objects::TransactionExecutionInfo;
+use starknet_types::rpc::state::ThinStateDiff;
+use starknet_types::rpc::transactions::{
+    DeclareTransactionTrace, DeployAccountTransactionTrace, ExecutionInvocation,
+    FunctionInvocation, InvokeTransactionTrace, L1HandlerTransactionTrace, TransactionTrace,
+    TransactionType,
+};
+
+use crate::error::{DevnetResult, Error};
+
+fn get_execute_call_info<S: StateReader>(
+    state: &mut CachedState<S>,
+    execution_info: &TransactionExecutionInfo,
+) -> DevnetResult<ExecutionInvocation> {
+    Ok(match &execution_info.execute_call_info {
+        Some(call_info) => match call_info.execution.failed {
+            false => ExecutionInvocation::Succeeded(FunctionInvocation::try_from_call_info(
+                call_info, state,
+            )?),
+            true => ExecutionInvocation::Reverted(starknet_types::rpc::transactions::Reversion {
+                revert_reason: execution_info
+                    .revert_error
+                    .clone()
+                    .unwrap_or("Revert reason not found".into()),
+            }),
+        },
+        None => match execution_info.revert_error.clone() {
+            Some(revert_reason) => {
+                ExecutionInvocation::Reverted(starknet_types::rpc::transactions::Reversion {
+                    revert_reason,
+                })
+            }
+            None => {
+                return Err(Error::UnexpectedInternalError {
+                    msg: "Simulation contains neither call_info nor revert_error".into(),
+                });
+            }
+        },
+    })
+}
+
+fn get_call_info_invocation<S: StateReader>(
+    state: &mut CachedState<S>,
+    call_info_invocation: &Option<CallInfo>,
+) -> DevnetResult<Option<FunctionInvocation>> {
+    Ok(if let Some(call_info) = call_info_invocation {
+        Some(FunctionInvocation::try_from_call_info(call_info, state)?)
+    } else {
+        None
+    })
+}
+
+pub(crate) fn create_trace<S: StateReader>(
+    state: &mut CachedState<S>,
+    tx_type: TransactionType,
+    execution_info: &TransactionExecutionInfo,
+    state_diff: ThinStateDiff,
+) -> DevnetResult<TransactionTrace> {
+    let state_diff = Some(state_diff);
+    let validate_invocation = get_call_info_invocation(state, &execution_info.validate_call_info)?;
+
+    let fee_transfer_invocation =
+        get_call_info_invocation(state, &execution_info.fee_transfer_call_info)?;
+
+    match tx_type {
+        TransactionType::Declare => Ok(TransactionTrace::Declare(DeclareTransactionTrace {
+            validate_invocation,
+            fee_transfer_invocation,
+            state_diff,
+        })),
+        TransactionType::DeployAccount => {
+            Ok(TransactionTrace::DeployAccount(DeployAccountTransactionTrace {
+                validate_invocation,
+                constructor_invocation: get_call_info_invocation(
+                    state,
+                    &execution_info.execute_call_info,
+                )?,
+                fee_transfer_invocation,
+                state_diff,
+            }))
+        }
+        TransactionType::Invoke => Ok(TransactionTrace::Invoke(InvokeTransactionTrace {
+            validate_invocation,
+            execute_invocation: get_execute_call_info(state, execution_info)?,
+            fee_transfer_invocation,
+            state_diff,
+        })),
+        TransactionType::L1Handler => {
+            match get_call_info_invocation(state, &execution_info.execute_call_info)? {
+                Some(function_invocation) => {
+                    Ok(TransactionTrace::L1Handler(L1HandlerTransactionTrace {
+                        function_invocation,
+                        state_diff,
+                    }))
+                }
+                _ => Err(Error::NoTransactionTrace),
+            }
+        }
+        _ => Err(Error::UnsupportedTransactionType),
+    }
+}

--- a/crates/starknet-devnet-core/src/transactions.rs
+++ b/crates/starknet-devnet-core/src/transactions.rs
@@ -281,12 +281,12 @@ mod tests {
     use starknet_types::traits::HashProducer;
 
     use super::{StarknetTransaction, StarknetTransactions};
-    use crate::starknet::Starknet;
+    use crate::starknet::transaction_trace::create_trace;
     use crate::traits::HashIdentifiedMut;
     use crate::utils::test_utils::dummy_declare_transaction_v1;
 
     fn dummy_trace(tx: &Transaction) -> TransactionTrace {
-        Starknet::create_trace(
+        create_trace(
             &mut Default::default(),
             tx.get_type(),
             &Default::default(),


### PR DESCRIPTION
## Usage related changes

None

## Development related changes

- Move trace calculation to a separate module
- Replace `Starknet` self param with `CachedState` param in trace creation
- Body of `create_trace` is basically unmodified, just moved

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Checked the TODO section in README.md if this PR resolves it
- [x] Updated the tests
- [x] All tests are passing - `cargo test`
