### PR TITLE
Add set time generate_block option

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ POST /set_time
 }
 ```
 
-Sets the exact time for the next block generated.
+Doesn't generate a new block, but sets the exact time for the next generated block.
 
 ```
 POST /set_time

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Response:
 
 ## Advancing time
 
-Block timestamp can be manipulated by setting the exact time or setting the time offset. Timestamps methods `/set_time` and `/increase_time` will generate a new block. All values should be set in Unix time seconds [Unix time seconds](https://en.wikipedia.org/wiki/Unix_time).
+Block timestamp can be manipulated by setting the exact time or setting the time offset. By default timestamps methods `/set_time` and `/increase_time` set will generate a new block. This behavior can be changed for `/set_time` endpoint by setting the optional parameter `generate_block` to `false`, in that case exact time will be set for the next generated block. All values should be set in Unix time seconds [Unix time seconds](https://en.wikipedia.org/wiki/Unix_time).
 
 ### Set time
 
@@ -290,7 +290,17 @@ Sets the exact time and generates a new block.
 ```
 POST /set_time
 {
-    "time": TIME_IN_SECONDS
+    "time": TIME_IN_SECONDS,
+}
+```
+
+Sets the exact time for the next block generated.
+
+```
+POST /set_time
+{
+    "time": TIME_IN_SECONDS,
+    "generate_block": false
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Sets the exact time and generates a new block.
 ```
 POST /set_time
 {
-    "time": TIME_IN_SECONDS,
+    "time": TIME_IN_SECONDS
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,9 @@ Response:
 
 ## Advancing time
 
-Block timestamp can be manipulated by setting the exact time or setting the time offset. By default timestamps methods `/set_time` and `/increase_time` set will generate a new block. This behavior can be changed for `/set_time` endpoint by setting the optional parameter `generate_block` to `false`, in that case exact time will be set for the next generated block. All values should be set in Unix time seconds [Unix time seconds](https://en.wikipedia.org/wiki/Unix_time).
+Block timestamp can be manipulated by setting the exact time or setting the time offset. By default, timestamp methods `/set_time` and `/increase_time` generate a new block. This can be changed for `/set_time` by setting the optional parameter `generate_block` to `false`. This skips immediate new block generation, but will use the specified timestamp whenever the next block is supposed to be generated.
+
+All values should be set in [Unix time seconds](https://en.wikipedia.org/wiki/Unix_time).
 
 ### Set time
 

--- a/crates/starknet-devnet-core/src/starknet/dump.rs
+++ b/crates/starknet-devnet-core/src/starknet/dump.rs
@@ -15,6 +15,7 @@ use crate::error::{DevnetResult, Error};
 pub enum DumpEvent {
     CreateBlock,
     SetTime(u64),
+    SetTimeCreateBlock(u64),
     IncreaseTime(u64),
     AddDeclareTransaction(BroadcastedDeclareTransaction),
     AddInvokeTransaction(BroadcastedInvokeTransaction),
@@ -58,7 +59,10 @@ impl Starknet {
                     self.create_block_dump_event(None, None)?;
                 }
                 DumpEvent::SetTime(timestamp) => {
-                    self.set_time(timestamp)?;
+                    self.set_time(timestamp, false)?;
+                }
+                DumpEvent::SetTimeCreateBlock(timestamp) => {
+                    self.set_time(timestamp, true)?;
                 }
                 DumpEvent::IncreaseTime(time_shift) => {
                     self.increase_time(time_shift)?;

--- a/crates/starknet-devnet-core/src/starknet/dump.rs
+++ b/crates/starknet-devnet-core/src/starknet/dump.rs
@@ -56,7 +56,7 @@ impl Starknet {
                     self.add_l1_handler_transaction(tx)?;
                 }
                 DumpEvent::CreateBlock => {
-                    self.create_block_dump_event(None, None)?;
+                    self.create_block_dump_event(None)?;
                 }
                 DumpEvent::SetTime(timestamp) => {
                     self.set_time(timestamp, false)?;

--- a/crates/starknet-devnet-core/src/starknet/dump.rs
+++ b/crates/starknet-devnet-core/src/starknet/dump.rs
@@ -15,7 +15,6 @@ use crate::error::{DevnetResult, Error};
 pub enum DumpEvent {
     CreateBlock,
     SetTime(u64),
-    SetTimeCreateBlock(u64),
     IncreaseTime(u64),
     AddDeclareTransaction(BroadcastedDeclareTransaction),
     AddInvokeTransaction(BroadcastedInvokeTransaction),
@@ -60,9 +59,6 @@ impl Starknet {
                 }
                 DumpEvent::SetTime(timestamp) => {
                     self.set_time(timestamp, false)?;
-                }
-                DumpEvent::SetTimeCreateBlock(timestamp) => {
-                    self.set_time(timestamp, true)?;
                 }
                 DumpEvent::IncreaseTime(time_shift) => {
                     self.increase_time(time_shift)?;

--- a/crates/starknet-devnet-core/src/starknet/get_class_impls.rs
+++ b/crates/starknet-devnet-core/src/starknet/get_class_impls.rs
@@ -125,7 +125,7 @@ mod tests {
     fn get_class_hash_at_generated_accounts() {
         let (mut starknet, account) = setup(Some(100000000), StateArchiveCapacity::Full);
 
-        starknet.generate_new_block(StateDiff::default(), None).unwrap();
+        starknet.generate_new_block(StateDiff::default()).unwrap();
 
         let block_number = starknet.get_latest_block().unwrap().block_number();
         let block_id = BlockId::Number(block_number.0);
@@ -139,7 +139,7 @@ mod tests {
     fn get_class_hash_at_generated_accounts_without_state_archive() {
         let (mut starknet, account) = setup(Some(100000000), StateArchiveCapacity::None);
 
-        starknet.generate_new_block(StateDiff::default(), None).unwrap();
+        starknet.generate_new_block(StateDiff::default()).unwrap();
 
         let block_number = starknet.get_latest_block().unwrap().block_number();
         let block_id = BlockId::Number(block_number.0);
@@ -155,7 +155,7 @@ mod tests {
     fn get_class_at_generated_accounts() {
         let (mut starknet, account) = setup(Some(100000000), StateArchiveCapacity::Full);
 
-        starknet.generate_new_block(StateDiff::default(), None).unwrap();
+        starknet.generate_new_block(StateDiff::default()).unwrap();
 
         let block_number = starknet.get_latest_block().unwrap().block_number();
         let block_id = BlockId::Number(block_number.0);

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -971,7 +971,7 @@ impl Starknet {
         Ok(())
     }
 
-    // Create empty block
+    // Set time
     pub fn set_time(&mut self, timestamp: u64, create_block: bool) -> DevnetResult<(), Error> {
         self.set_block_timestamp_shift(
             timestamp as i64 - Starknet::get_unix_timestamp_as_seconds() as i64,

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -979,7 +979,8 @@ impl Starknet {
         if create_block {
             self.set_next_block_timestamp(timestamp);
             self.create_block()?;
-            self.handle_dump_event(DumpEvent::SetTimeCreateBlock(timestamp))?;
+            self.handle_dump_event(DumpEvent::SetTime(timestamp))?;
+            self.handle_dump_event(DumpEvent::CreateBlock)?;
         } else {
             self.set_next_block_timestamp(timestamp);
             self.handle_dump_event(DumpEvent::SetTime(timestamp))?;

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -971,7 +971,7 @@ impl Starknet {
         Ok(())
     }
 
-    // Set time
+    // Set time and optionally create a new block
     pub fn set_time(&mut self, timestamp: u64, create_block: bool) -> DevnetResult<(), Error> {
         self.set_block_timestamp_shift(
             timestamp as i64 - Starknet::get_unix_timestamp_as_seconds() as i64,

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -981,13 +981,13 @@ impl Starknet {
             self.create_block_dump_event(
                 Some(timestamp),
                 Some(DumpEvent::SetTimeCreateBlock(timestamp)),
-            )
+            )?;
         } else {
             self.set_next_block_timestamp(timestamp);
             self.handle_dump_event(DumpEvent::SetTime(timestamp))?;
-
-            Ok(())
         }
+
+        Ok(())
     }
 
     // Set timestamp shift and create empty block

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -980,18 +980,15 @@ impl Starknet {
             timestamp as i64 - Starknet::get_unix_timestamp_as_seconds() as i64,
         );
 
-        // TODO: implement dump...
         if create_block {
-            // TODO: fire this only if optional parameter, add tests
             self.create_block_dump_event(
                 Some(timestamp),
                 Some(DumpEvent::SetTimeCreateBlock(timestamp)),
             )
         } else {
-            // self.create_block(timestamp);
             self.set_next_block_timestamp(timestamp);
-            // TODO: store event
-            // no next transaction should be with next_block_timestamp
+            self.handle_dump_event(DumpEvent::SetTime(timestamp))?;
+
             Ok(())
         }
     }

--- a/crates/starknet-devnet-server/src/api/http/endpoints/blocks.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/blocks.rs
@@ -9,7 +9,7 @@ pub async fn create_block(
 ) -> HttpApiResult<Json<CreatedBlock>> {
     let mut starknet = state.api.starknet.write().await;
     starknet
-        .create_block_dump_event(None, None)
+        .create_block_dump_event(None)
         .map_err(|err| HttpApiError::CreateEmptyBlockError { msg: err.to_string() })?;
 
     let last_block = starknet.get_latest_block();

--- a/crates/starknet-devnet-server/src/api/http/endpoints/time.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/time.rs
@@ -1,30 +1,41 @@
 use axum::{Extension, Json};
+use starknet_core::error::Error;
 
 use crate::api::http::error::HttpApiError;
-use crate::api::http::models::{IncreaseTimeResponse, SetTimeResponse, Time};
+use crate::api::http::models::{IncreaseTime, IncreaseTimeResponse, SetTime, SetTimeResponse};
 use crate::api::http::{HttpApiHandler, HttpApiResult};
 
 pub async fn set_time(
-    Json(data): Json<Time>,
+    Json(data): Json<SetTime>,
     Extension(state): Extension<HttpApiHandler>,
 ) -> HttpApiResult<Json<SetTimeResponse>> {
     let mut starknet = state.api.starknet.write().await;
+    let generate_block = data.generate_block.unwrap_or(true);
+
     starknet
-        .set_time(data.time)
+        .set_time(data.time, generate_block)
         .map_err(|err| HttpApiError::BlockSetTimeError { msg: err.to_string() })?;
 
     let last_block = starknet.get_latest_block();
     match last_block {
         Ok(block) => Ok(Json(SetTimeResponse {
             block_timestamp: block.timestamp().0,
-            block_hash: block.block_hash(),
+            block_hash: Some(block.block_hash()),
         })),
+        Err(Error::NoBlock) => {
+            // Handle case when generate_block is false and there is no latest block
+            if !generate_block {
+                return Ok(Json(SetTimeResponse { block_timestamp: data.time, block_hash: None }));
+            }
+
+            Err(HttpApiError::CreateEmptyBlockError { msg: Error::NoBlock.to_string() })
+        }
         Err(err) => Err(HttpApiError::CreateEmptyBlockError { msg: err.to_string() }),
     }
 }
 
 pub async fn increase_time(
-    Json(data): Json<Time>,
+    Json(data): Json<IncreaseTime>,
     Extension(state): Extension<HttpApiHandler>,
 ) -> HttpApiResult<Json<IncreaseTimeResponse>> {
     let mut starknet = state.api.starknet.write().await;

--- a/crates/starknet-devnet-server/src/api/http/endpoints/time.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/time.rs
@@ -23,7 +23,8 @@ pub async fn set_time(
             block_hash: Some(block.block_hash()),
         })),
         Err(Error::NoBlock) => {
-            // Handle case when generate_block is false and there is no latest block
+            // Handle case when generate_block is false and there is no latest block, this case can
+            // be removed once the genesis block is implemented
             if !generate_block {
                 return Ok(Json(SetTimeResponse { block_timestamp: data.time, block_hash: None }));
             }

--- a/crates/starknet-devnet-server/src/api/http/models.rs
+++ b/crates/starknet-devnet-server/src/api/http/models.rs
@@ -52,14 +52,20 @@ pub struct AbortedBlocks {
 }
 
 #[derive(Deserialize)]
-pub struct Time {
+pub struct IncreaseTime {
     pub time: u64,
+}
+
+#[derive(Deserialize)]
+pub struct SetTime {
+    pub time: u64,
+    pub generate_block: Option<bool>,
 }
 
 #[derive(Serialize)]
 pub struct SetTimeResponse {
     pub block_timestamp: u64,
-    pub block_hash: BlockHash,
+    pub block_hash: Option<BlockHash>,
 }
 
 #[derive(Serialize)]

--- a/crates/starknet-devnet/tests/test_advancing_time.rs
+++ b/crates/starknet-devnet/tests/test_advancing_time.rs
@@ -581,4 +581,37 @@ mod advancing_time_tests {
             - last_block["timestamp"].as_i64().unwrap();
         assert!(timestamp_diff.abs() < BUFFER_TIME_SECONDS as i64)
     }
+
+    #[tokio::test]
+    async fn set_time_with_later_block_generation() {
+        let now = get_unix_timestamp_as_seconds();
+        let devnet = BackgroundDevnet::spawn_with_additional_args(&[
+            "--start-time",
+            now.to_string().as_str(),
+        ])
+        .await
+        .expect("Could not start Devnet");
+
+        // set time in past without block generation
+        let past_time = 1;
+        let set_time_body =
+            Body::from(json!({ "time": past_time, "generate_block": false }).to_string());
+        let resp_set_time = devnet.post_json("/set_time".into(), set_time_body).await.unwrap();
+        let resp_body_set_time = get_json_body(resp_set_time).await;
+
+        // time is set but the block was not generated
+        assert_eq!(resp_body_set_time["block_timestamp"], past_time);
+        assert_eq!(resp_body_set_time["block_hash"].to_string(), "null");
+
+        // wait 1 second
+        thread::sleep(time::Duration::from_secs(1));
+
+        devnet.post_json("/create_block".into(), Body::from(json!({}).to_string())).await.unwrap();
+        let empty_block = &devnet
+            .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
+            .await["result"];
+
+        assert_eq!(empty_block["block_number"], 0);
+        assert_eq!(empty_block["timestamp"], past_time);
+    }
 }

--- a/crates/starknet-devnet/tests/test_advancing_time.rs
+++ b/crates/starknet-devnet/tests/test_advancing_time.rs
@@ -601,7 +601,7 @@ mod advancing_time_tests {
 
         // time is set but the block was not generated
         assert_eq!(resp_body_set_time["block_timestamp"], past_time);
-        assert_eq!(resp_body_set_time["block_hash"].to_string(), "null");
+        assert!(resp_body_set_time["block_hash"].is_null());
 
         // wait 1 second
         thread::sleep(time::Duration::from_secs(1));

--- a/crates/starknet-devnet/tests/test_advancing_time.rs
+++ b/crates/starknet-devnet/tests/test_advancing_time.rs
@@ -606,12 +606,13 @@ mod advancing_time_tests {
         // wait 1 second
         thread::sleep(time::Duration::from_secs(1));
 
+        // create block and assert
         devnet.post_json("/create_block".into(), Body::from(json!({}).to_string())).await.unwrap();
-        let empty_block = &devnet
+        let latest_block = &devnet
             .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
             .await["result"];
 
-        assert_eq!(empty_block["block_number"], 0);
-        assert_eq!(empty_block["timestamp"], past_time);
+        assert_eq!(latest_block["block_number"], 0);
+        assert_eq!(latest_block["timestamp"], past_time);
     }
 }

--- a/crates/starknet-devnet/tests/test_dump_and_load.rs
+++ b/crates/starknet-devnet/tests/test_dump_and_load.rs
@@ -428,9 +428,9 @@ mod dump_and_load_tests {
             .post_json("/create_block".into(), Body::from(json!({}).to_string()))
             .await
             .unwrap();
-        let _ = &devnet_dump
+        devnet_dump
             .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
-            .await["result"];
+            .await;
 
         // dump and load
         send_ctrl_c_signal_and_wait(&devnet_dump.process).await;


### PR DESCRIPTION
## Usage related changes

- Add generate_block option in set time API call

## Development related changes

- `next_block_timestamp` property in `Starknet` struct was added

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Checked the TODO section in README.md if this PR resolves it
- [x] Updated the tests
- [x] All tests are passing - `cargo test`
