### PR TITLE
use version 1.1.0 of cargo-get

### DIFF
--- a/docker/tag_images_and_create_joint_image_manifests.sh
+++ b/docker/tag_images_and_create_joint_image_manifests.sh
@@ -3,7 +3,7 @@ set -eu
 
 IMAGE=shardlabs/starknet-devnet-rs
 
-cargo install cargo-get
+cargo install cargo-get --version 1.1.0
 
 echo "Logging in to docker hub"
 docker login --username "$DOCKER_USER" --password "$DOCKER_PASS"

--- a/scripts/publish_cratesio_new_versions.sh
+++ b/scripts/publish_cratesio_new_versions.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-cargo install cargo-get
+cargo install cargo-get --version 1.1.0
 
 for workspace_member in $(cargo get --delimiter " " workspace.members); do
     package_name=$(cargo get --entry "$workspace_member" package.name)


### PR DESCRIPTION

## Development related changes

Lock the version of cargo-get used in publishing the crates.
Fixes an error on circleci which arises with the compilation of cargo-get@v.1.1.1 which uses rust 1.74.0

## Checklist:

- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
- [ ] Performed code self-review
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Documented the changes
- [ ] Linked the issues which this PR resolves
- [ ] Checked the TODO section in README.md if this PR resolves it
- [ ] Updated the tests
- [ ] All tests are passing - `cargo test`
