### PR TITLE
Fix empty params deserialization

### DIFF
--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -863,7 +863,7 @@ mod requests_tests {
 
     #[test]
     fn deseralize_chain_id_request() {
-        [
+        for body in [
             json!({
                 "method": "starknet_chainId",
                 "params": {}
@@ -875,16 +875,14 @@ mod requests_tests {
             json!({
                 "method": "starknet_chainId",
             }),
-        ]
-        .into_iter()
-        .for_each(|body| {
-            assert_deserialization_succeeds(body.to_string().as_str());
-        });
+        ] {
+            assert_deserialization_succeeds(body.to_string().as_str())
+        }
     }
 
     #[test]
     fn deserialize_spec_version_request() {
-        [
+        for body in [
             json!({
                 "method": "starknet_specVersion",
                 "params": {}
@@ -896,11 +894,9 @@ mod requests_tests {
             json!({
                 "method": "starknet_specVersion",
             }),
-        ]
-        .into_iter()
-        .for_each(|body| {
-            assert_deserialization_succeeds(body.to_string().as_str());
-        });
+        ] {
+            assert_deserialization_succeeds(body.to_string().as_str())
+        }
     }
 
     fn assert_deserialization_succeeds(json_str: &str) {

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -861,6 +861,48 @@ mod requests_tests {
         );
     }
 
+    #[test]
+    fn deseralize_chain_id_request() {
+        [
+            json!({
+                "method": "starknet_chainId",
+                "params": {}
+            }),
+            json!({
+                "method": "starknet_chainId",
+                "params": []
+            }),
+            json!({
+                "method": "starknet_chainId",
+            }),
+        ]
+        .into_iter()
+        .for_each(|body| {
+            assert_deserialization_succeeds(body.to_string().as_str());
+        });
+    }
+
+    #[test]
+    fn deserialize_spec_version_request() {
+        [
+            json!({
+                "method": "starknet_specVersion",
+                "params": {}
+            }),
+            json!({
+                "method": "starknet_specVersion",
+                "params": []
+            }),
+            json!({
+                "method": "starknet_specVersion",
+            }),
+        ]
+        .into_iter()
+        .for_each(|body| {
+            assert_deserialization_succeeds(body.to_string().as_str());
+        });
+    }
+
     fn assert_deserialization_succeeds(json_str: &str) {
         serde_json::from_str::<StarknetRequest>(json_str).unwrap();
     }

--- a/crates/starknet-devnet-server/src/api/serde_helpers.rs
+++ b/crates/starknet-devnet-server/src/api/serde_helpers.rs
@@ -1,4 +1,4 @@
-/// A module that deserializes `[]` optionally
+/// A module that deserializes `[]` and `{}` optionally
 pub mod empty_params {
     use serde::de::Error as DeError;
     use serde::{Deserialize, Deserializer};
@@ -11,6 +11,7 @@ pub mod empty_params {
         let value: Value = Deserialize::deserialize(d)?;
 
         match value {
+            Value::Null => Ok(()),
             Value::Object(obj) if obj.is_empty() => Ok(()),
             Value::Array(arr) if arr.is_empty() => Ok(()),
             other => Err(DeError::custom(format!(
@@ -61,5 +62,12 @@ mod tests {
     fn deserialize_other_types() {
         let json_str = "\"string\"";
         assert!(test_deserialization(json_str).is_err());
+    }
+
+    #[test]
+    fn deserialize_null() {
+        let value: Value = serde_json::Value::Null;
+        let deserializer = value.into_deserializer();
+        assert!(deserialize(deserializer).is_ok());
     }
 }

--- a/crates/starknet-devnet/src/main.rs
+++ b/crates/starknet-devnet/src/main.rs
@@ -13,6 +13,7 @@ use starknet_core::constants::{
 };
 use starknet_core::starknet::starknet_config::DumpOn;
 use starknet_core::starknet::Starknet;
+use starknet_types::chain_id::ChainId;
 use starknet_types::felt::Felt;
 use starknet_types::traits::{ToDecimalString, ToHexString};
 use tracing::info;
@@ -68,6 +69,11 @@ fn print_predeployed_contracts() {
     println!("Predeployed UDC");
     println!("Address: {UDC_CONTRACT_ADDRESS}");
     println!("Class Hash: {UDC_CONTRACT_CLASS_HASH}");
+    println!();
+}
+
+fn print_chain_id(chain_id: ChainId) {
+    println!("Chain ID: {} ({})", chain_id, chain_id.to_felt().to_prefixed_hex_str());
 }
 
 #[tokio::main]
@@ -89,6 +95,7 @@ async fn main() -> Result<(), anyhow::Error> {
     };
 
     print_predeployed_contracts();
+    print_chain_id(starknet_config.chain_id);
 
     let predeployed_accounts = api.starknet.read().await.get_predeployed_accounts();
     log_predeployed_accounts(


### PR DESCRIPTION
## Usage related changes

- Fixes bug introduced by #346
- Reported in this Discord issue: https://discord.com/channels/793094838509764618/1207428728284516403
- Chain ID is already mentioned in `--help`, but now will also be printed on startup.

## Development related changes

- None

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Checked the TODO section in README.md if this PR resolves it
- [x] Updated the tests
- [x] All tests are passing - `cargo test`
