### PR TITLE
Maintenance: improve block-manipulation tests, publishing executor, docs, PR template

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
   publish:
     docker:
       - image: cimg/rust:1.74.0
-    resource_class: medium
+    resource_class: large
     steps:
       - checkout
       - setup_remote_docker:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,7 @@
 
 ## Checklist:
 
+- [ ] Checked the relevant parts of the [Development](../README.md#development) section of the docs
 - [ ] Applied formatting - `./scripts/format.sh`
 - [ ] No linter errors - `./scripts/clippy_check.sh`
 - [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
@@ -15,6 +16,6 @@
 - [ ] Rebased to the last commit of the target branch (or merged it into my branch)
 - [ ] Documented the changes
 - [ ] Linked the issues which this PR resolves
-- [ ] Checked the TODO section in README.md if this PR resolves it
+- [ ] Checked the [TODO section of the docs](../README.md#todo-to-reach-feature-parity-with-the-pythonic-devnet)
 - [ ] Updated the tests
-- [ ] All tests are passing - `cargo test`
+- [ ] All tests are passing - [docs](../README.md#test-execution)

--- a/README.md
+++ b/README.md
@@ -29,11 +29,13 @@ This repository is work in progress, please be patient. Please check below the s
 - [x] Availability as a package (crate)
 - [x] [Forking](#forking)
 - [x] [L1-L2 Postman integration](https://0xspaceshard.github.io/starknet-devnet/docs/guide/postman)
+- [x] [Block manipulation](https://0xspaceshard.github.io/starknet-devnet/docs/guide/blocks)
+  - [x] Aborting blocks
+  - [x] Create an empty block
 
 ### TODO to reach feature parity with the Pythonic Devnet
 
-- [ ] [Block manipulation](https://0xspaceshard.github.io/starknet-devnet/docs/guide/blocks)
-  - [x] Create an empty block
+- [ ] Creating blocks on demand
 
 ## Requirements
 
@@ -282,11 +284,15 @@ A new block is generated with each new transaction, and you can create an empty 
 
 To create an empty block without transactions, POST a request to /create_block:
 
+```
 POST /create_block
+```
 
 Response:
 
-{'block_hash': '0x115e1b390cafa7942b6ab141ab85040defe7dee9bef3bc31d8b5b3d01cc9c67'}
+```
+{"block_hash": "0x115e1b390cafa7942b6ab141ab85040defe7dee9bef3bc31d8b5b3d01cc9c67"}
+```
 
 ### Abort blocks
 
@@ -408,11 +414,13 @@ cargo run -- --state-archive-capacity <CAPACITY>
 
 All RPC endpoints that support querying the state at an old (non-latest) block only work with state archive capacity set to `full`.
 
-## Development - Visual Studio Code
+## Development
+
+### Development - Visual Studio Code
 
 It is highly recommended to get familiar with [Visual Studio Code Dev Containers](https://code.visualstudio.com/docs/devcontainers/create-dev-container#_dockerfile) and install [rust-analyzer](https://code.visualstudio.com/docs/languages/rust) extension.
 
-## Development - Linter
+### Development - Linter
 
 Run the linter with:
 
@@ -420,7 +428,7 @@ Run the linter with:
 ./scripts/clippy_check.sh
 ```
 
-## Development - Formatter
+### Development - Formatter
 
 Run the formatter with:
 
@@ -440,7 +448,7 @@ Resolve it with:
 rustup default nightly
 ```
 
-## Development - Unused dependencies
+### Development - Unused dependencies
 
 To check for unused dependencies, run:
 
@@ -450,7 +458,7 @@ To check for unused dependencies, run:
 
 If you think this reports a dependency as a false-positive (i.e. isn't unused), check [here](https://github.com/bnjbvr/cargo-machete#false-positives).
 
-## Development - Testing
+### Development - Testing
 
 ### Prerequisites
 
@@ -458,7 +466,7 @@ Some tests require the `anvil` command, so you need to [install Foundry](https:/
 
 To ensure that integration tests pass, be sure to have run `cargo build --release` or `cargo run --release` prior to testing. This builds the production target used in integration tests, so spawning BackgroundDevnet won't time out.
 
-### Execution
+### Test execution
 
 Run all tests using all available CPUs with:
 
@@ -472,7 +480,7 @@ The previous command might cause your testing to die along the way due to memory
 cargo test --jobs <N>
 ```
 
-## Development - Docker
+### Development - Docker
 
 Due to internal needs, images with arch suffix are built and pushed to Docker Hub, but this is not mentioned in the user docs as users should NOT be needing it.
 
@@ -485,7 +493,7 @@ This is what happens under the hood on `main`:
 
 In the image, `tini` is used to properly handle killing of dockerized Devnet with Ctrl+C
 
-## Development - L1 / L2 (postman)
+### Development - L1 / L2 (postman)
 
 To test Starknet messaging, Devnet exposes endpoints prefixed with `postman/` which are dedicated to the messaging feature.
 You can find a full guide to test the messaging feature in the [contracts/l1-l2-messaging README](./contracts/l1-l2-messaging/README.md).
@@ -497,7 +505,7 @@ Devnet exposes the following endpoints:
 - `/postman/send_message_to_l2`: sends and executes a message on L2 (L1 node **not** required).
 - `/postman/consume_message_from_l2`: consumes a message on L1 node from the L2 (requires L1 node to be running).
 
-## Development - Update of OpenZeppelin contracts
+### Development - Update of OpenZeppelin contracts
 
 Tests in devnet require an erc20 contract with the `Mintable` feature, keep in mind that before the compilation process of [cairo-contracts](https://github.com/OpenZeppelin/cairo-contracts/) you need to mark the `Mintable` check box in this [wizard](https://wizard.openzeppelin.com/cairo) and copy this implementation to `/src/presets/erc20.cairo`.
 

--- a/README.md
+++ b/README.md
@@ -379,13 +379,13 @@ cargo run -- --timeout <TIMEOUT>
 
 ## Forking
 
-To interact with contracts deployed on mainnet or testnet, you can use the forking mode to simulate origin and experiment with it locally, making no changes to the origin itself.
+To interact with contracts deployed on mainnet or testnet, you can use the forking to simulate the origin and experiment with it locally, making no changes to the origin itself.
 
 ```
 cargo run -- --fork-network <URL> [--fork-block <BLOCK_NUMBER>]
 ```
 
-The value passed to `--fork-network` should be the URL to a Starknet JSON-RPC API provider. Specifying a `--fork-block` is optional - defaults to the `"latest"` block at the time of Devnet's start-up. All calls will first try Devnet's state and then fall back to the forking block.
+The value passed to `--fork-network` should be the URL to a Starknet JSON-RPC API provider. Specifying a `--fork-block` is optional; it defaults to the `"latest"` block at the time of Devnet's start-up. All calls will first try Devnet's state and then fall back to the forking block.
 
 ### Forking status
 

--- a/crates/starknet-devnet-server/src/api/http/error.rs
+++ b/crates/starknet-devnet-server/src/api/http/error.rs
@@ -24,7 +24,7 @@ pub enum HttpApiError {
     BlockSetTimeError { msg: String },
     #[error("The increase time operation failed: {msg}")]
     BlockIncreaseTimeError { msg: String },
-    #[error("The block abortion failed: {msg}")]
+    #[error("Block abortion failed: {msg}")]
     BlockAbortError { msg: String },
     #[error("Could not restart: {msg}")]
     RestartError { msg: String },

--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -10,7 +10,9 @@ use hyper::{Body, Client, Response, StatusCode, Uri};
 use lazy_static::lazy_static;
 use serde_json::json;
 use starknet_core::constants::ETH_ERC20_CONTRACT_ADDRESS;
-use starknet_rs_core::types::{BlockId, FieldElement, FunctionCall};
+use starknet_rs_core::types::{
+    BlockId, BlockTag, BlockWithTxHashes, FieldElement, FunctionCall, MaybePendingBlockWithTxHashes,
+};
 use starknet_rs_core::utils::get_selector_from_name;
 use starknet_rs_providers::jsonrpc::HttpTransport;
 use starknet_rs_providers::{JsonRpcClient, Provider};
@@ -284,6 +286,15 @@ impl BackgroundDevnet {
         let block_creation_resp_body = get_json_body(block_creation_resp).await;
         let block_hash_str = block_creation_resp_body["block_hash"].as_str().unwrap();
         Ok(FieldElement::from_hex_be(block_hash_str)?)
+    }
+
+    pub async fn get_latest_block_with_tx_hashes(
+        &self,
+    ) -> Result<BlockWithTxHashes, anyhow::Error> {
+        match self.json_rpc_client.get_block_with_tx_hashes(BlockId::Tag(BlockTag::Latest)).await {
+            Ok(MaybePendingBlockWithTxHashes::Block(b)) => Ok(b),
+            other => Err(anyhow::format_err!("Got unexpected block: {other:?}")),
+        }
     }
 }
 

--- a/crates/starknet-devnet/tests/test_abort_blocks.rs
+++ b/crates/starknet-devnet/tests/test_abort_blocks.rs
@@ -17,15 +17,9 @@ mod abort_blocks_tests {
         devnet: &BackgroundDevnet,
         starting_block_hash: &FieldElement,
     ) -> Vec<FieldElement> {
-        let abort_blocks_resp = devnet
-            .post_json(
-                "/abort_blocks".into(),
-                Body::from(
-                    json!({ "starting_block_hash": to_hex_felt(starting_block_hash) }).to_string(),
-                ),
-            )
-            .await
-            .unwrap();
+        let body = json!({ "starting_block_hash": to_hex_felt(starting_block_hash) }).to_string();
+        let abort_blocks_resp =
+            devnet.post_json("/abort_blocks".into(), Body::from(body)).await.unwrap();
 
         let mut aborted_blocks = get_json_body(abort_blocks_resp).await;
         let aborted_blocks = aborted_blocks["aborted"].take().as_array().unwrap().clone();
@@ -37,18 +31,12 @@ mod abort_blocks_tests {
     }
 
     async fn abort_blocks_error(devnet: &BackgroundDevnet, starting_block_hash: &FieldElement) {
-        let abort_blocks = devnet
-            .post_json(
-                "/abort_blocks".into(),
-                Body::from(
-                    json!({ "starting_block_hash": to_hex_felt(starting_block_hash) }).to_string(),
-                ),
-            )
-            .await
-            .unwrap();
+        let body = json!({ "starting_block_hash": to_hex_felt(starting_block_hash) }).to_string();
+        let abort_blocks =
+            devnet.post_json("/abort_blocks".into(), Body::from(body)).await.unwrap();
 
         let aborted_blocks = get_json_body(abort_blocks).await;
-        assert!(aborted_blocks["error"].to_string().starts_with("\"The block abortion failed"));
+        assert!(aborted_blocks["error"].to_string().starts_with("\"Block abortion failed"));
     }
 
     async fn assert_block_rejected(devnet: &BackgroundDevnet, block_hash: &FieldElement) {

--- a/crates/starknet-devnet/tests/test_advancing_time.rs
+++ b/crates/starknet-devnet/tests/test_advancing_time.rs
@@ -110,7 +110,7 @@ mod advancing_time_tests {
 
         devnet.create_block().await.unwrap();
 
-        // check if timestamp is greater/equal
+        // check if timestamp >=
         let current_timestamp = get_current_timestamp(&devnet, timestamp_contract_address).await;
         assert_ge_with_buffer(current_timestamp, Some(past_time));
     }
@@ -131,7 +131,7 @@ mod advancing_time_tests {
 
         devnet.create_block().await.unwrap();
 
-        // check if timestamp is greater/equal
+        // check if timestamp >=
         let current_timestamp = get_current_timestamp(&devnet, timestamp_contract_address).await;
         assert_ge_with_buffer(current_timestamp, Some(future_time));
     }
@@ -148,7 +148,7 @@ mod advancing_time_tests {
         let increase_time_body = Body::from(json!({ "time": increase_time }).to_string());
         devnet.post_json("/increase_time".into(), increase_time_body).await.unwrap();
 
-        // check if timestamp is greater/equal
+        // check if timestamp >=
         let current_timestamp = get_current_timestamp(&devnet, timestamp_contract_address).await;
         assert_ge_with_buffer(current_timestamp, Some(now + increase_time));
 
@@ -212,7 +212,7 @@ mod advancing_time_tests {
 
         devnet.create_block().await.unwrap();
 
-        // check if timestamp is greater/equal
+        // check if timestamp >=
         let current_timestamp = get_current_timestamp(&devnet, timestamp_contract_address).await;
         assert_ge_with_buffer(current_timestamp, Some(past_time));
     }
@@ -231,14 +231,14 @@ mod advancing_time_tests {
 
         devnet.create_block().await.unwrap();
 
-        // check if timestamp is greater/equal
+        // check if timestamp >=
         let current_timestamp = get_current_timestamp(&devnet, timestamp_contract_address).await;
         assert_ge_with_buffer(current_timestamp, Some(future_time));
     }
 
     #[tokio::test]
     async fn set_time_in_past() {
-        // set time and assert if it's greater/equal than past_time, check if it's inside buffer
+        // set time and assert if >= than past_time, check if inside buffer
         // limit
         let past_time = 1;
         let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
@@ -246,37 +246,30 @@ mod advancing_time_tests {
         let resp_set_time = devnet.post_json("/set_time".into(), set_time_body).await.unwrap();
         let resp_body_set_time = get_json_body(resp_set_time).await;
         assert_eq!(resp_body_set_time["block_timestamp"], past_time);
-        let set_time_block = &devnet
-            .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
-            .await["result"];
-        assert_ge_with_buffer(set_time_block["timestamp"].as_u64(), Some(past_time));
+        let set_time_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
+        assert_ge_with_buffer(Some(set_time_block.timestamp), Some(past_time)); // TODO Option?
 
         // wait 1 second
         thread::sleep(time::Duration::from_secs(1));
 
-        // create block and check if block_timestamp is greater than past_time, check if it's inside
+        // create block and check if block_timestamp is greater than past_time, check if inside
         // buffer limit
         devnet.create_block().await.unwrap();
-        let empty_block = &devnet
-            .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
-            .await["result"];
-        assert_gt_with_buffer(empty_block["timestamp"].as_u64(), Some(past_time));
+        let empty_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
+        assert_gt_with_buffer(Some(empty_block.timestamp), Some(past_time));
 
         // wait 1 second
         thread::sleep(time::Duration::from_secs(1));
 
-        // check if after mint timestamp is greater than last block, check if it's inside buffer
-        // limit
+        // check if after mint timestamp > than last block, check if inside buffer limit
         devnet.mint(DUMMY_ADDRESS, DUMMY_AMOUNT).await;
-        let mint_block = &devnet
-            .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
-            .await["result"];
-        assert_gt_with_buffer(mint_block["timestamp"].as_u64(), empty_block["timestamp"].as_u64());
+        let mint_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
+        assert_gt_with_buffer(Some(mint_block.timestamp), Some(empty_block.timestamp));
     }
 
     #[tokio::test]
     async fn set_time_in_future() {
-        // set time and assert if it's greater/equal than future_time, check if it's inside buffer
+        // set time and assert if >= than future_time, check if inside buffer
         // limit
         let now = get_unix_timestamp_as_seconds();
         let future_time = now + 1000;
@@ -285,32 +278,25 @@ mod advancing_time_tests {
         let resp = devnet.post_json("/set_time".into(), set_time_body).await.unwrap();
         let resp_body = get_json_body(resp).await;
         assert_eq!(resp_body["block_timestamp"], future_time);
-        let set_time_block = &devnet
-            .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
-            .await["result"];
-        assert_ge_with_buffer(set_time_block["timestamp"].as_u64(), Some(future_time));
+        let set_time_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
+        assert_ge_with_buffer(Some(set_time_block.timestamp), Some(future_time));
 
         // wait 1 second
         thread::sleep(time::Duration::from_secs(1));
 
-        // create block and check if block_timestamp is greater than future_time, check if it's
-        // inside buffer limit
+        // create block and check if block_timestamp > future_time, check if inside buffer limit
         devnet.create_block().await.unwrap();
-        let empty_block = &devnet
-            .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
-            .await["result"];
-        assert_gt_with_buffer(empty_block["timestamp"].as_u64(), Some(future_time));
+        let empty_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
+        assert_gt_with_buffer(Some(empty_block.timestamp), Some(future_time));
 
         // wait 1 second
         thread::sleep(time::Duration::from_secs(1));
 
-        // check if after mint timestamp is greater than last empty block, check if it's inside
+        // check if after mint timestamp is greater than last empty block, check if inside
         // buffer limit
         devnet.mint(DUMMY_ADDRESS, DUMMY_AMOUNT).await;
-        let mint_block = &devnet
-            .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
-            .await["result"];
-        assert_gt_with_buffer(mint_block["timestamp"].as_u64(), Some(future_time));
+        let mint_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
+        assert_gt_with_buffer(Some(mint_block.timestamp), Some(future_time));
     }
 
     #[tokio::test]
@@ -339,56 +325,48 @@ mod advancing_time_tests {
         let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
         let now = get_unix_timestamp_as_seconds();
 
-        // increase time and assert if it's greater than now, check if it's inside buffer limit
+        // increase time and assert if greater than now, check if inside buffer limit
         let first_increase_time: u64 = 10000;
         let first_increase_time_body =
             Body::from(json!({ "time": first_increase_time }).to_string());
         devnet.post_json("/increase_time".into(), first_increase_time_body).await.unwrap();
-        let first_increase_time_block = &devnet
-            .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
-            .await["result"];
+        let first_increase_time_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
         assert_ge_with_buffer(
-            first_increase_time_block["timestamp"].as_u64(),
+            Some(first_increase_time_block.timestamp),
             Some(now + first_increase_time),
         );
 
-        // second increase time, check if it's inside buffer limit
+        // second increase time, check if inside buffer limit
         let second_increase_time: u64 = 1000;
         let second_increase_time_body =
             Body::from(json!({ "time": second_increase_time }).to_string());
         devnet.post_json("/increase_time".into(), second_increase_time_body).await.unwrap();
-        let second_increase_time_block = &devnet
-            .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
-            .await["result"];
+        let second_increase_time_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
         assert_ge_with_buffer(
-            second_increase_time_block["timestamp"].as_u64(),
+            Some(second_increase_time_block.timestamp),
             Some(now + first_increase_time + second_increase_time),
         );
 
         // wait 1 second
         thread::sleep(time::Duration::from_secs(1));
 
-        // create block and check again if block_timestamp is greater than last block, check if it's
+        // create block and check again if block_timestamp is greater than last block, check if
         // inside buffer limit
         devnet.create_block().await.unwrap();
-        let empty_block = &devnet
-            .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
-            .await["result"];
+        let empty_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
         assert_gt_with_buffer(
-            empty_block["timestamp"].as_u64(),
-            second_increase_time_block["timestamp"].as_u64(),
+            Some(empty_block.timestamp),
+            Some(second_increase_time_block.timestamp),
         );
 
         // wait 1 second
         thread::sleep(time::Duration::from_secs(1));
 
-        // check if after mint timestamp is greater than last block, check if it's inside buffer
+        // check if after mint timestamp is greater than last block, check if inside buffer
         // limit
         devnet.mint(DUMMY_ADDRESS, DUMMY_AMOUNT).await;
-        let last_block = &devnet
-            .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
-            .await["result"];
-        assert_gt_with_buffer(last_block["timestamp"].as_u64(), empty_block["timestamp"].as_u64());
+        let last_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
+        assert_gt_with_buffer(Some(last_block.timestamp), Some(empty_block.timestamp));
     }
 
     #[tokio::test]
@@ -428,13 +406,11 @@ mod advancing_time_tests {
         .await
         .expect("Could not start Devnet");
 
-        // create block and check if block timestamp is greater/equal 1, check if it's inside buffer
+        // create block and check if block timestamp >= 1, check if inside buffer
         // limit
         devnet.create_block().await.unwrap();
-        let empty_block = &devnet
-            .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
-            .await["result"];
-        assert_ge_with_buffer(empty_block["timestamp"].as_u64(), Some(past_time));
+        let empty_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
+        assert_ge_with_buffer(Some(empty_block.timestamp), Some(past_time));
     }
 
     #[tokio::test]
@@ -448,13 +424,11 @@ mod advancing_time_tests {
         .await
         .expect("Could not start Devnet");
 
-        // create block and check if block timestamp is greater than now, check if it's inside
+        // create block and check if block timestamp is greater than now, check if inside
         // buffer limit
         devnet.create_block().await.unwrap();
-        let empty_block = &devnet
-            .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
-            .await["result"];
-        assert_ge_with_buffer(empty_block["timestamp"].as_u64(), Some(future_time));
+        let empty_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
+        assert_ge_with_buffer(Some(empty_block.timestamp), Some(future_time));
     }
 
     #[tokio::test]
@@ -473,85 +447,70 @@ mod advancing_time_tests {
         .await
         .expect("Could not start Devnet");
 
-        // increase time and assert if it's greater/equal than start-time argument +
-        // first_increase_time, check if it's inside buffer limit
+        // increase time and assert if >= than start-time argument +
+        // first_increase_time, check if inside buffer limit
         let first_increase_time: u64 = 1000;
         let first_increase_time_body =
             Body::from(json!({ "time": first_increase_time }).to_string());
         devnet.post_json("/increase_time".into(), first_increase_time_body).await.unwrap();
-        let first_increase_time_block = &devnet
-            .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
-            .await["result"];
+        let first_increase_time_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
         assert_ge_with_buffer(
-            first_increase_time_block["timestamp"].as_u64(),
+            Some(first_increase_time_block.timestamp),
             Some(past_time + first_increase_time),
         );
 
-        // increase the time a second time and assert if it's greater/equal than past_time +
-        // first_increase_time + second_increase_time, check if it's inside buffer limit
+        // increase the time a second time and assert if >= than past_time +
+        // first_increase_time + second_increase_time, check if inside buffer limit
         let second_increase_time: u64 = 100;
         let second_increase_time_body =
             Body::from(json!({ "time": second_increase_time }).to_string());
         devnet.post_json("/increase_time".into(), second_increase_time_body).await.unwrap();
-        let second_increase_time_block = &devnet
-            .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
-            .await["result"];
+        let second_increase_time_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
         assert_ge_with_buffer(
-            second_increase_time_block["timestamp"].as_u64(),
+            Some(second_increase_time_block.timestamp),
             Some(past_time + first_increase_time + second_increase_time),
         );
 
-        // set time to be now and check if the latest block timestamp is greater/equal now, check if
+        // set time to be now and check if the latest block timestamp >= now, check if
         // it's inside buffer limit
         let set_time_body = Body::from(json!({ "time": now }).to_string());
         let resp_set_time = devnet.post_json("/set_time".into(), set_time_body).await.unwrap();
         let resp_body_set_time = get_json_body(resp_set_time).await;
         assert_eq!(resp_body_set_time["block_timestamp"], now);
-        let set_time_block = &devnet
-            .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
-            .await["result"];
-        assert_ge_with_buffer(set_time_block["timestamp"].as_u64(), Some(now));
+        let set_time_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
+        assert_ge_with_buffer(Some(set_time_block.timestamp), Some(now));
 
         // wait 1 second
         thread::sleep(time::Duration::from_secs(1));
 
         // create a new empty block and check again if block timestamp is greater than
-        // set_time_block, check if it's inside buffer limit
+        // set_time_block, check if inside buffer limit
         devnet.create_block().await.unwrap();
-        let empty_block = &devnet
-            .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
-            .await["result"];
-        assert_gt_with_buffer(
-            empty_block["timestamp"].as_u64(),
-            set_time_block["timestamp"].as_u64(),
-        );
+        let empty_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
+        assert_gt_with_buffer(Some(empty_block.timestamp), Some(set_time_block.timestamp));
 
-        // increase the time a third time and assert if it's greater/equal than last empty block
-        // timestamp + third_increase_time, check if it's inside buffer limit
+        // increase the time a third time and assert if >= than last empty block
+        // timestamp + third_increase_time, check if inside buffer limit
         let third_increase_time: u64 = 10000;
         let third_increase_time_body =
             Body::from(json!({ "time": third_increase_time }).to_string());
         devnet.post_json("/increase_time".into(), third_increase_time_body).await.unwrap();
-        let third_increase_time_block = &devnet
-            .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
-            .await["result"];
+        let third_increase_time_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
         assert_ge_with_buffer(
-            third_increase_time_block["timestamp"].as_u64(),
-            Some(empty_block["timestamp"].as_u64().unwrap() + third_increase_time),
+            Some(third_increase_time_block.timestamp),
+            Some(empty_block.timestamp + third_increase_time),
         );
 
         // wait 1 second
         thread::sleep(time::Duration::from_secs(1));
 
-        // check if the last block timestamp is greater previous block, check if it's inside buffer
+        // check if the last block timestamp is greater previous block, check if inside buffer
         // limit
         devnet.create_block().await.unwrap();
-        let last_block = &devnet
-            .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
-            .await["result"];
+        let last_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
         assert_ge_with_buffer(
-            last_block["timestamp"].as_u64(),
-            third_increase_time_block["timestamp"].as_u64(),
+            Some(last_block.timestamp),
+            Some(third_increase_time_block.timestamp),
         );
 
         send_ctrl_c_signal_and_wait(&devnet.process).await;
@@ -568,14 +527,11 @@ mod advancing_time_tests {
         .await
         .expect("Could not start Devnet");
 
-        let last_block_load = &devnet_load
-            .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
-            .await["result"];
-        assert_eq!(last_block["block_number"], last_block_load["block_number"]);
+        let last_block_load = devnet_load.get_latest_block_with_tx_hashes().await.unwrap();
+        assert_eq!(last_block.block_number, last_block_load.block_number);
 
-        let timestamp_diff = last_block_load["timestamp"].as_i64().unwrap()
-            - last_block["timestamp"].as_i64().unwrap();
-        assert!(timestamp_diff.abs() < BUFFER_TIME_SECONDS as i64)
+        let timestamp_diff = last_block_load.timestamp.abs_diff(last_block.timestamp);
+        assert!(timestamp_diff < BUFFER_TIME_SECONDS)
     }
 
     #[tokio::test]
@@ -604,11 +560,9 @@ mod advancing_time_tests {
 
         // create block and assert
         devnet.create_block().await.unwrap();
-        let latest_block = &devnet
-            .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
-            .await["result"];
+        let latest_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
 
-        assert_eq!(latest_block["block_number"], 0);
-        assert_eq!(latest_block["timestamp"], past_time);
+        assert_eq!(latest_block.block_number, 0);
+        assert_eq!(latest_block.timestamp, past_time);
     }
 }

--- a/crates/starknet-devnet/tests/test_advancing_time.rs
+++ b/crates/starknet-devnet/tests/test_advancing_time.rs
@@ -110,7 +110,7 @@ mod advancing_time_tests {
 
         devnet.create_block().await.unwrap();
 
-        // check if timestamp >=
+        // check if timestamp is greater/equal
         let current_timestamp = get_current_timestamp(&devnet, timestamp_contract_address).await;
         assert_ge_with_buffer(current_timestamp, past_time);
     }
@@ -131,7 +131,7 @@ mod advancing_time_tests {
 
         devnet.create_block().await.unwrap();
 
-        // check if timestamp >=
+        // check if timestamp is greater/equal
         let current_timestamp = get_current_timestamp(&devnet, timestamp_contract_address).await;
         assert_ge_with_buffer(current_timestamp, future_time);
     }
@@ -148,7 +148,7 @@ mod advancing_time_tests {
         let increase_time_body = Body::from(json!({ "time": increase_time }).to_string());
         devnet.post_json("/increase_time".into(), increase_time_body).await.unwrap();
 
-        // check if timestamp >=
+        // check if timestamp is greater/equal
         let current_timestamp = get_current_timestamp(&devnet, timestamp_contract_address).await;
         assert_ge_with_buffer(current_timestamp, now + increase_time);
 
@@ -193,7 +193,7 @@ mod advancing_time_tests {
         thread::sleep(time::Duration::from_secs(1));
         devnet.create_block().await.unwrap();
 
-        // check if current timestamp is greater than storage timestamp and now
+        // check if current timestamp > storage timestamp and now
         let current_timestamp = get_current_timestamp(&devnet, timestamp_contract_address).await;
         assert_gt_with_buffer(current_timestamp, now);
         assert_gt_with_buffer(current_timestamp, storage_timestamp);
@@ -212,7 +212,7 @@ mod advancing_time_tests {
 
         devnet.create_block().await.unwrap();
 
-        // check if timestamp >=
+        // check if timestamp is greater/equal
         let current_timestamp = get_current_timestamp(&devnet, timestamp_contract_address).await;
         assert_ge_with_buffer(current_timestamp, past_time);
     }
@@ -231,15 +231,14 @@ mod advancing_time_tests {
 
         devnet.create_block().await.unwrap();
 
-        // check if timestamp >=
+        // check if timestamp is greater/equal
         let current_timestamp = get_current_timestamp(&devnet, timestamp_contract_address).await;
         assert_ge_with_buffer(current_timestamp, future_time);
     }
 
     #[tokio::test]
     async fn set_time_in_past() {
-        // set time and assert if >= than past_time, check if inside buffer
-        // limit
+        // set time and assert if >= past_time, check if inside buffer limit
         let past_time = 1;
         let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
         let set_time_body = Body::from(json!({ "time": past_time }).to_string());
@@ -252,8 +251,7 @@ mod advancing_time_tests {
         // wait 1 second
         thread::sleep(time::Duration::from_secs(1));
 
-        // create block and check if block_timestamp is greater than past_time, check if inside
-        // buffer limit
+        // create block and check if block_timestamp > past_time, check if inside buffer limit
         devnet.create_block().await.unwrap();
         let empty_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
         assert_gt_with_buffer(empty_block.timestamp, past_time);
@@ -261,7 +259,7 @@ mod advancing_time_tests {
         // wait 1 second
         thread::sleep(time::Duration::from_secs(1));
 
-        // check if after mint timestamp > than last block, check if inside buffer limit
+        // check if after mint timestamp > last block, check if inside buffer limit
         devnet.mint(DUMMY_ADDRESS, DUMMY_AMOUNT).await;
         let mint_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
         assert_gt_with_buffer(mint_block.timestamp, empty_block.timestamp);
@@ -269,8 +267,7 @@ mod advancing_time_tests {
 
     #[tokio::test]
     async fn set_time_in_future() {
-        // set time and assert if >= than future_time, check if inside buffer
-        // limit
+        // set time and assert if >= future_time, check if inside buffer limit
         let now = get_unix_timestamp_as_seconds();
         let future_time = now + 1000;
         let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
@@ -292,8 +289,7 @@ mod advancing_time_tests {
         // wait 1 second
         thread::sleep(time::Duration::from_secs(1));
 
-        // check if after mint timestamp is greater than last empty block, check if inside
-        // buffer limit
+        // check if after mint timestamp > last empty block, check if inside buffer limit
         devnet.mint(DUMMY_ADDRESS, DUMMY_AMOUNT).await;
         let mint_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
         assert_gt_with_buffer(mint_block.timestamp, future_time);
@@ -325,7 +321,7 @@ mod advancing_time_tests {
         let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
         let now = get_unix_timestamp_as_seconds();
 
-        // increase time and assert if greater than now, check if inside buffer limit
+        // increase time and assert if > now, check if inside buffer limit
         let first_increase_time: u64 = 10000;
         let first_increase_time_body =
             Body::from(json!({ "time": first_increase_time }).to_string());
@@ -347,7 +343,7 @@ mod advancing_time_tests {
         // wait 1 second
         thread::sleep(time::Duration::from_secs(1));
 
-        // create block and check again if block_timestamp is greater than last block, check if
+        // create block and check again if block_timestamp > last block, check if
         // inside buffer limit
         devnet.create_block().await.unwrap();
         let empty_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
@@ -356,8 +352,7 @@ mod advancing_time_tests {
         // wait 1 second
         thread::sleep(time::Duration::from_secs(1));
 
-        // check if after mint timestamp is greater than last block, check if inside buffer
-        // limit
+        // check if after mint timestamp > last block, check if inside buffer limit
         devnet.mint(DUMMY_ADDRESS, DUMMY_AMOUNT).await;
         let last_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
         assert_gt_with_buffer(last_block.timestamp, empty_block.timestamp);
@@ -400,8 +395,7 @@ mod advancing_time_tests {
         .await
         .expect("Could not start Devnet");
 
-        // create block and check if block timestamp >= 1, check if inside buffer
-        // limit
+        // create block and check if block timestamp >= 1, check if inside buffer limit
         devnet.create_block().await.unwrap();
         let empty_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
         assert_ge_with_buffer(empty_block.timestamp, past_time);
@@ -418,8 +412,7 @@ mod advancing_time_tests {
         .await
         .expect("Could not start Devnet");
 
-        // create block and check if block timestamp is greater than now, check if inside
-        // buffer limit
+        // create block and check if block timestamp > now, check if inside buffer limit
         devnet.create_block().await.unwrap();
         let empty_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
         assert_ge_with_buffer(empty_block.timestamp, future_time);
@@ -441,8 +434,8 @@ mod advancing_time_tests {
         .await
         .expect("Could not start Devnet");
 
-        // increase time and assert if >= than start-time argument +
-        // first_increase_time, check if inside buffer limit
+        // increase time and assert if >= start-time argument + first_increase_time, check if inside
+        // buffer limit
         let first_increase_time: u64 = 1000;
         let first_increase_time_body =
             Body::from(json!({ "time": first_increase_time }).to_string());
@@ -450,8 +443,8 @@ mod advancing_time_tests {
         let first_increase_time_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
         assert_ge_with_buffer(first_increase_time_block.timestamp, past_time + first_increase_time);
 
-        // increase the time a second time and assert if >= than past_time +
-        // first_increase_time + second_increase_time, check if inside buffer limit
+        // increase the time a second time and assert if >= past_time + first_increase_time +
+        // second_increase_time, check if inside buffer limit
         let second_increase_time: u64 = 100;
         let second_increase_time_body =
             Body::from(json!({ "time": second_increase_time }).to_string());
@@ -474,14 +467,14 @@ mod advancing_time_tests {
         // wait 1 second
         thread::sleep(time::Duration::from_secs(1));
 
-        // create a new empty block and check again if block timestamp is greater than
-        // set_time_block, check if inside buffer limit
+        // create a new empty block and check again if block timestamp > set_time_block, check if
+        // inside buffer limit
         devnet.create_block().await.unwrap();
         let empty_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
         assert_gt_with_buffer(empty_block.timestamp, set_time_block.timestamp);
 
-        // increase the time a third time and assert if >= than last empty block
-        // timestamp + third_increase_time, check if inside buffer limit
+        // increase the time a third time and assert >= last empty block timestamp +
+        // third_increase_time, check if inside buffer limit
         let third_increase_time: u64 = 10000;
         let third_increase_time_body =
             Body::from(json!({ "time": third_increase_time }).to_string());
@@ -495,8 +488,7 @@ mod advancing_time_tests {
         // wait 1 second
         thread::sleep(time::Duration::from_secs(1));
 
-        // check if the last block timestamp is greater previous block, check if inside buffer
-        // limit
+        // check if the last block timestamp is > previous block, check if inside buffer limit
         devnet.create_block().await.unwrap();
         let last_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
         assert_ge_with_buffer(last_block.timestamp, third_increase_time_block.timestamp);

--- a/crates/starknet-devnet/tests/test_dump_and_load.rs
+++ b/crates/starknet-devnet/tests/test_dump_and_load.rs
@@ -53,10 +53,8 @@ mod dump_and_load_tests {
         .await
         .expect("Could not start Devnet");
 
-        let last_block = &devnet_load
-            .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
-            .await["result"];
-        assert_eq!(last_block["block_number"], 3);
+        let last_block = devnet_load.get_latest_block_with_tx_hashes().await.unwrap();
+        assert_eq!(last_block.block_number, 3);
     }
 
     #[tokio::test]
@@ -424,9 +422,7 @@ mod dump_and_load_tests {
         thread::sleep(time::Duration::from_secs(1));
 
         devnet_dump.create_block().await.unwrap();
-        devnet_dump
-            .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
-            .await;
+        devnet_dump.get_latest_block_with_tx_hashes().await.unwrap();
 
         // dump and load
         send_ctrl_c_signal_and_wait(&devnet_dump.process).await;
@@ -437,11 +433,9 @@ mod dump_and_load_tests {
                 .await
                 .expect("Could not start Devnet");
 
-        let latest_block = &devnet_load
-            .send_custom_rpc("starknet_getBlockWithTxHashes", json!({ "block_id": "latest" }))
-            .await["result"];
+        let latest_block = devnet_load.get_latest_block_with_tx_hashes().await.unwrap();
 
-        assert_eq!(latest_block["block_number"], 0);
-        assert_eq!(latest_block["timestamp"], past_time);
+        assert_eq!(latest_block.block_number, 0);
+        assert_eq!(latest_block.timestamp, past_time);
     }
 }


### PR DESCRIPTION
## Usage related changes

- None

## Development related changes

- Use a stronger Docker executor for the publishing task on CircleCI:
  - Large (4 CPUs) instead of Medium (2 CPUs)
  - Should speed up publishing (currently takes 24 minutes)
- Improve PR template
- Improve docs
- Improve block-manipulation tests after #388:
  - Add `BackgroundDevnet::get_latest_block_with_tx_hashes` and replace all occurrences of manually doing it.
  - Rely on the block hash returned by `BackgroundDevnet::create_block` instead of manually fetching it.
  - Rely more on `FieldElement` instead of `serde_json::Value`.
  - Rely more on `u64` instead of `Option<u64`>.

## Checklist:

- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Checked the TODO section in README.md if this PR resolves it
- [x] Updated the tests
- [x] All tests are passing - `cargo test`
