### PR TITLE
Make data availability mode as Blob

### DIFF
--- a/crates/starknet-devnet-core/src/blocks/mod.rs
+++ b/crates/starknet-devnet-core/src/blocks/mod.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use indexmap::IndexMap;
 use starknet_api::block::{BlockHeader, BlockNumber, BlockStatus, BlockTimestamp};
+use starknet_api::data_availability::L1DataAvailabilityMode;
 use starknet_api::hash::{pedersen_hash_array, StarkFelt};
 use starknet_api::stark_felt;
 use starknet_rs_core::types::BlockId;
@@ -222,7 +223,10 @@ impl StarknetBlock {
 
     pub(crate) fn create_pending_block() -> Self {
         Self {
-            header: BlockHeader::default(),
+            header: BlockHeader {
+                l1_da_mode: L1DataAvailabilityMode::Blob,
+                ..BlockHeader::default()
+            },
             status: BlockStatus::Pending,
             transaction_hashes: Vec::new(),
         }

--- a/crates/starknet-devnet-core/src/blocks/mod.rs
+++ b/crates/starknet-devnet-core/src/blocks/mod.rs
@@ -703,6 +703,12 @@ mod tests {
         let block = StarknetBlock::create_pending_block();
         assert!(block.status == BlockStatus::Pending);
         assert!(block.transaction_hashes.is_empty());
-        assert_eq!(block.header, BlockHeader::default());
+        assert_eq!(
+            block.header,
+            BlockHeader {
+                l1_da_mode: starknet_api::data_availability::L1DataAvailabilityMode::Blob,
+                ..Default::default()
+            }
+        );
     }
 }


### PR DESCRIPTION
## Usage related changes

Make l1_da_mode in BlockHeader be Blob instead of the default one Calldata

## Checklist:

- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
- [ ] Performed code self-review
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Documented the changes
- [ ] Linked the issues which this PR resolves
- [ ] Checked the TODO section in README.md if this PR resolves it
- [ ] Updated the tests
- [ ] All tests are passing - `cargo test`
