### PR TITLE
Incorporate pending block generation into new block generation

### DIFF
--- a/crates/starknet-devnet-core/src/starknet/get_class_impls.rs
+++ b/crates/starknet-devnet-core/src/starknet/get_class_impls.rs
@@ -126,7 +126,6 @@ mod tests {
         let (mut starknet, account) = setup(Some(100000000), StateArchiveCapacity::Full);
 
         starknet.generate_new_block(StateDiff::default(), None).unwrap();
-        starknet.generate_pending_block().unwrap();
 
         let block_number = starknet.get_latest_block().unwrap().block_number();
         let block_id = BlockId::Number(block_number.0);
@@ -141,7 +140,6 @@ mod tests {
         let (mut starknet, account) = setup(Some(100000000), StateArchiveCapacity::None);
 
         starknet.generate_new_block(StateDiff::default(), None).unwrap();
-        starknet.generate_pending_block().unwrap();
 
         let block_number = starknet.get_latest_block().unwrap().block_number();
         let block_id = BlockId::Number(block_number.0);
@@ -158,7 +156,6 @@ mod tests {
         let (mut starknet, account) = setup(Some(100000000), StateArchiveCapacity::Full);
 
         starknet.generate_new_block(StateDiff::default(), None).unwrap();
-        starknet.generate_pending_block().unwrap();
 
         let block_number = starknet.get_latest_block().unwrap().block_number();
         let block_id = BlockId::Number(block_number.0);

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -216,9 +216,9 @@ impl Starknet {
         self.predeployed_accounts.get_accounts().to_vec()
     }
 
-    // Update block context
-    // Initialize values for new pending block
-    pub(crate) fn generate_pending_block(&mut self) -> DevnetResult<()> {
+    /// Update block context
+    /// Initialize values for new pending block
+    fn generate_pending_block(&mut self) -> DevnetResult<()> {
         Self::update_block_context(&mut self.block_context);
         self.restart_pending_block()?;
 
@@ -226,6 +226,7 @@ impl Starknet {
     }
 
     /// Transfer data from pending block into new block and save it to blocks collection
+    /// Generates new pending block
     /// Returns the new block number
     pub(crate) fn generate_new_block(
         &mut self,
@@ -270,6 +271,8 @@ impl Starknet {
             let deep_cloned_state = self.state.clone();
             self.blocks.save_state_at(new_block_number, deep_cloned_state);
         }
+
+        self.generate_pending_block()?;
 
         Ok(new_block_number)
     }
@@ -409,8 +412,6 @@ impl Starknet {
         self.state.clear_dirty_state();
         // create new block from pending one
         self.generate_new_block(state_diff, None)?;
-        // clear pending block information
-        self.generate_pending_block()?;
 
         Ok(())
     }
@@ -937,13 +938,9 @@ impl Starknet {
         Ok(simulation_results)
     }
 
+    /// create new block from pending one
     pub fn create_block(&mut self, timestamp: Option<u64>) -> DevnetResult<(), Error> {
-        // create new block from pending one
         self.generate_new_block(StateDiff::default(), timestamp)?;
-
-        // clear pending block information
-        self.generate_pending_block()?;
-
         Ok(())
     }
 
@@ -1287,7 +1284,6 @@ mod tests {
         starknet.get_latest_block().err().unwrap();
 
         starknet.generate_new_block(StateDiff::default(), None).unwrap();
-        starknet.generate_pending_block().unwrap();
 
         // last added block number -> 0
         let added_block = starknet.blocks.num_to_block.get(&BlockNumber(0)).unwrap();
@@ -1297,7 +1293,6 @@ mod tests {
         assert_eq!(block_number.0, added_block.header.block_number.0);
 
         starknet.generate_new_block(StateDiff::default(), None).unwrap();
-        starknet.generate_pending_block().unwrap();
 
         let added_block2 = starknet.blocks.num_to_block.get(&BlockNumber(1)).unwrap();
         let block_number2 = starknet.get_latest_block().unwrap().block_number();
@@ -1311,7 +1306,6 @@ mod tests {
         let mut starknet = Starknet::new(&config).unwrap();
 
         starknet.generate_new_block(StateDiff::default(), None).unwrap();
-        starknet.generate_pending_block().unwrap();
 
         let num_no_transactions = starknet.get_block_txs_count(&BlockId::Number(0));
 
@@ -1348,7 +1342,6 @@ mod tests {
 
         // generate initial block with empty state
         starknet.generate_new_block(StateDiff::default(), None).unwrap();
-        starknet.generate_pending_block().unwrap();
 
         // **generate second block**
         // add data to state
@@ -1359,7 +1352,6 @@ mod tests {
         starknet.state.apply_state_difference(state_diff.clone()).unwrap();
         // generate new block and save the state
         let second_block = starknet.generate_new_block(state_diff, None).unwrap();
-        starknet.generate_pending_block().unwrap();
 
         // **generate third block**
         // add data to state
@@ -1370,7 +1362,6 @@ mod tests {
         starknet.state.apply_state_difference(state_diff.clone()).unwrap();
         // generate new block and save the state
         let third_block = starknet.generate_new_block(state_diff, None).unwrap();
-        starknet.generate_pending_block().unwrap();
 
         // check modified state at block 1 and 2 to contain the correct value for the nonce
         let second_block_address_nonce = starknet
@@ -1406,9 +1397,7 @@ mod tests {
         let mut starknet = Starknet::new(&config).unwrap();
 
         starknet.generate_new_block(StateDiff::default(), None).unwrap();
-        starknet.generate_pending_block().unwrap();
         starknet.generate_new_block(StateDiff::default(), None).unwrap();
-        starknet.generate_pending_block().unwrap();
         starknet.generate_new_block(StateDiff::default(), None).unwrap();
 
         let latest_block = starknet.get_latest_block();
@@ -1420,8 +1409,7 @@ mod tests {
         let config = StarknetConfig::default();
         let mut starknet = Starknet::new(&config).unwrap();
 
-        Starknet::update_block_context(&mut starknet.block_context);
-        starknet.generate_pending_block().unwrap();
+        starknet.generate_new_block(StateDiff::default(), None).unwrap();
         starknet
             .blocks
             .pending_block


### PR DESCRIPTION
## Usage related changes

- None, hopefully

## Development related changes

- Reduces code complexity by making pending block generation the last step of new block generation.
- Could also be useful for #353

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Checked the TODO section in README.md if this PR resolves it
- [x] Updated the tests
- [x] All tests are passing - `cargo test`
