### PR TITLE
Warn on forking mismatch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,15 +64,10 @@ jobs:
           key: << parameters.cargo_cache_key >>
       - run:
           name: Unit tests
-          # if jobs not limited - fails
-          # problem: https://app.circleci.com/pipelines/github/0xSpaceShard/starknet-devnet-rs/339/workflows/97e98c29-1563-4aa0-b716-4bfd023c563e/jobs/335/steps
-          # solution: https://stackoverflow.com/questions/71962406/how-to-use-less-memory-when-compiling-to-avoid-killing-the-build
           command: cargo test --jobs 7 --lib --bins --no-fail-fast
       - run:
           name: Integration tests
-          # if jobs not limited - fails
-          # problem: https://app.circleci.com/pipelines/github/0xSpaceShard/starknet-devnet-rs/339/workflows/97e98c29-1563-4aa0-b716-4bfd023c563e/jobs/335/steps
-          # solution: https://stackoverflow.com/questions/71962406/how-to-use-less-memory-when-compiling-to-avoid-killing-the-build
+          # fails if jobs not limited; read more in https://github.com/0xSpaceShard/starknet-devnet-rs/issues/378
           command: cargo test --jobs 3 --test '*' --no-fail-fast
 
   image-build-amd:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,13 +8,12 @@
 
 ## Checklist:
 
-- [ ] Checked the relevant parts of the [Development section of the docs](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#development)
+- [ ] Checked the relevant parts of [development docs](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#development)
 - [ ] Applied formatting - `./scripts/format.sh`
 - [ ] No linter errors - `./scripts/clippy_check.sh`
 - [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
 - [ ] Performed code self-review
-- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
-- [ ] Documented the changes
-- [ ] Checked if the [TODO section of the docs](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#todo-to-reach-feature-parity-with-the-pythonic-devnet) can be edited
+- [ ] Rebased to the latest commit of the target branch (or merged it into my branch)
+- [ ] Updated the docs if needed, including the [TODO section](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#todo-to-reach-feature-parity-with-the-pythonic-devnet)
 - [ ] Linked the issues which this PR resolves
-- [ ] Updated the tests if needed; all passing ([execution info](<(https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#test-execution)>))
+- [ ] Updated the tests if needed; all passing ([execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#test-execution))

--- a/crates/starknet-devnet/src/main.rs
+++ b/crates/starknet-devnet/src/main.rs
@@ -64,7 +64,7 @@ fn log_predeployed_accounts(
     }
 }
 
-fn print_predeployed_contracts() {
+fn log_predeployed_contracts() {
     println!("Predeployed FeeToken");
     println!("ETH Address: {ETH_ERC20_CONTRACT_ADDRESS}");
     println!("STRK Address: {STRK_ERC20_CONTRACT_ADDRESS}");
@@ -76,12 +76,12 @@ fn print_predeployed_contracts() {
     println!();
 }
 
-fn print_chain_id(chain_id: ChainId) {
+fn log_chain_id(chain_id: ChainId) {
     println!("Chain ID: {} ({})", chain_id, chain_id.to_felt().to_prefixed_hex_str());
 }
 
-pub async fn check_forking_spec_version(
-    client: JsonRpcClient<HttpTransport>,
+async fn check_forking_spec_version(
+    client: &JsonRpcClient<HttpTransport>,
 ) -> Result<(), anyhow::Error> {
     let origin_spec_version = client.spec_version().await?;
     if origin_spec_version != RPC_SPEC_VERSION {
@@ -93,9 +93,27 @@ pub async fn check_forking_spec_version(
     Ok(())
 }
 
+async fn check_forking_chain_id(
+    client: &JsonRpcClient<HttpTransport>,
+    devnet_chain_id: ChainId,
+) -> Result<(), anyhow::Error> {
+    let origin_chain_id = client.chain_id().await?;
+    let devnet_chain_id_felt = devnet_chain_id.into();
+    if origin_chain_id != devnet_chain_id_felt {
+        warn!(
+            "Origin chain ID ({:#x}) does not match this Devnet's chain ID ({:#x}).",
+            origin_chain_id, devnet_chain_id_felt
+        );
+    }
+    Ok(())
+}
+
 /// Logs forking info if forking specified. If block_number not specified, it is set to the latest
 /// block number.
-pub async fn set_and_log_fork_config(fork_config: &mut ForkConfig) -> Result<(), anyhow::Error> {
+pub async fn set_and_log_fork_config(
+    fork_config: &mut ForkConfig,
+    chain_id: ChainId,
+) -> Result<(), anyhow::Error> {
     if let Some(url) = &fork_config.url {
         let json_rpc_client = JsonRpcClient::new(HttpTransport::new(url.clone()));
         let block_id =
@@ -117,6 +135,9 @@ pub async fn set_and_log_fork_config(fork_config: &mut ForkConfig) -> Result<(),
             }
             _ => panic!("Unreachable"),
         };
+
+        check_forking_spec_version(&json_rpc_client).await?;
+        check_forking_chain_id(&json_rpc_client, chain_id).await?;
     }
 
     Ok(())
@@ -130,7 +151,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let args = Args::parse();
     let mut starknet_config = args.to_starknet_config()?;
 
-    set_and_log_fork_config(&mut starknet_config.fork_config).await?;
+    set_and_log_fork_config(&mut starknet_config.fork_config, starknet_config.chain_id).await?;
 
     let mut addr: SocketAddr = SocketAddr::new(starknet_config.host, starknet_config.port);
 
@@ -143,8 +164,8 @@ async fn main() -> Result<(), anyhow::Error> {
         );
     };
 
-    print_predeployed_contracts();
-    print_chain_id(starknet_config.chain_id);
+    log_predeployed_contracts();
+    log_chain_id(starknet_config.chain_id);
 
     let predeployed_accounts = api.starknet.read().await.get_predeployed_accounts();
     log_predeployed_accounts(

--- a/crates/starknet-devnet/src/main.rs
+++ b/crates/starknet-devnet/src/main.rs
@@ -108,7 +108,7 @@ async fn check_forking_chain_id(
     Ok(())
 }
 
-/// Logs forking info if forking specified. If block_number not specified, it is set to the latest
+/// Logs forking info if forking specified. If block_number is not specified, it is set to the latest
 /// block number.
 pub async fn set_and_log_fork_config(
     fork_config: &mut ForkConfig,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,9 +11,11 @@ RUN cargo build --bin starknet-devnet --release
 FROM debian:buster-slim
 
 # Use tini to avoid hanging process on Ctrl+C
+# Use ca-certificates to allow forking from URLs using https scheme
 RUN apt-get -y update && \
     apt-get install tini && \
     apt-get install libssl-dev -y && \
+    apt-get install ca-certificates -y && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Usage related changes

- Log a warning (but continue operating) if origin and spawned Devnet differ in one of the following:
  - chain ID
  - JSON-RPC API version
- Fix bug of failed Devnet startup when forking from a URL using https
  - by installing the `ca-certificates` package in Dockerfile

## Development related changes

- Remove redundant comment in config.yml
- Simplify PR template
- Rename `print_` utilities to `log_` for consistency's sake
- Update Dockerfile

## Checklist:

- [x] Checked the relevant parts of the [Development section of the docs](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#development)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes
- [x] Checked if the [TODO section of the docs](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#todo-to-reach-feature-parity-with-the-pythonic-devnet) can be edited
- [x] Linked the issues which this PR resolves
- [x] Updated the tests if needed; all passing ([execution info](<(https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#test-execution)>))
