### PR TITLE
Removed partially custom BlockId implementation

### DIFF
--- a/crates/starknet-devnet-core/src/blocks/mod.rs
+++ b/crates/starknet-devnet-core/src/blocks/mod.rs
@@ -70,10 +70,10 @@ impl StarknetBlocks {
         self.num_to_state.insert(block_number, state);
     }
 
-    pub fn get_by_block_id(&self, block_id: BlockId) -> Option<&StarknetBlock> {
+    pub fn get_by_block_id(&self, block_id: &BlockId) -> Option<&StarknetBlock> {
         match block_id {
             BlockId::Hash(hash) => self.get_by_hash(Felt::from(hash)),
-            BlockId::Number(block_number) => self.num_to_block.get(&BlockNumber(block_number)),
+            BlockId::Number(block_number) => self.num_to_block.get(&BlockNumber(*block_number)),
             // latest and pending for now will return the latest one
             BlockId::Tag(_) => {
                 if let Some(hash) = self.last_block_hash {
@@ -86,7 +86,7 @@ impl StarknetBlocks {
     }
 
     /// Returns the block number from a block id, by finding the block by the block id
-    fn block_number_from_block_id(&self, block_id: BlockId) -> Option<BlockNumber> {
+    fn block_number_from_block_id(&self, block_id: &BlockId) -> Option<BlockNumber> {
         self.get_by_block_id(block_id).map(|block| block.block_number())
     }
 
@@ -107,7 +107,7 @@ impl StarknetBlocks {
         let starting_block = if let Some(block_id) = from {
             // If the value for block number provided is not correct it will return None
             // So we have to return an error
-            let block_number = self.block_number_from_block_id(block_id).ok_or(Error::NoBlock)?;
+            let block_number = self.block_number_from_block_id(&block_id).ok_or(Error::NoBlock)?;
             Some(block_number)
         } else {
             None
@@ -116,7 +116,7 @@ impl StarknetBlocks {
         let ending_block = if let Some(block_id) = to {
             // if the value for block number provided is not correct it will return None
             // So we set the block number to the first possible block number which is 0
-            let block_number = self.block_number_from_block_id(block_id).ok_or(Error::NoBlock)?;
+            let block_number = self.block_number_from_block_id(&block_id).ok_or(Error::NoBlock)?;
             Some(block_number)
         } else {
             None
@@ -295,12 +295,14 @@ mod tests {
         // latest/pending block returns none, because collection is empty
         assert!(
             blocks
-                .block_number_from_block_id(BlockId::Tag(starknet_rs_core::types::BlockTag::Latest))
+                .block_number_from_block_id(&BlockId::Tag(
+                    starknet_rs_core::types::BlockTag::Latest
+                ))
                 .is_none()
         );
         assert!(
             blocks
-                .block_number_from_block_id(BlockId::Tag(
+                .block_number_from_block_id(&BlockId::Tag(
                     starknet_rs_core::types::BlockTag::Pending
                 ))
                 .is_none()
@@ -313,23 +315,25 @@ mod tests {
         blocks.insert(block_to_insert, StateDiff::default());
 
         // returns block number, even if the block number is not present in the collection
-        assert!(blocks.block_number_from_block_id(BlockId::Number(11)).is_none());
-        assert!(blocks.block_number_from_block_id(BlockId::Number(10)).is_some());
+        assert!(blocks.block_number_from_block_id(&BlockId::Number(11)).is_none());
+        assert!(blocks.block_number_from_block_id(&BlockId::Number(10)).is_some());
         // returns none because there is no block with the given hash
-        assert!(blocks.block_number_from_block_id(BlockId::Hash(Felt::from(1).into())).is_none());
+        assert!(blocks.block_number_from_block_id(&BlockId::Hash(Felt::from(1).into())).is_none());
         assert!(
             blocks
-                .block_number_from_block_id(BlockId::Tag(starknet_rs_core::types::BlockTag::Latest))
+                .block_number_from_block_id(&BlockId::Tag(
+                    starknet_rs_core::types::BlockTag::Latest
+                ))
                 .is_some()
         );
         assert!(
             blocks
-                .block_number_from_block_id(BlockId::Tag(
+                .block_number_from_block_id(&BlockId::Tag(
                     starknet_rs_core::types::BlockTag::Pending
                 ))
                 .is_some()
         );
-        assert!(blocks.block_number_from_block_id(BlockId::Hash(block_hash.into())).is_some());
+        assert!(blocks.block_number_from_block_id(&BlockId::Hash(block_hash.into())).is_some());
     }
 
     #[test]
@@ -611,24 +615,24 @@ mod tests {
 
         blocks.insert(block_to_insert.clone(), StateDiff::default());
 
-        let extracted_block = blocks.get_by_block_id(BlockId::Number(10)).unwrap();
+        let extracted_block = blocks.get_by_block_id(&BlockId::Number(10)).unwrap();
         assert!(block_to_insert == extracted_block.clone());
 
         let extracted_block =
-            blocks.get_by_block_id(BlockId::Hash(block_to_insert.block_hash().into())).unwrap();
+            blocks.get_by_block_id(&BlockId::Hash(block_to_insert.block_hash().into())).unwrap();
         assert!(block_to_insert == extracted_block.clone());
 
         let extracted_block = blocks
-            .get_by_block_id(BlockId::Tag(starknet_rs_core::types::BlockTag::Latest))
+            .get_by_block_id(&BlockId::Tag(starknet_rs_core::types::BlockTag::Latest))
             .unwrap();
         assert!(block_to_insert == extracted_block.clone());
 
         let extracted_block = blocks
-            .get_by_block_id(BlockId::Tag(starknet_rs_core::types::BlockTag::Pending))
+            .get_by_block_id(&BlockId::Tag(starknet_rs_core::types::BlockTag::Pending))
             .unwrap();
         assert!(block_to_insert == extracted_block.clone());
 
-        match blocks.get_by_block_id(BlockId::Number(11)) {
+        match blocks.get_by_block_id(&BlockId::Number(11)) {
             None => (),
             _ => panic!("Expected none"),
         }

--- a/crates/starknet-devnet-core/src/starknet/estimations.rs
+++ b/crates/starknet-devnet-core/src/starknet/estimations.rs
@@ -46,11 +46,11 @@ pub fn estimate_fee(
 
 pub fn estimate_message_fee(
     starknet: &Starknet,
-    block_id: BlockId,
+    block_id: &BlockId,
     message: MsgFromL1,
 ) -> DevnetResult<FeeEstimateWrapper> {
-    let estimate_message_fee = EstimateMessageFeeRequestWrapper::new(block_id, message);
-    let mut state = starknet.get_state_at(estimate_message_fee.get_raw_block_id())?.clone();
+    let estimate_message_fee = EstimateMessageFeeRequestWrapper::new(*block_id, message);
+    let mut state = starknet.get_state_at(block_id)?.clone();
 
     match starknet
         .get_class_hash_at(block_id, ContractAddress::new(estimate_message_fee.get_to_address())?)

--- a/crates/starknet-devnet-core/src/starknet/estimations.rs
+++ b/crates/starknet-devnet-core/src/starknet/estimations.rs
@@ -15,12 +15,12 @@ use crate::state::StarknetState;
 
 pub fn estimate_fee(
     starknet: &Starknet,
-    block_id: BlockId,
+    block_id: &BlockId,
     transactions: &[BroadcastedTransaction],
     charge_fee: Option<bool>,
     validate: Option<bool>,
 ) -> DevnetResult<Vec<FeeEstimateWrapper>> {
-    let mut state = starknet.get_state_at(&block_id)?.clone();
+    let mut state = starknet.get_state_at(block_id)?.clone();
     let chain_id = starknet.chain_id().to_felt();
 
     let transactions = transactions

--- a/crates/starknet-devnet-core/src/starknet/get_class_impls.rs
+++ b/crates/starknet-devnet-core/src/starknet/get_class_impls.rs
@@ -9,10 +9,10 @@ use crate::traits::DevnetStateReader;
 
 pub fn get_class_hash_at_impl(
     starknet: &Starknet,
-    block_id: BlockId,
+    block_id: &BlockId,
     contract_address: ContractAddress,
 ) -> DevnetResult<ClassHash> {
-    let state = starknet.get_state_at(&block_id)?;
+    let state = starknet.get_state_at(block_id)?;
     let class_hash = state.state.state.class_hash_at(&contract_address);
 
     if class_hash == Felt::default() {
@@ -24,16 +24,16 @@ pub fn get_class_hash_at_impl(
 
 pub fn get_class_impl(
     starknet: &Starknet,
-    block_id: BlockId,
+    block_id: &BlockId,
     class_hash: ClassHash,
 ) -> DevnetResult<ContractClass> {
-    let state = starknet.get_state_at(&block_id)?;
+    let state = starknet.get_state_at(block_id)?;
     state.state.state.contract_class_at(&class_hash)
 }
 
 pub fn get_class_at_impl(
     starknet: &Starknet,
-    block_id: BlockId,
+    block_id: &BlockId,
     contract_address: ContractAddress,
 ) -> DevnetResult<ContractClass> {
     let class_hash = starknet.get_class_hash_at(block_id, contract_address)?;
@@ -116,7 +116,7 @@ mod tests {
 
         let block_number = starknet.get_latest_block().unwrap().block_number();
         let contract_class =
-            starknet.get_class(BlockId::Number(block_number.0), class_hash).unwrap();
+            starknet.get_class(&BlockId::Number(block_number.0), class_hash).unwrap();
 
         assert_eq!(contract_class, expected)
     }
@@ -131,7 +131,7 @@ mod tests {
         let block_number = starknet.get_latest_block().unwrap().block_number();
         let block_id = BlockId::Number(block_number.0);
 
-        let class_hash = starknet.get_class_hash_at(block_id, account.account_address).unwrap();
+        let class_hash = starknet.get_class_hash_at(&block_id, account.account_address).unwrap();
         let expected = account.class_hash;
         assert_eq!(class_hash, expected);
     }
@@ -146,7 +146,7 @@ mod tests {
         let block_number = starknet.get_latest_block().unwrap().block_number();
         let block_id = BlockId::Number(block_number.0);
 
-        let class_hash = starknet.get_class_hash_at(block_id, account.account_address);
+        let class_hash = starknet.get_class_hash_at(&block_id, account.account_address);
         match class_hash.err().unwrap() {
             Error::StateHistoryDisabled { .. } => (),
             _ => panic!("Should fail with StateHistoryDisabled."),
@@ -163,7 +163,7 @@ mod tests {
         let block_number = starknet.get_latest_block().unwrap().block_number();
         let block_id = BlockId::Number(block_number.0);
 
-        let contract_class = starknet.get_class_at(block_id, account.account_address).unwrap();
+        let contract_class = starknet.get_class_at(&block_id, account.account_address).unwrap();
         assert_eq!(contract_class, account.contract_class);
     }
 }

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -490,7 +490,7 @@ impl Starknet {
                     return Err(Error::StateHistoryDisabled);
                 }
 
-                let block = self.blocks.get_by_block_id(*block_id).ok_or(Error::NoBlock)?;
+                let block = self.blocks.get_by_block_id(block_id).ok_or(Error::NoBlock)?;
                 let state = self
                     .blocks
                     .num_to_state
@@ -527,12 +527,12 @@ impl Starknet {
 
     pub fn call(
         &self,
-        block_id: BlockId,
+        block_id: &BlockId,
         contract_address: Felt,
         entrypoint_selector: Felt,
         calldata: Vec<Felt>,
     ) -> DevnetResult<Vec<Felt>> {
-        let state = self.get_state_at(&block_id)?;
+        let state = self.get_state_at(block_id)?;
 
         if !state.is_contract_deployed(&ContractAddress::new(contract_address)?) {
             return Err(Error::ContractNotFound);
@@ -573,7 +573,7 @@ impl Starknet {
 
     pub fn estimate_fee(
         &self,
-        block_id: BlockId,
+        block_id: &BlockId,
         transactions: &[BroadcastedTransaction],
         simulation_flags: &[SimulationFlag],
     ) -> DevnetResult<Vec<FeeEstimateWrapper>> {
@@ -719,11 +719,11 @@ impl Starknet {
         add_invoke_transaction::add_invoke_transaction_v1(self, invoke_tx)
     }
 
-    pub fn block_state_update(&self, block_id: BlockId) -> DevnetResult<StateUpdate> {
+    pub fn block_state_update(&self, block_id: &BlockId) -> DevnetResult<StateUpdate> {
         state_update::state_update_by_block_id(self, block_id)
     }
 
-    pub fn get_block_txs_count(&self, block_id: BlockId) -> DevnetResult<u64> {
+    pub fn get_block_txs_count(&self, block_id: &BlockId) -> DevnetResult<u64> {
         let block = self.blocks.get_by_block_id(block_id).ok_or(Error::NoBlock)?;
 
         Ok(block.get_transactions().len() as u64)
@@ -748,12 +748,12 @@ impl Starknet {
         state.get_storage(ContractStorageKey::new(contract_address, storage_key))
     }
 
-    pub fn get_block(&self, block_id: BlockId) -> DevnetResult<StarknetBlock> {
+    pub fn get_block(&self, block_id: &BlockId) -> DevnetResult<StarknetBlock> {
         let block = self.blocks.get_by_block_id(block_id).ok_or(Error::NoBlock)?;
         Ok(block.clone())
     }
 
-    pub fn get_block_with_transactions(&self, block_id: BlockId) -> DevnetResult<Block> {
+    pub fn get_block_with_transactions(&self, block_id: &BlockId) -> DevnetResult<Block> {
         let block = self.blocks.get_by_block_id(block_id).ok_or(Error::NoBlock)?;
         let transactions = block
             .get_transactions()
@@ -775,7 +775,7 @@ impl Starknet {
 
     pub fn get_transaction_by_block_id_and_index(
         &self,
-        block_id: BlockId,
+        block_id: &BlockId,
         index: u64,
     ) -> DevnetResult<&Transaction> {
         let block = self.get_block(block_id)?;
@@ -790,7 +790,7 @@ impl Starknet {
     pub fn get_latest_block(&self) -> DevnetResult<StarknetBlock> {
         let block = self
             .blocks
-            .get_by_block_id(BlockId::Tag(starknet_rs_core::types::BlockTag::Latest))
+            .get_by_block_id(&BlockId::Tag(starknet_rs_core::types::BlockTag::Latest))
             .ok_or(crate::error::Error::NoBlock)?;
 
         Ok(block.clone())
@@ -835,7 +835,7 @@ impl Starknet {
 
     pub fn get_transaction_traces_from_block(
         &self,
-        block_id: BlockId,
+        block_id: &BlockId,
     ) -> DevnetResult<BlockTransactionTraces> {
         let transactions = self.get_block_with_transactions(block_id)?.transactions;
 
@@ -865,11 +865,11 @@ impl Starknet {
 
     pub fn simulate_transactions(
         &mut self,
-        block_id: BlockId,
+        block_id: &BlockId,
         transactions: &[BroadcastedTransaction],
         simulation_flags: Vec<SimulationFlag>,
     ) -> DevnetResult<Vec<SimulatedTransaction>> {
-        let mut state = self.get_state_at(&block_id)?.clone();
+        let mut state = self.get_state_at(block_id)?.clone();
         let chain_id = self.chain_id().to_felt();
 
         let mut skip_validate = false;
@@ -1200,7 +1200,7 @@ mod tests {
             starknet_rs_core::utils::get_selector_from_name("balanceOf").unwrap();
 
         match starknet.call(
-            BlockId::Tag(BlockTag::Latest),
+            &BlockId::Tag(BlockTag::Latest),
             undeployed_address,
             entry_point_selector.into(),
             vec![],
@@ -1220,7 +1220,7 @@ mod tests {
             starknet_rs_core::utils::get_selector_from_name("nonExistentMethod").unwrap();
 
         match starknet.call(
-            BlockId::Tag(BlockTag::Latest),
+            &BlockId::Tag(BlockTag::Latest),
             Felt::from_prefixed_hex_str(ETH_ERC20_CONTRACT_ADDRESS).unwrap(),
             entry_point_selector.into(),
             vec![Felt::from(predeployed_account.account_address)],
@@ -1244,7 +1244,7 @@ mod tests {
         let entry_point_selector =
             starknet_rs_core::utils::get_selector_from_name("balanceOf").unwrap();
         starknet.call(
-            BlockId::Tag(BlockTag::Latest),
+            &BlockId::Tag(BlockTag::Latest),
             Felt::from_prefixed_hex_str(ETH_ERC20_CONTRACT_ADDRESS)?,
             entry_point_selector.into(),
             vec![Felt::from(contract_address)],
@@ -1313,7 +1313,7 @@ mod tests {
         starknet.generate_new_block(StateDiff::default(), None).unwrap();
         starknet.generate_pending_block().unwrap();
 
-        let num_no_transactions = starknet.get_block_txs_count(BlockId::Number(0));
+        let num_no_transactions = starknet.get_block_txs_count(&BlockId::Number(0));
 
         assert_eq!(num_no_transactions.unwrap(), 0);
 
@@ -1324,7 +1324,7 @@ mod tests {
 
         starknet.generate_new_block(StateDiff::default(), None).unwrap();
 
-        let num_one_transaction = starknet.get_block_txs_count(BlockId::Number(1));
+        let num_one_transaction = starknet.get_block_txs_count(&BlockId::Number(1));
 
         assert_eq!(num_one_transaction.unwrap(), 1);
     }

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -503,7 +503,7 @@ impl Starknet {
 
     pub fn get_class_hash_at(
         &self,
-        block_id: BlockId,
+        block_id: &BlockId,
         contract_address: ContractAddress,
     ) -> DevnetResult<ClassHash> {
         get_class_impls::get_class_hash_at_impl(self, block_id, contract_address)
@@ -511,7 +511,7 @@ impl Starknet {
 
     pub fn get_class(
         &self,
-        block_id: BlockId,
+        block_id: &BlockId,
         class_hash: ClassHash,
     ) -> DevnetResult<ContractClass> {
         get_class_impls::get_class_impl(self, block_id, class_hash)
@@ -519,7 +519,7 @@ impl Starknet {
 
     pub fn get_class_at(
         &self,
-        block_id: BlockId,
+        block_id: &BlockId,
         contract_address: ContractAddress,
     ) -> DevnetResult<ContractClass> {
         get_class_impls::get_class_at_impl(self, block_id, contract_address)
@@ -588,7 +588,7 @@ impl Starknet {
 
     pub fn estimate_message_fee(
         &self,
-        block_id: BlockId,
+        block_id: &BlockId,
         message: MsgFromL1,
     ) -> DevnetResult<FeeEstimateWrapper> {
         estimations::estimate_message_fee(self, block_id, message)
@@ -731,20 +731,20 @@ impl Starknet {
 
     pub fn contract_nonce_at_block(
         &self,
-        block_id: BlockId,
+        block_id: &BlockId,
         contract_address: ContractAddress,
     ) -> DevnetResult<Felt> {
-        let state = self.get_state_at(&block_id)?;
+        let state = self.get_state_at(block_id)?;
         state.get_nonce(&contract_address)
     }
 
     pub fn contract_storage_at_block(
         &self,
-        block_id: BlockId,
+        block_id: &BlockId,
         contract_address: ContractAddress,
         storage_key: PatriciaKey,
     ) -> DevnetResult<Felt> {
-        let state = self.get_state_at(&block_id)?;
+        let state = self.get_state_at(block_id)?;
         state.get_storage(ContractStorageKey::new(contract_address, storage_key))
     }
 

--- a/crates/starknet-devnet-core/src/starknet/state_update.rs
+++ b/crates/starknet-devnet-core/src/starknet/state_update.rs
@@ -6,7 +6,7 @@ use crate::state::state_update::StateUpdate;
 
 pub fn state_update_by_block_id(
     starknet: &Starknet,
-    block_id: BlockId,
+    block_id: &BlockId,
 ) -> DevnetResult<StateUpdate> {
     let block = starknet.blocks.get_by_block_id(block_id).ok_or(crate::error::Error::NoBlock)?;
     let state_diff =
@@ -65,7 +65,7 @@ mod tests {
         assert_eq!(tx.execution_result.status(), TransactionExecutionStatus::Succeeded);
 
         let state_update = starknet
-            .block_state_update(starknet_rs_core::types::BlockId::Tag(
+            .block_state_update(&starknet_rs_core::types::BlockId::Tag(
                 starknet_rs_core::types::BlockTag::Latest,
             ))
             .unwrap();

--- a/crates/starknet-devnet-server/src/api/http/endpoints/mint_token.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/mint_token.rs
@@ -25,7 +25,7 @@ fn get_balance(
     let balance_selector =
         starknet_rs_core::utils::get_selector_from_name("balanceOf").unwrap().into();
     let new_balance_raw = starknet.call(
-        BlockId::Tag(BlockTag::Pending),
+        &BlockId::Tag(BlockTag::Pending),
         erc20_address.into(),
         balance_selector,
         vec![Felt::from(address)], // calldata = the address being queried

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -126,7 +126,7 @@ impl JsonRpcHandler {
             StarknetRequest::ClassHashAtContractAddress(BlockAndContractAddressInput {
                 block_id,
                 contract_address,
-            }) => self.get_class_hash_at(block_id.as_ref(), contract_address).await.to_rpc_result(),
+            }) => self.get_class_hash_at(block_id, contract_address).await.to_rpc_result(),
             StarknetRequest::ClassAtContractAddress(BlockAndContractAddressInput {
                 block_id,
                 contract_address,

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -126,7 +126,7 @@ impl JsonRpcHandler {
             StarknetRequest::ClassHashAtContractAddress(BlockAndContractAddressInput {
                 block_id,
                 contract_address,
-            }) => self.get_class_hash_at(block_id, contract_address).await.to_rpc_result(),
+            }) => self.get_class_hash_at(block_id.as_ref(), contract_address).await.to_rpc_result(),
             StarknetRequest::ClassAtContractAddress(BlockAndContractAddressInput {
                 block_id,
                 contract_address,

--- a/crates/starknet-devnet-server/src/api/json_rpc/models.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/models.rs
@@ -169,14 +169,14 @@ pub struct TransactionStatusOutput {
 
 #[cfg(test)]
 mod tests {
+    use starknet_rs_core::types::{BlockId as ImportedBlockId, BlockTag, FieldElement};
     use starknet_types::contract_address::ContractAddress;
     use starknet_types::felt::Felt;
     use starknet_types::patricia_key::PatriciaKey;
-    use starknet_types::rpc::block::{BlockHashOrNumber, BlockId, Tag};
+    use starknet_types::rpc::block::BlockId;
     use starknet_types::rpc::transactions::{
         BroadcastedDeclareTransaction, BroadcastedTransaction,
     };
-    use starknet_types::starknet_api::block::BlockNumber;
 
     use super::{BlockIdInput, EstimateFeeInput, GetStorageInput};
     use crate::api::json_rpc::requests_tests::assert_contains;
@@ -238,8 +238,8 @@ mod tests {
             "request": [
                 {
                     "type": "DECLARE",
-                    "max_fee": "0xA", 
-                    "version": "0x1", 
+                    "max_fee": "0xA",
+                    "version": "0x1",
                     "signature": ["0xFF", "0xAA"],
                     "nonce": "0x0",
                     "sender_address": "0x0001",
@@ -269,8 +269,8 @@ mod tests {
                         }],
                         "program": "",
                         "entry_points_by_type": {
-                            "CONSTRUCTOR": [], 
-                            "EXTERNAL": [], 
+                            "CONSTRUCTOR": [],
+                            "EXTERNAL": [],
                             "L1_HANDLER": []
                         }
                     }
@@ -353,7 +353,7 @@ mod tests {
                     "constructor_calldata": ["0x01"],
                     "class_hash": "0x01"
                 }
-                ], 
+                ],
             "block_id": {
                 "block_number": 1
             },
@@ -361,10 +361,7 @@ mod tests {
         }"#;
 
         let estimate_fee_input = serde_json::from_str::<super::EstimateFeeInput>(json_str).unwrap();
-        assert_eq!(
-            estimate_fee_input.block_id,
-            BlockId::HashOrNumber(BlockHashOrNumber::Number(BlockNumber(1)))
-        );
+        assert_eq!(estimate_fee_input.block_id.as_ref(), &ImportedBlockId::Number(1));
         assert_eq!(estimate_fee_input.request.len(), 4);
         assert!(matches!(
             estimate_fee_input.request[0],
@@ -394,7 +391,7 @@ mod tests {
                     entry_point_selector: Felt::from_prefixed_hex_str("0x02").unwrap(),
                     calldata: vec![Felt::from_prefixed_hex_str("0x03").unwrap()],
                 },
-                block_id: BlockId::HashOrNumber(BlockHashOrNumber::Number(BlockNumber(1))),
+                block_id: BlockId::from(ImportedBlockId::Number(1)),
             }
         );
     }
@@ -417,8 +414,8 @@ mod tests {
         }
 
         let expected_storage_input = GetStorageInput {
-            block_id: BlockId::HashOrNumber(BlockHashOrNumber::Hash(
-                Felt::from_prefixed_hex_str("0x01").unwrap(),
+            block_id: BlockId::from(ImportedBlockId::Hash(
+                FieldElement::from_hex_be("0x01").unwrap(),
             )),
             contract_address: ContractAddress::new(Felt::from_prefixed_hex_str("0x02").unwrap())
                 .unwrap(),
@@ -462,16 +459,16 @@ mod tests {
     }
     #[test]
     fn deserialize_block_id_tag_variants() {
-        assert_block_id_tag_correctness(true, Tag::Latest, r#"{"block_id": "latest"}"#);
-        assert_block_id_tag_correctness(true, Tag::Pending, r#"{"block_id": "pending"}"#);
+        assert_block_id_tag_correctness(true, BlockTag::Latest, r#"{"block_id": "latest"}"#);
+        assert_block_id_tag_correctness(true, BlockTag::Pending, r#"{"block_id": "pending"}"#);
 
         // Incorrect tag
-        assert_block_id_tag_correctness(false, Tag::Latest, r#"{"block_id": "latests"}"#);
-        assert_block_id_tag_correctness(false, Tag::Pending, r#"{"block_id": "pendingg"}"#);
+        assert_block_id_tag_correctness(false, BlockTag::Latest, r#"{"block_id": "latests"}"#);
+        assert_block_id_tag_correctness(false, BlockTag::Pending, r#"{"block_id": "pendingg"}"#);
 
         // Incorrect key
-        assert_block_id_tag_correctness(false, Tag::Latest, r#"{"block": "latest"}"#);
-        assert_block_id_tag_correctness(false, Tag::Pending, r#"{"block": "pending"}"#);
+        assert_block_id_tag_correctness(false, BlockTag::Latest, r#"{"block": "latest"}"#);
+        assert_block_id_tag_correctness(false, BlockTag::Pending, r#"{"block": "pending"}"#);
     }
 
     #[test]
@@ -572,16 +569,13 @@ mod tests {
 
     fn assert_block_id_tag_correctness(
         should_be_correct: bool,
-        expected_tag: Tag,
+        expected_tag: BlockTag,
         json_str_block_id: &str,
     ) {
-        let is_correct = if let Ok(BlockIdInput { block_id: BlockId::Tag(generated_tag) }) =
+        let is_correct =
             serde_json::from_str::<BlockIdInput>(json_str_block_id)
-        {
-            generated_tag == expected_tag
-        } else {
-            false
-        };
+                .map(|BlockIdInput { block_id }| matches!(block_id.as_ref(), ImportedBlockId::Tag(generated_tag) if *generated_tag == expected_tag))
+                .unwrap_or(false);
 
         assert_eq!(should_be_correct, is_correct);
     }
@@ -591,14 +585,13 @@ mod tests {
         expected_block_number: u64,
         json_str_block_id: &str,
     ) {
-        let is_correct = if let Ok(BlockIdInput {
-            block_id: BlockId::HashOrNumber(BlockHashOrNumber::Number(generated_block_number)),
-        }) = serde_json::from_str::<BlockIdInput>(json_str_block_id)
-        {
-            generated_block_number == BlockNumber(expected_block_number)
-        } else {
-            false
-        };
+        let is_correct =
+            serde_json::from_str::<BlockIdInput>(json_str_block_id)
+                .map(
+                    |BlockIdInput { block_id }|
+                    matches!(block_id.as_ref(),
+                    ImportedBlockId::Number(generated_block_number) if *generated_block_number == expected_block_number)
+            ).unwrap_or(false);
 
         assert_eq!(should_be_correct, is_correct);
     }
@@ -608,14 +601,10 @@ mod tests {
         expected_block_hash: &str,
         json_str_block_id: &str,
     ) {
-        let is_correct = if let Ok(BlockIdInput {
-            block_id: BlockId::HashOrNumber(BlockHashOrNumber::Hash(generated_block_hash)),
-        }) = serde_json::from_str::<BlockIdInput>(json_str_block_id)
-        {
-            generated_block_hash == Felt::from_prefixed_hex_str(expected_block_hash).unwrap()
-        } else {
-            false
-        };
+        let is_correct =
+            serde_json::from_str::<BlockIdInput>(json_str_block_id)
+                .map(|BlockIdInput { block_id }| matches!(block_id.as_ref(), ImportedBlockId::Hash(generated_block_hash) if *generated_block_hash == FieldElement::from_hex_be(expected_block_hash).unwrap()))
+        .unwrap_or(false);
 
         assert_eq!(should_be_correct, is_correct)
     }

--- a/crates/starknet-devnet-types/src/rpc/block.rs
+++ b/crates/starknet-devnet-types/src/rpc/block.rs
@@ -15,8 +15,14 @@ pub enum BlockHashOrNumber {
     Number(u64),
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct BlockId(ImportedBlockId);
+
+impl From<ImportedBlockId> for BlockId {
+    fn from(value: ImportedBlockId) -> Self {
+        Self(value)
+    }
+}
 
 impl AsRef<ImportedBlockId> for BlockId {
     fn as_ref(&self) -> &ImportedBlockId {

--- a/crates/starknet-devnet-types/src/rpc/block.rs
+++ b/crates/starknet-devnet-types/src/rpc/block.rs
@@ -8,71 +8,19 @@ use crate::rpc::transactions::Transactions;
 pub type GlobalRootHex = Felt;
 
 #[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub enum Tag {
-    /// The most recent fully constructed block
-    #[serde(rename = "latest")]
-    Latest,
-    /// Currently constructed block
-    #[serde(rename = "pending")]
-    Pending,
-}
-
-impl From<Tag> for ImportedBlockTag {
-    fn from(value: Tag) -> Self {
-        match value {
-            Tag::Latest => ImportedBlockTag::Latest,
-            Tag::Pending => ImportedBlockTag::Pending,
-        }
-    }
-}
-
-impl From<ImportedBlockTag> for Tag {
-    fn from(value: ImportedBlockTag) -> Self {
-        match value {
-            ImportedBlockTag::Latest => Tag::Latest,
-            ImportedBlockTag::Pending => Tag::Pending,
-        }
-    }
-}
-
-#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum BlockHashOrNumber {
     #[serde(rename = "block_hash")]
     Hash(Felt),
     #[serde(rename = "block_number")]
-    Number(BlockNumber),
+    Number(u64),
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
-#[serde(untagged)]
-pub enum BlockId {
-    HashOrNumber(BlockHashOrNumber),
-    Tag(Tag),
-}
+pub struct BlockId(starknet_rs_core::types::BlockId);
 
 impl From<BlockId> for ImportedBlockId {
     fn from(block_id: BlockId) -> Self {
-        match block_id {
-            BlockId::HashOrNumber(hash_or_number) => match hash_or_number {
-                BlockHashOrNumber::Hash(hash) => ImportedBlockId::Hash(hash.into()),
-                BlockHashOrNumber::Number(number) => ImportedBlockId::Number(number.0),
-            },
-            BlockId::Tag(tag) => ImportedBlockId::Tag(tag.into()),
-        }
-    }
-}
-
-impl From<ImportedBlockId> for BlockId {
-    fn from(block_id: ImportedBlockId) -> Self {
-        match block_id {
-            ImportedBlockId::Tag(tag) => BlockId::Tag(tag.into()),
-            ImportedBlockId::Number(number) => {
-                BlockId::HashOrNumber(BlockHashOrNumber::Number(BlockNumber(number)))
-            }
-            ImportedBlockId::Hash(hash) => {
-                BlockId::HashOrNumber(BlockHashOrNumber::Hash(hash.into()))
-            }
-        }
+        block_id.0
     }
 }
 
@@ -83,13 +31,16 @@ impl<'de> Deserialize<'de> for BlockId {
     {
         let value = serde_json::Value::deserialize(deserializer)?;
         if value.as_str().is_some() {
-            let block_id: Tag = serde_json::from_value(value)
+            let block_tag: ImportedBlockTag = serde_json::from_value(value)
                 .map_err(|e| serde::de::Error::custom(format!("Invalid block ID: {e}")))?;
-            Ok(BlockId::Tag(block_id))
+            Ok(BlockId(ImportedBlockId::Tag(block_tag)))
         } else if value.as_object().is_some() {
             let block_id: BlockHashOrNumber = serde_json::from_value(value)
                 .map_err(|e| serde::de::Error::custom(format!("Invalid block ID: {e}")))?;
-            Ok(BlockId::HashOrNumber(block_id))
+            match block_id {
+                BlockHashOrNumber::Hash(hash) => Ok(BlockId(ImportedBlockId::Hash(hash.into()))),
+                BlockHashOrNumber::Number(number) => Ok(BlockId(ImportedBlockId::Number(number))),
+            }
         } else {
             Err(serde::de::Error::custom(format!("Invalid block ID: {value}")))
         }

--- a/crates/starknet-devnet-types/src/rpc/block.rs
+++ b/crates/starknet-devnet-types/src/rpc/block.rs
@@ -16,7 +16,13 @@ pub enum BlockHashOrNumber {
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize)]
-pub struct BlockId(starknet_rs_core::types::BlockId);
+pub struct BlockId(ImportedBlockId);
+
+impl AsRef<ImportedBlockId> for BlockId {
+    fn as_ref(&self) -> &ImportedBlockId {
+        &self.0
+    }
+}
 
 impl From<BlockId> for ImportedBlockId {
     fn from(block_id: BlockId) -> Self {

--- a/crates/starknet-devnet-types/src/rpc/estimate_message_fee.rs
+++ b/crates/starknet-devnet-types/src/rpc/estimate_message_fee.rs
@@ -11,7 +11,6 @@ use starknet_rs_ff::FieldElement;
 
 use crate::error::DevnetResult;
 use crate::felt::Felt;
-use crate::rpc::block::BlockId;
 use crate::rpc::eth_address::EthAddressWrapper;
 use crate::{impl_wrapper_deserialize, impl_wrapper_serialize};
 
@@ -71,11 +70,7 @@ impl EstimateMessageFeeRequestWrapper {
         self.inner.message.payload.iter().map(|el| (*el).into()).collect()
     }
 
-    pub fn get_block_id(&self) -> BlockId {
-        self.inner.block_id.into()
-    }
-
-    pub fn get_raw_block_id(&self) -> &SrBlockId {
+    pub fn get_block_id(&self) -> &SrBlockId {
         &self.inner.block_id
     }
 

--- a/crates/starknet-devnet-types/src/rpc/felt.rs
+++ b/crates/starknet-devnet-types/src/rpc/felt.rs
@@ -103,6 +103,12 @@ impl From<starknet_rs_ff::FieldElement> for Felt {
     }
 }
 
+impl From<&starknet_rs_ff::FieldElement> for Felt {
+    fn from(value: &starknet_rs_ff::FieldElement) -> Self {
+        Self(value.to_bytes_be())
+    }
+}
+
 impl From<u128> for Felt {
     fn from(value: u128) -> Self {
         let le_part: [u8; 16] = value.to_be_bytes();


### PR DESCRIPTION
## Usage related changes

## Development related changes

Implemented as_ref method for wrapper `BlockId(starknet-rs::BlockId)` to return reference to its inner type.
Removed usage if any of our custom BlockId implementation and left only its custom deserialisation.
Refactored methods to receive` &BlockId` as an argument, instead of `BlockId`, to avoid copying of 32 bytes. Copying is done because starknet-rs BlockId implements the Copy trait.

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [ ] Performed code self-review
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Checked the TODO section in README.md if this PR resolves it
- [x] Updated the tests
- [x] All tests are passing - `cargo test`
