### PR TITLE
Missing data gas price in rpc endpoints

### DIFF
--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -1193,9 +1193,13 @@ mod tests {
         let mut starknet = Starknet::new(&config).unwrap();
 
         let initial_block_number = starknet.block_context.block_info().block_number;
-        let initial_gas_price = starknet.block_context.block_info().gas_prices.eth_l1_gas_price;
-        let initial_data_gas_price =
+        let initial_gas_price_wei = starknet.block_context.block_info().gas_prices.eth_l1_gas_price;
+        let initial_gas_price_fri =
+            starknet.block_context.block_info().gas_prices.strk_l1_gas_price;
+        let initial_data_gas_price_wei =
             starknet.block_context.block_info().gas_prices.eth_l1_data_gas_price;
+        let initial_data_gas_price_fri =
+            starknet.block_context.block_info().gas_prices.strk_l1_data_gas_price;
         let initial_block_timestamp = starknet.block_context.block_info().block_timestamp;
         let initial_sequencer = starknet.block_context.block_info().sequencer_address;
 
@@ -1219,11 +1223,19 @@ mod tests {
         assert_eq!(starknet.pending_block().header.parent_hash, BlockHash::default());
         assert_eq!(
             starknet.pending_block().header.l1_gas_price.price_in_wei,
-            GasPrice(initial_gas_price.get())
+            GasPrice(initial_gas_price_wei.get())
+        );
+        assert_eq!(
+            starknet.pending_block().header.l1_gas_price.price_in_fri,
+            GasPrice(initial_gas_price_fri.get())
         );
         assert_eq!(
             starknet.pending_block().header.l1_data_gas_price.price_in_wei,
-            GasPrice(initial_data_gas_price.get())
+            GasPrice(initial_data_gas_price_wei.get())
+        );
+        assert_eq!(
+            starknet.pending_block().header.l1_data_gas_price.price_in_fri,
+            GasPrice(initial_data_gas_price_fri.get())
         );
         assert_eq!(starknet.pending_block().header.sequencer.0, initial_sequencer);
     }

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -1194,6 +1194,8 @@ mod tests {
 
         let initial_block_number = starknet.block_context.block_info().block_number;
         let initial_gas_price = starknet.block_context.block_info().gas_prices.eth_l1_gas_price;
+        let initial_data_gas_price =
+            starknet.block_context.block_info().gas_prices.eth_l1_data_gas_price;
         let initial_block_timestamp = starknet.block_context.block_info().block_timestamp;
         let initial_sequencer = starknet.block_context.block_info().sequencer_address;
 
@@ -1218,6 +1220,10 @@ mod tests {
         assert_eq!(
             starknet.pending_block().header.l1_gas_price.price_in_wei,
             GasPrice(initial_gas_price.get())
+        );
+        assert_eq!(
+            starknet.pending_block().header.l1_data_gas_price.price_in_wei,
+            GasPrice(initial_data_gas_price.get())
         );
         assert_eq!(starknet.pending_block().header.sequencer.0, initial_sequencer);
     }

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -501,6 +501,14 @@ impl Starknet {
                 self.block_context.block_info().gas_prices.eth_l1_gas_price.get(),
             ),
         };
+        block.header.l1_data_gas_price = GasPricePerToken {
+            price_in_fri: GasPrice(
+                self.block_context.block_info().gas_prices.strk_l1_data_gas_price.get(),
+            ),
+            price_in_wei: GasPrice(
+                self.block_context.block_info().gas_prices.eth_l1_data_gas_price.get(),
+            ),
+        };
         block.header.sequencer =
             SequencerContractAddress(self.block_context.block_info().sequencer_address);
 


### PR DESCRIPTION
## Usage related changes

An issue reported that starknet_getBlockWithReceipts return 0 for data_gas_price.


## Checklist:

- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
- [ ] Performed code self-review
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Documented the changes
- [ ] Linked the issues which this PR resolves
- [ ] Checked the TODO section in README.md if this PR resolves it
- [ ] Updated the tests
- [ ] All tests are passing - `cargo test`
