### PR TITLE
Add /account_balance endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ POST /mint
 Check the balance of an address by sending a GET request to `/account_balance`. The address should be a 0x-prefixed hex string; the unit defaults to `WEI`.
 
 ```
-GET /account_balance?address=<ADDRESS>&unit=[FRI|WEI]
+GET /account_balance?address=<ADDRESS>&[unit=<FRI|WEI>]
 ```
 
 ## Dumping & Loading

--- a/README.md
+++ b/README.md
@@ -212,6 +212,14 @@ POST /mint
 }
 ```
 
+### Check balance
+
+Check the balance of an address by sending a GET request to `/account_balance`. The address should be a 0x-prefixed hex string; the unit defaults to `WEI`.
+
+```
+GET /account_balance?address=<ADDRESS>&unit=[FRI|WEI]
+```
+
 ## Dumping & Loading
 
 To preserve your Devnet instance for future use, these are the options:

--- a/crates/starknet-devnet-server/src/api/http/endpoints/accounts.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/accounts.rs
@@ -47,7 +47,7 @@ pub async fn get_account_balance(
 
     let mut starknet = state.api.starknet.write().await;
 
-    let balance = get_balance(&mut starknet, account_address, erc20_address)
+    let amount = get_balance(&mut starknet, account_address, erc20_address)
         .map_err(|e| HttpApiError::GeneralError(e.to_string()))?;
-    Ok(Json(Balance { amount: balance.to_str_radix(10), unit }))
+    Ok(Json(Balance { amount, unit }))
 }

--- a/crates/starknet-devnet-server/src/api/http/endpoints/accounts.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/accounts.rs
@@ -48,6 +48,6 @@ pub async fn get_account_balance(
     let mut starknet = state.api.starknet.write().await;
 
     let balance = get_balance(&mut starknet, account_address, erc20_address)
-        .map_err(|_| HttpApiError::GeneralError)?;
+        .map_err(|e| HttpApiError::GeneralError(e.to_string()))?;
     Ok(Json(Balance { amount: balance.to_str_radix(10), unit }))
 }

--- a/crates/starknet-devnet-server/src/api/http/endpoints/accounts.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/accounts.rs
@@ -1,7 +1,10 @@
 use axum::extract::Query;
 use axum::{Extension, Json};
 use starknet_types::contract_address::ContractAddress;
+use starknet_types::felt::Felt;
+use starknet_types::rpc::transaction_receipt::FeeUnit;
 
+use super::mint_token::{get_balance, get_erc20_address};
 use crate::api::http::error::HttpApiError;
 use crate::api::http::models::{Balance, SerializableAccount};
 use crate::api::http::{HttpApiHandler, HttpApiResult};
@@ -27,8 +30,24 @@ pub async fn get_predeployed_accounts(
     Ok(Json(predeployed_accounts))
 }
 
+#[derive(serde::Deserialize, Debug)]
+pub struct BalanceQuery {
+    address: Felt,
+    unit: Option<FeeUnit>,
+}
+
 pub async fn get_account_balance(
-    Query(_contract_address): Query<ContractAddress>,
+    Extension(state): Extension<HttpApiHandler>,
+    Query(params): Query<BalanceQuery>,
 ) -> HttpApiResult<Json<Balance>> {
-    Err(HttpApiError::GeneralError)
+    let account_address = ContractAddress::new(params.address)
+        .map_err(|e| HttpApiError::InvalidValueError { msg: e.to_string() })?;
+    let unit = params.unit.unwrap_or(FeeUnit::WEI);
+    let erc20_address = get_erc20_address(&unit);
+
+    let mut starknet = state.api.starknet.write().await;
+
+    let balance = get_balance(&mut starknet, account_address, erc20_address)
+        .map_err(|_| HttpApiError::GeneralError)?;
+    Ok(Json(Balance { amount: balance.to_str_radix(10), unit }))
 }

--- a/crates/starknet-devnet-server/src/api/http/endpoints/blocks.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/blocks.rs
@@ -20,5 +20,5 @@ pub async fn create_block(
 }
 
 pub async fn abort_blocks(Json(_data): Json<AbortingBlocks>) -> HttpApiResult<Json<AbortedBlocks>> {
-    Err(HttpApiError::GeneralError)
+    Err(HttpApiError::GeneralError("Unimplemented".into()))
 }

--- a/crates/starknet-devnet-server/src/api/http/endpoints/mint_token.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/mint_token.rs
@@ -8,13 +8,9 @@ use starknet_types::num_bigint::BigUint;
 use starknet_types::rpc::transaction_receipt::FeeUnit;
 
 use crate::api::http::error::HttpApiError;
-use crate::api::http::models::{FeeToken, MintTokensRequest, MintTokensResponse};
+use crate::api::http::models::{MintTokensRequest, MintTokensResponse};
 use crate::api::http::{HttpApiHandler, HttpApiResult};
 use crate::api::json_rpc::error::ApiError;
-
-pub async fn get_fee_token() -> HttpApiResult<Json<FeeToken>> {
-    Err(HttpApiError::GeneralError)
-}
 
 /// get the balance of the `address`
 pub fn get_balance(

--- a/crates/starknet-devnet-server/src/api/http/endpoints/mint_token.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/mint_token.rs
@@ -5,7 +5,7 @@ use starknet_rs_core::types::{BlockId, BlockTag};
 use starknet_types::contract_address::ContractAddress;
 use starknet_types::felt::Felt;
 use starknet_types::num_bigint::BigUint;
-use starknet_types::rpc::transaction_receipt::FeeUnits;
+use starknet_types::rpc::transaction_receipt::FeeUnit;
 
 use crate::api::http::error::HttpApiError;
 use crate::api::http::models::{FeeToken, MintTokensRequest, MintTokensResponse};
@@ -17,7 +17,7 @@ pub async fn get_fee_token() -> HttpApiResult<Json<FeeToken>> {
 }
 
 /// get the balance of the `address`
-fn get_balance(
+pub fn get_balance(
     starknet: &mut Starknet,
     address: ContractAddress,
     erc20_address: ContractAddress,
@@ -46,22 +46,27 @@ fn get_balance(
     Ok(new_balance)
 }
 
+/// Returns the address of the ERC20 (fee token) contract associated with the unit.
+pub fn get_erc20_address(unit: &FeeUnit) -> ContractAddress {
+    match unit {
+        FeeUnit::WEI => {
+            ContractAddress::new(Felt::from_prefixed_hex_str(ETH_ERC20_CONTRACT_ADDRESS).unwrap())
+                .unwrap()
+        }
+        FeeUnit::FRI => {
+            ContractAddress::new(Felt::from_prefixed_hex_str(STRK_ERC20_CONTRACT_ADDRESS).unwrap())
+                .unwrap()
+        }
+    }
+}
+
 pub async fn mint(
     Json(request): Json<MintTokensRequest>,
     Extension(state): Extension<HttpApiHandler>,
 ) -> HttpApiResult<Json<MintTokensResponse>> {
     let mut starknet = state.api.starknet.write().await;
-    let unit = request.unit.unwrap_or(FeeUnits::WEI);
-    let erc20_address = match unit {
-        FeeUnits::WEI => {
-            ContractAddress::new(Felt::from_prefixed_hex_str(ETH_ERC20_CONTRACT_ADDRESS).unwrap())
-                .unwrap()
-        }
-        FeeUnits::FRI => {
-            ContractAddress::new(Felt::from_prefixed_hex_str(STRK_ERC20_CONTRACT_ADDRESS).unwrap())
-                .unwrap()
-        }
-    };
+    let unit = request.unit.unwrap_or(FeeUnit::WEI);
+    let erc20_address = get_erc20_address(&unit);
 
     // increase balance
     let tx_hash = starknet

--- a/crates/starknet-devnet-server/src/api/http/endpoints/mod.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/mod.rs
@@ -41,5 +41,5 @@ pub async fn restart(Extension(state): Extension<HttpApiHandler>) -> HttpApiResu
 
 /// Fork
 pub async fn get_fork_status() -> HttpApiResult<Json<ForkStatus>> {
-    Err(HttpApiError::GeneralError)
+    Err(HttpApiError::GeneralError("Unimplemented".into()))
 }

--- a/crates/starknet-devnet-server/src/api/http/error.rs
+++ b/crates/starknet-devnet-server/src/api/http/error.rs
@@ -6,8 +6,8 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum HttpApiError {
-    #[error("General error")]
-    GeneralError,
+    #[error("{0}")]
+    GeneralError(String),
     #[error("Minting error: {msg}")]
     MintingError { msg: String },
     #[error("The file does not exist")]
@@ -35,7 +35,7 @@ pub enum HttpApiError {
 impl IntoResponse for HttpApiError {
     fn into_response(self) -> axum::response::Response {
         let (status, error_message) = match self {
-            err @ HttpApiError::GeneralError => (StatusCode::BAD_REQUEST, err.to_string()),
+            HttpApiError::GeneralError(err) => (StatusCode::BAD_REQUEST, err.to_string()),
             err @ HttpApiError::FileNotFound => (StatusCode::BAD_REQUEST, err.to_string()),
             err @ HttpApiError::DumpError { msg: _ } => (StatusCode::BAD_REQUEST, err.to_string()),
             err @ HttpApiError::LoadError => (StatusCode::BAD_REQUEST, err.to_string()),

--- a/crates/starknet-devnet-server/src/api/http/models.rs
+++ b/crates/starknet-devnet-server/src/api/http/models.rs
@@ -5,7 +5,7 @@ use starknet_types::felt::{BlockHash, Calldata, EntryPointSelector, Felt, Nonce,
 use starknet_types::num_bigint::BigUint;
 use starknet_types::rpc::eth_address::EthAddressWrapper;
 use starknet_types::rpc::messaging::{MessageToL1, MessageToL2};
-use starknet_types::rpc::transaction_receipt::FeeUnits;
+use starknet_types::rpc::transaction_receipt::FeeUnit;
 use starknet_types::rpc::transactions::L1HandlerTransaction;
 use starknet_types::serde_helpers::dec_string::deserialize_biguint;
 
@@ -86,8 +86,8 @@ pub struct SerializableAccount {
 
 #[derive(Serialize)]
 pub struct Balance {
-    amount: BigUint,
-    unit: String,
+    pub amount: String,
+    pub unit: FeeUnit,
 }
 
 #[derive(Serialize)]
@@ -102,14 +102,14 @@ pub struct MintTokensRequest {
     #[serde(deserialize_with = "deserialize_biguint")]
     pub amount: BigUint,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit: Option<FeeUnits>,
+    pub unit: Option<FeeUnit>,
 }
 
 #[derive(Serialize)]
 pub struct MintTokensResponse {
     /// decimal repr
     pub new_balance: String,
-    pub unit: FeeUnits,
+    pub unit: FeeUnit,
     pub tx_hash: TransactionHash,
 }
 

--- a/crates/starknet-devnet-server/src/api/http/models.rs
+++ b/crates/starknet-devnet-server/src/api/http/models.rs
@@ -86,7 +86,7 @@ pub struct SerializableAccount {
 
 #[derive(Serialize)]
 pub struct Balance {
-    pub amount: String,
+    pub amount: BigUint,
     pub unit: FeeUnit,
 }
 

--- a/crates/starknet-devnet-server/src/server.rs
+++ b/crates/starknet-devnet-server/src/server.rs
@@ -44,7 +44,6 @@ pub fn serve_http_api_json_rpc(
         .http_api_route("/increase_time", post(http::time::increase_time))
         .http_api_route("/predeployed_accounts", get(http::accounts::get_predeployed_accounts))
         .http_api_route("/account_balance", get(http::accounts::get_account_balance))
-        .http_api_route("/fee_token", get(http::mint_token::get_fee_token))
         .http_api_route("/mint", post(http::mint_token::mint))
         .http_api_route("/fork_status", get(http::get_fork_status))
         .build(starknet_config)

--- a/crates/starknet-devnet-types/src/rpc/transaction_receipt.rs
+++ b/crates/starknet-devnet-types/src/rpc/transaction_receipt.rs
@@ -281,7 +281,16 @@ pub enum FeeInUnits {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub enum FeeUnits {
+pub enum FeeUnit {
     WEI,
     FRI,
+}
+
+impl std::fmt::Display for FeeUnit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            FeeUnit::WEI => "WEI",
+            FeeUnit::FRI => "FRI",
+        })
+    }
 }

--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -9,14 +9,11 @@ use hyper::http::request;
 use hyper::{Body, Client, Response, StatusCode, Uri};
 use lazy_static::lazy_static;
 use serde_json::json;
-use starknet_core::constants::ETH_ERC20_CONTRACT_ADDRESS;
-use starknet_rs_core::types::{BlockId, BlockTag, FieldElement, FunctionCall};
-use starknet_rs_core::utils::get_selector_from_name;
+use starknet_rs_core::types::FieldElement;
 use starknet_rs_providers::jsonrpc::HttpTransport;
-use starknet_rs_providers::{JsonRpcClient, Provider};
+use starknet_rs_providers::JsonRpcClient;
 use starknet_rs_signers::{LocalWallet, SigningKey};
-use starknet_types::felt::Felt;
-use starknet_types::num_bigint::BigUint;
+use starknet_types::rpc::transaction_receipt::FeeUnit;
 use tokio::sync::Mutex;
 use url::Url;
 
@@ -200,18 +197,21 @@ impl BackgroundDevnet {
     }
 
     /// Get balance at contract_address, as written in ERC20
-    pub async fn get_balance(&self, address: &FieldElement) -> Result<FieldElement, anyhow::Error> {
-        let call = FunctionCall {
-            contract_address: FieldElement::from_hex_be(ETH_ERC20_CONTRACT_ADDRESS).unwrap(),
-            entry_point_selector: get_selector_from_name("balanceOf").unwrap(),
-            calldata: vec![*address],
-        };
-        let balance_raw = self.json_rpc_client.call(call, BlockId::Tag(BlockTag::Latest)).await?;
-        assert_eq!(balance_raw.len(), 2);
-        let balance_low: BigUint = (Felt::from(*balance_raw.get(0).unwrap())).into();
-        let balance_high: BigUint = (Felt::from(*balance_raw.get(1).unwrap())).into();
-        let balance: BigUint = (balance_high << 128) + balance_low;
-        Ok(FieldElement::from_byte_slice_be(&balance.to_bytes_be())?)
+    pub async fn get_balance(
+        &self,
+        address: &FieldElement,
+        unit: FeeUnit,
+    ) -> Result<FieldElement, anyhow::Error> {
+        let params = format!("address={:#x}&unit={}", address, unit);
+
+        let resp = self.get("/account_balance", Some(params)).await?;
+        let json_resp = get_json_body(resp).await;
+
+        let amount = serde_json::from_value(json_resp["amount"].clone()).unwrap();
+        let received_unit: FeeUnit = serde_json::from_value(json_resp["unit"].clone()).unwrap();
+        assert_eq!(received_unit, unit);
+
+        Ok(amount)
     }
 
     pub async fn get(
@@ -219,12 +219,7 @@ impl BackgroundDevnet {
         path: &str,
         query: Option<String>,
     ) -> Result<Response<Body>, hyper::Error> {
-        let uri = if query.is_none() {
-            format!("{}{}", self.url, path)
-        } else {
-            format!("{}{}?{}", self.url, path, query.unwrap())
-        };
-
+        let uri = format!("{}{}?{}", self.url, path, query.unwrap_or("".into()));
         let response = self.http_client.get(uri.as_str().parse::<Uri>().unwrap()).await.unwrap();
         Ok(response)
     }

--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -13,6 +13,7 @@ use starknet_rs_core::types::FieldElement;
 use starknet_rs_providers::jsonrpc::HttpTransport;
 use starknet_rs_providers::JsonRpcClient;
 use starknet_rs_signers::{LocalWallet, SigningKey};
+use starknet_types::num_bigint::BigUint;
 use starknet_types::rpc::transaction_receipt::FeeUnit;
 use tokio::sync::Mutex;
 use url::Url;
@@ -207,11 +208,12 @@ impl BackgroundDevnet {
         let resp = self.get("/account_balance", Some(params)).await?;
         let json_resp = get_json_body(resp).await;
 
-        let amount = serde_json::from_value(json_resp["amount"].clone()).unwrap();
+        let amount: BigUint = serde_json::from_value(json_resp["amount"].clone()).unwrap();
         let received_unit: FeeUnit = serde_json::from_value(json_resp["unit"].clone()).unwrap();
         assert_eq!(received_unit, unit);
 
-        Ok(amount)
+        let felt_amount = FieldElement::from_hex_be(&amount.to_str_radix(16))?;
+        Ok(felt_amount)
     }
 
     pub async fn get(

--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -196,7 +196,7 @@ impl BackgroundDevnet {
         FieldElement::from_hex_be(resp_body["tx_hash"].as_str().unwrap()).unwrap()
     }
 
-    /// Get balance at contract_address, as written in ERC20
+    /// Get balance at contract_address, as written in the ERC20 contract corresponding to `unit`
     pub async fn get_balance(
         &self,
         address: &FieldElement,

--- a/crates/starknet-devnet/tests/test_call.rs
+++ b/crates/starknet-devnet/tests/test_call.rs
@@ -4,6 +4,7 @@ mod call {
     use starknet_core::constants::ETH_ERC20_CONTRACT_ADDRESS;
     use starknet_rs_core::types::{BlockId, BlockTag, FieldElement, FunctionCall, StarknetError};
     use starknet_rs_providers::{Provider, ProviderError};
+    use starknet_types::rpc::transaction_receipt::FeeUnit;
 
     use crate::common::background_devnet::BackgroundDevnet;
     use crate::common::constants::{
@@ -70,7 +71,7 @@ mod call {
         let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
         let contract_address = FieldElement::from_hex_be(PREDEPLOYED_ACCOUNT_ADDRESS).unwrap();
 
-        let retrieved_result = devnet.get_balance(&contract_address).await.unwrap();
+        let retrieved_result = devnet.get_balance(&contract_address, FeeUnit::WEI).await.unwrap();
 
         let expected_hex_balance = format!("0x{PREDEPLOYED_ACCOUNT_INITIAL_BALANCE:x}");
         let expected_balance = FieldElement::from_hex_be(expected_hex_balance.as_str()).unwrap();

--- a/crates/starknet-devnet/tests/test_dump_and_load.rs
+++ b/crates/starknet-devnet/tests/test_dump_and_load.rs
@@ -7,6 +7,7 @@ mod dump_and_load_tests {
     use hyper::Body;
     use serde_json::json;
     use starknet_rs_providers::Provider;
+    use starknet_types::rpc::transaction_receipt::FeeUnit;
 
     use crate::common::background_devnet::BackgroundDevnet;
     use crate::common::utils::{send_ctrl_c_signal_and_wait, UniqueAutoDeletableFile};
@@ -386,8 +387,10 @@ mod dump_and_load_tests {
         let load_body = Body::from(json!({ "path": dump_file.path }).to_string());
         devnet_load.post_json("/load".into(), load_body).await.unwrap();
 
-        let balance_result =
-            devnet_load.get_balance(&FieldElement::from(DUMMY_ADDRESS)).await.unwrap();
+        let balance_result = devnet_load
+            .get_balance(&FieldElement::from(DUMMY_ADDRESS), FeeUnit::WEI)
+            .await
+            .unwrap();
         assert_eq!(balance_result, DUMMY_AMOUNT.into());
 
         let loaded_transaction =

--- a/crates/starknet-devnet/tests/test_minting.rs
+++ b/crates/starknet-devnet/tests/test_minting.rs
@@ -3,7 +3,9 @@ pub mod common;
 mod minting_tests {
     use hyper::{Body, StatusCode};
     use serde_json::json;
+    use starknet_rs_core::types::FieldElement;
     use starknet_types::num_bigint::BigUint;
+    use starknet_types::rpc::transaction_receipt::FeeUnit;
 
     use crate::common::background_devnet::BackgroundDevnet;
     use crate::common::constants::{
@@ -18,7 +20,7 @@ mod minting_tests {
         address: &str,
         init_amount: u128,
         mint_amount: u128,
-        unit: &str,
+        unit: FeeUnit,
     ) {
         let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
         let req_body = Body::from(
@@ -37,26 +39,33 @@ mod minting_tests {
 
         // tx hash is not constant so we later just assert its general form
         let tx_hash_value = resp_body["tx_hash"].take();
+        let final_balance = BigUint::from(init_amount) + BigUint::from(mint_amount);
         assert_eq!(
             resp_body,
             json!({
-                "new_balance": (BigUint::from(init_amount) + BigUint::from(mint_amount)).to_string(),
+                "new_balance": final_balance.to_string(),
                 "unit": unit,
                 "tx_hash": null
             })
         );
 
         assert!(tx_hash_value.as_str().unwrap().starts_with("0x"));
+
+        let new_balance =
+            devnet.get_balance(&FieldElement::from_hex_be(address).unwrap(), unit).await.unwrap();
+
+        let final_balance = FieldElement::from_dec_str(&final_balance.to_str_radix(10)).unwrap();
+        assert_eq!(final_balance, new_balance);
     }
 
     #[tokio::test]
     async fn increase_balance_of_undeployed_address_wei() {
-        increase_balance_happy_path(DUMMY_ADDRESS, 0, DUMMY_AMOUNT, "WEI").await;
+        increase_balance_happy_path(DUMMY_ADDRESS, 0, DUMMY_AMOUNT, FeeUnit::WEI).await;
     }
 
     #[tokio::test]
     async fn increase_balance_of_undeployed_address_fri() {
-        increase_balance_happy_path(DUMMY_ADDRESS, 0, DUMMY_AMOUNT, "FRI").await;
+        increase_balance_happy_path(DUMMY_ADDRESS, 0, DUMMY_AMOUNT, FeeUnit::FRI).await;
     }
 
     #[tokio::test]
@@ -95,7 +104,7 @@ mod minting_tests {
             PREDEPLOYED_ACCOUNT_ADDRESS,
             PREDEPLOYED_ACCOUNT_INITIAL_BALANCE,
             DUMMY_AMOUNT,
-            "WEI",
+            FeeUnit::WEI,
         )
         .await
     }
@@ -106,7 +115,7 @@ mod minting_tests {
             PREDEPLOYED_ACCOUNT_ADDRESS,
             PREDEPLOYED_ACCOUNT_INITIAL_BALANCE,
             u128::MAX,
-            "WEI",
+            FeeUnit::WEI,
         )
         .await
     }
@@ -121,64 +130,60 @@ mod minting_tests {
         // 4. now tx succeeds
     }
 
-    async fn reject_bad_request(
-        devnet: &BackgroundDevnet,
-        json_body: serde_json::Value,
-        expected_status_code: StatusCode,
-    ) {
+    async fn reject_bad_minting_request(json_body: serde_json::Value) {
+        let devnet = BackgroundDevnet::spawn().await.unwrap();
         let req_body = Body::from(json_body.to_string());
         let resp = devnet.post_json("/mint".into(), req_body).await.unwrap();
-        assert_eq!(resp.status(), expected_status_code, "Checking status of {resp:?}");
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY, "Checking status of {resp:?}");
     }
 
     #[tokio::test]
     async fn reject_unknown_unit() {
-        let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
-        reject_bad_request(
-            &devnet,
-            json!({
-                "address": DUMMY_ADDRESS,
-                "amount": DUMMY_AMOUNT,
-                "unit": "Satoshi"
-            }),
-            StatusCode::UNPROCESSABLE_ENTITY,
-        )
+        reject_bad_minting_request(json!({
+            "address": DUMMY_ADDRESS,
+            "amount": DUMMY_AMOUNT,
+            "unit": "Satoshi"
+        }))
         .await;
     }
 
     #[tokio::test]
     async fn reject_negative_amount() {
-        let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
-        reject_bad_request(
-            &devnet,
-            json!({
-                "address": DUMMY_ADDRESS,
-                "amount": -1
-            }),
-            StatusCode::UNPROCESSABLE_ENTITY,
-        )
+        reject_bad_minting_request(json!({
+            "address": DUMMY_ADDRESS,
+            "amount": -1
+        }))
         .await;
     }
 
     #[tokio::test]
     async fn reject_missing_address() {
-        let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
-        reject_bad_request(
-            &devnet,
-            json!({ "amount": DUMMY_AMOUNT }),
-            StatusCode::UNPROCESSABLE_ENTITY,
-        )
-        .await;
+        reject_bad_minting_request(json!({ "amount": DUMMY_AMOUNT })).await;
     }
 
     #[tokio::test]
     async fn reject_missing_amount() {
-        let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
-        reject_bad_request(
-            &devnet,
-            json!({ "address": DUMMY_ADDRESS }),
-            StatusCode::UNPROCESSABLE_ENTITY,
-        )
-        .await;
+        reject_bad_minting_request(json!({ "address": DUMMY_ADDRESS })).await;
+    }
+
+    async fn reject_bad_balance_query(query: &str) {
+        let devnet = BackgroundDevnet::spawn().await.unwrap();
+        let resp = devnet.get("/account_balance", Some(query.into())).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY, "Checking status of {resp:?}");
+    }
+
+    #[tokio::test]
+    async fn reject_if_no_params_when_querying() {
+        reject_bad_balance_query("").await;
+    }
+
+    #[tokio::test]
+    async fn reject_missing_address_when_querying() {
+        reject_bad_balance_query("unit=FRI").await;
+    }
+
+    #[tokio::test]
+    async fn reject_invalid_unit_when_querying() {
+        reject_bad_balance_query("address=0x1&unit=INVALID").await;
     }
 }

--- a/crates/starknet-devnet/tests/test_restart.rs
+++ b/crates/starknet-devnet/tests/test_restart.rs
@@ -16,6 +16,7 @@ mod test_restart {
     use starknet_rs_core::types::{BlockId, BlockTag, FieldElement, StarknetError};
     use starknet_rs_core::utils::get_storage_var_address;
     use starknet_rs_providers::{Provider, ProviderError};
+    use starknet_types::rpc::transaction_receipt::FeeUnit;
 
     use crate::common::background_devnet::BackgroundDevnet;
     use crate::common::constants::CHAIN_ID;
@@ -175,12 +176,14 @@ mod test_restart {
 
         let predeployed_account_addresss = devnet.get_first_predeployed_account().await.1;
 
-        let balance_before = devnet.get_balance(&predeployed_account_addresss).await.unwrap();
+        let balance_before =
+            devnet.get_balance(&predeployed_account_addresss, FeeUnit::WEI).await.unwrap();
         assert_eq!(balance_before, FieldElement::from(initial_balance));
 
         devnet.restart().await.unwrap();
 
-        let balance_after = devnet.get_balance(&predeployed_account_addresss).await.unwrap();
+        let balance_after =
+            devnet.get_balance(&predeployed_account_addresss, FeeUnit::WEI).await.unwrap();
         assert_eq!(balance_before, balance_after);
     }
 


### PR DESCRIPTION
## Usage related changes

- Closes #393
- Adds the same `/account_balance` that existed in Devnet-py, but with added token specifier:
  - `GET /account_balance?address=<ADDRESS>&[unit=<WEI|FRI>]`
- Remove `/fee_token` - nobody's asked for it, it seems to be a remnant from times when ERC20 contracts were not deployed to the same addresses as on mainnet/testnet.
- Improve `GeneralError` message

## Development related changes

- Refactor `BackgroundDevnet::get_balance` to rely on the new endpoint.
- Refactor existing minting tests:
  - Add `/account_balance` testing
  - Simplify existing tests

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Checked the TODO section in README.md if this PR resolves it
- [x] Updated the tests
- [x] All tests are passing - `cargo test`
