### PR TITLE
Always predeclare Cairo0 and Cairo1 account classes

### DIFF
--- a/crates/starknet-devnet-core/src/contract_class_choice.rs
+++ b/crates/starknet-devnet-core/src/contract_class_choice.rs
@@ -1,13 +1,13 @@
 use std::str::FromStr;
 
-use starknet_core::constants::{
-    CAIRO_0_ACCOUNT_CONTRACT_PATH, CAIRO_1_ACCOUNT_CONTRACT_SIERRA_PATH,
-};
 use starknet_rs_core::types::FieldElement;
 use starknet_rs_core::utils::get_selector_from_name;
 use starknet_types::contract_class::{Cairo0ContractClass, Cairo0Json, ContractClass};
 use starknet_types::felt::Felt;
 use starknet_types::traits::HashProducer;
+
+use crate::constants::{CAIRO_0_ACCOUNT_CONTRACT_PATH, CAIRO_1_ACCOUNT_CONTRACT_SIERRA_PATH};
+use crate::error::DevnetResult;
 
 #[derive(clap::ValueEnum, Debug, Clone)]
 pub enum AccountContractClassChoice {
@@ -16,7 +16,7 @@ pub enum AccountContractClassChoice {
 }
 
 impl AccountContractClassChoice {
-    pub(crate) fn get_class_wrapper(&self) -> Result<AccountClassWrapper, anyhow::Error> {
+    pub fn get_class_wrapper(&self) -> DevnetResult<AccountClassWrapper> {
         Ok(match self {
             AccountContractClassChoice::Cairo0 => {
                 let contract_class = Cairo0ContractClass::RawJson(Cairo0Json::raw_json_from_path(
@@ -46,7 +46,7 @@ pub struct AccountClassWrapper {
 }
 
 impl FromStr for AccountClassWrapper {
-    type Err = anyhow::Error;
+    type Err = crate::error::Error;
 
     fn from_str(path_candidate: &str) -> Result<Self, Self::Err> {
         // load artifact
@@ -72,7 +72,7 @@ impl FromStr for AccountClassWrapper {
                 "Not a valid Sierra account artifact; has __execute__: {has_execute}; has \
                  __validate__: {has_validate}"
             );
-            return Err(anyhow::Error::msg(msg));
+            return Err(crate::error::Error::ContractClassLoadError(msg));
         }
 
         // generate the hash and return
@@ -85,13 +85,11 @@ impl FromStr for AccountClassWrapper {
 #[cfg(test)]
 mod tests {
     use clap::ValueEnum;
-    use starknet_core::constants::{
-        CAIRO_0_ACCOUNT_CONTRACT_HASH, CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH,
-    };
     use starknet_types::felt::Felt;
     use starknet_types::traits::HashProducer;
 
     use super::AccountContractClassChoice;
+    use crate::constants::{CAIRO_0_ACCOUNT_CONTRACT_HASH, CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH};
     use crate::contract_class_choice::AccountClassWrapper;
 
     #[test]

--- a/crates/starknet-devnet-core/src/error.rs
+++ b/crates/starknet-devnet-core/src/error.rs
@@ -49,8 +49,8 @@ pub enum Error {
     UnsupportedAction { msg: String },
     #[error("Unexpected internal error: {msg}")]
     UnexpectedInternalError { msg: String },
-    #[error("Failed to load ContractClass")]
-    ContractClassLoadError,
+    #[error("Failed to load ContractClass: {0}")]
+    ContractClassLoadError(String),
     #[error("Deserialization error: {origin}")]
     DeserializationError { origin: String },
     #[error("Serialization error: {origin}")]

--- a/crates/starknet-devnet-core/src/lib.rs
+++ b/crates/starknet-devnet-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod account;
 mod blocks;
 pub mod constants;
+pub mod contract_class_choice;
 pub mod error;
 pub mod messaging;
 mod predeployed_accounts;

--- a/crates/starknet-devnet-core/src/predeployed_accounts.rs
+++ b/crates/starknet-devnet-core/src/predeployed_accounts.rs
@@ -62,7 +62,7 @@ impl AccountGenerator for PredeployedAccounts {
         &mut self,
         number_of_accounts: u8,
         class_hash: ClassHash,
-        contract_class: ContractClass,
+        contract_class: &ContractClass,
     ) -> DevnetResult<&Vec<Self::Acc>> {
         let private_keys = self.generate_private_keys(number_of_accounts);
 

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -61,6 +61,7 @@ use crate::constants::{
     ETH_ERC20_CONTRACT_ADDRESS, ETH_ERC20_NAME, ETH_ERC20_SYMBOL, STRK_ERC20_CONTRACT_ADDRESS,
     STRK_ERC20_NAME, STRK_ERC20_SYMBOL,
 };
+use crate::contract_class_choice::AccountContractClassChoice;
 use crate::error::{DevnetResult, Error, TransactionValidationError};
 use crate::messaging::MessagingBroker;
 use crate::predeployed_accounts::PredeployedAccounts;
@@ -132,6 +133,18 @@ impl Starknet {
     pub fn new(config: &StarknetConfig) -> DevnetResult<Self> {
         let defaulter = StarknetDefaulter::new(config.fork_config.clone());
         let mut state = StarknetState::new(defaulter);
+
+        // predeclare account classes
+        for account_class_choice in
+            [AccountContractClassChoice::Cairo0, AccountContractClassChoice::Cairo1]
+        {
+            let class_wrapper = account_class_choice.get_class_wrapper()?;
+            state.predeclare_contract_class(
+                class_wrapper.class_hash,
+                class_wrapper.contract_class,
+            )?;
+        }
+
         // deploy udc, eth erc20 and strk erc20 contracts
         let eth_erc20_fee_contract =
             predeployed::create_erc20_at_address(ETH_ERC20_CONTRACT_ADDRESS)?;
@@ -167,7 +180,7 @@ impl Starknet {
         let accounts = predeployed_accounts.generate_accounts(
             config.total_accounts,
             config.account_contract_class_hash,
-            config.account_contract_class.clone(),
+            &config.account_contract_class,
         )?;
         for account in accounts {
             account.deploy(&mut state)?;
@@ -826,7 +839,7 @@ impl Starknet {
         // starting block is reached in while loop.
         if last_reached_block_hash == Felt::from(0) && reached_starting_block {
             self.blocks.last_block_hash = None;
-            self.state = self.init_state.clone_historic(); // This will be refactored during the genesis block PR 
+            self.state = self.init_state.clone_historic(); // This will be refactored during the genesis block PR
         } else if reached_starting_block {
             let current_block =
                 self.blocks.hash_to_block.get(&last_reached_block_hash).ok_or(Error::NoBlock)?;

--- a/crates/starknet-devnet-core/src/traits.rs
+++ b/crates/starknet-devnet-core/src/traits.rs
@@ -66,6 +66,6 @@ pub trait AccountGenerator {
         &mut self,
         number_of_accounts: u8,
         class_hash: ClassHash,
-        contract_class: ContractClass,
+        contract_class: &ContractClass,
     ) -> DevnetResult<&Vec<Self::Acc>>;
 }

--- a/crates/starknet-devnet/src/cli.rs
+++ b/crates/starknet-devnet/src/cli.rs
@@ -5,13 +5,13 @@ use starknet_core::constants::{
     DEVNET_DEFAULT_DATA_GAS_PRICE, DEVNET_DEFAULT_GAS_PRICE, DEVNET_DEFAULT_PORT,
     DEVNET_DEFAULT_TIMEOUT, DEVNET_DEFAULT_TOTAL_ACCOUNTS,
 };
+use starknet_core::contract_class_choice::{AccountClassWrapper, AccountContractClassChoice};
 use starknet_core::random_number_generator::generate_u32_random_number;
 use starknet_core::starknet::starknet_config::{
     DumpOn, ForkConfig, StarknetConfig, StateArchiveCapacity,
 };
 use starknet_types::chain_id::ChainId;
 
-use crate::contract_class_choice::{AccountClassWrapper, AccountContractClassChoice};
 use crate::initial_balance_wrapper::InitialBalanceWrapper;
 use crate::ip_addr_wrapper::IpAddrWrapper;
 

--- a/crates/starknet-devnet/src/main.rs
+++ b/crates/starknet-devnet/src/main.rs
@@ -23,7 +23,6 @@ use tracing::info;
 use tracing_subscriber::EnvFilter;
 
 mod cli;
-mod contract_class_choice;
 mod initial_balance_wrapper;
 mod ip_addr_wrapper;
 

--- a/crates/starknet-devnet/tests/test_account_selection.rs
+++ b/crates/starknet-devnet/tests/test_account_selection.rs
@@ -127,6 +127,11 @@ mod test_account_selection {
     }
 
     #[tokio::test]
+    async fn can_deploy_new_cairo1_account_when_cairo0_selected() {
+        can_deploy_new_account_test_body(&["--account-class", "cairo0"]).await;
+    }
+
+    #[tokio::test]
     async fn can_deploy_new_custom_account() {
         can_deploy_new_account_test_body(&[
             "--account-class-custom",


### PR DESCRIPTION
## Usage related changes

- Close #373 

## Development related changes

- `AccountClassChoice` had to be moved from `starknet-devnet` to `starknet-devnet-core`
- Reduce class cloning

## Checklist:

- [x] Checked the relevant parts of the [Development](../README.md#development) section of the docs
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Linked the issues which this PR resolves
- [x] Checked the [TODO section of the docs](../README.md#todo-to-reach-feature-parity-with-the-pythonic-devnet)
- [x] Updated the tests
- [x] All tests are passing - [docs](../README.md#test-execution)
