### PR TITLE
Fix panic on binding to occupied port

### DIFF
--- a/crates/starknet-devnet-server/src/builder.rs
+++ b/crates/starknet-devnet-server/src/builder.rs
@@ -13,6 +13,7 @@ use tower_http::cors::CorsLayer;
 use tower_http::timeout::TimeoutLayer;
 use tower_http::trace::TraceLayer;
 
+use crate::error::ServerResult;
 use crate::rpc_handler::{self, RpcHandler};
 use crate::ServerConfig;
 
@@ -91,7 +92,7 @@ impl<TJsonRpcHandler: RpcHandler, THttpApiHandler: Clone + Send + Sync + 'static
     /// [`ServerConfig`] and all handlers that have Some value. If TJsonRpcHandler and/or
     /// THttpApiHandler are set each methods that serves the route will be able to use it.
     /// https://docs.rs/axum/latest/axum/#using-request-extensions
-    pub fn build(self, starknet_config: &StarknetConfig) -> StarknetDevnetServer {
+    pub fn build(self, starknet_config: &StarknetConfig) -> ServerResult<StarknetDevnetServer> {
         let mut svc = self.routes;
 
         svc = svc
@@ -111,6 +112,6 @@ impl<TJsonRpcHandler: RpcHandler, THttpApiHandler: Clone + Send + Sync + 'static
             )
         }
 
-        Server::bind(&self.address).serve(svc.into_make_service())
+        Ok(Server::try_bind(&self.address)?.serve(svc.into_make_service()))
     }
 }

--- a/crates/starknet-devnet-server/src/error.rs
+++ b/crates/starknet-devnet-server/src/error.rs
@@ -1,0 +1,7 @@
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    HyperError(#[from] hyper::Error),
+}
+
+pub type ServerResult<T, E = Error> = Result<T, E>;

--- a/crates/starknet-devnet-server/src/lib.rs
+++ b/crates/starknet-devnet-server/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod builder;
 mod config;
+pub mod error;
 pub mod rpc_core;
 /// handlers for axum server
 pub mod rpc_handler;

--- a/crates/starknet-devnet-server/src/server.rs
+++ b/crates/starknet-devnet-server/src/server.rs
@@ -7,6 +7,7 @@ use crate::api::http::{endpoints as http, HttpApiHandler};
 use crate::api::json_rpc::JsonRpcHandler;
 use crate::api::Api;
 use crate::builder::StarknetDevnetServer;
+use crate::error::ServerResult;
 use crate::ServerConfig;
 
 /// Configures an [axum::Server] that handles related JSON-RPC calls and WEB API calls via HTTP
@@ -15,7 +16,7 @@ pub fn serve_http_api_json_rpc(
     config: ServerConfig,
     api: Api,
     starknet_config: &StarknetConfig,
-) -> StarknetDevnetServer {
+) -> ServerResult<StarknetDevnetServer> {
     let http = HttpApiHandler { api: api.clone() };
     let json_rpc = JsonRpcHandler { api };
 

--- a/crates/starknet-devnet/src/main.rs
+++ b/crates/starknet-devnet/src/main.rs
@@ -105,7 +105,7 @@ async fn main() -> Result<(), anyhow::Error> {
     );
 
     let server =
-        serve_http_api_json_rpc(addr, ServerConfig::default(), api.clone(), &starknet_config);
+        serve_http_api_json_rpc(addr, ServerConfig::default(), api.clone(), &starknet_config)?;
     addr = server.local_addr();
 
     info!("Starknet Devnet listening on {}", addr);


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->
Explicit error if binding is failed.

## Development related changes
Panic removed, hence ability to properly handle error.
<!-- How these changes affect the developers of this project. E.g. changes in dev tools, testing, CI/CD... -->

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Documented the changes
- [ ] Linked the issues which this PR resolves
- [x] Checked the TODO section in README.md if this PR resolves it
- [ ] Updated the tests
- [x] All tests are passing - `cargo test`
