### PR TITLE
Make request body size limit configurable

### DIFF
--- a/crates/starknet-devnet-core/src/constants.rs
+++ b/crates/starknet-devnet-core/src/constants.rs
@@ -73,6 +73,7 @@ pub const DEVNET_DEFAULT_PORT: u16 = 5050;
 pub const DEVNET_DEFAULT_TIMEOUT: u16 = 120;
 pub const DEVNET_DEFAULT_CHAIN_ID: ChainId = ChainId::Testnet;
 pub const DEVNET_DEFAULT_STARTING_BLOCK_NUMBER: u64 = 0;
+pub const DEVNET_DEFAULT_REQUEST_BODY_SIZE_LIMIT: usize = 2_000_000;
 
 pub const SUPPORTED_TX_VERSION: u32 = 1;
 pub const QUERY_VERSION_BASE: FieldElement = FieldElement::from_mont([

--- a/crates/starknet-devnet-core/src/starknet/starknet_config.rs
+++ b/crates/starknet-devnet-core/src/starknet/starknet_config.rs
@@ -11,8 +11,8 @@ use url::Url;
 use crate::constants::{
     CAIRO_1_ACCOUNT_CONTRACT_SIERRA_PATH, DEVNET_DEFAULT_CHAIN_ID, DEVNET_DEFAULT_DATA_GAS_PRICE,
     DEVNET_DEFAULT_GAS_PRICE, DEVNET_DEFAULT_HOST, DEVNET_DEFAULT_INITIAL_BALANCE,
-    DEVNET_DEFAULT_PORT, DEVNET_DEFAULT_TEST_SEED, DEVNET_DEFAULT_TIMEOUT,
-    DEVNET_DEFAULT_TOTAL_ACCOUNTS,
+    DEVNET_DEFAULT_PORT, DEVNET_DEFAULT_REQUEST_BODY_SIZE_LIMIT, DEVNET_DEFAULT_TEST_SEED,
+    DEVNET_DEFAULT_TIMEOUT, DEVNET_DEFAULT_TOTAL_ACCOUNTS,
 };
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, clap::ValueEnum)]
@@ -56,6 +56,7 @@ pub struct StarknetConfig {
     pub re_execute_on_init: bool,
     pub state_archive: StateArchiveCapacity,
     pub fork_config: ForkConfig,
+    pub request_body_size_limit: usize,
 }
 
 impl Default for StarknetConfig {
@@ -80,6 +81,7 @@ impl Default for StarknetConfig {
             re_execute_on_init: true,
             state_archive: StateArchiveCapacity::default(),
             fork_config: ForkConfig::default(),
+            request_body_size_limit: DEVNET_DEFAULT_REQUEST_BODY_SIZE_LIMIT,
         }
     }
 }

--- a/crates/starknet-devnet-core/src/starknet/starknet_config.rs
+++ b/crates/starknet-devnet-core/src/starknet/starknet_config.rs
@@ -1,4 +1,3 @@
-use std::net::IpAddr;
 use std::num::NonZeroU128;
 
 use starknet_types::chain_id::ChainId;
@@ -10,9 +9,8 @@ use url::Url;
 
 use crate::constants::{
     CAIRO_1_ACCOUNT_CONTRACT_SIERRA_PATH, DEVNET_DEFAULT_CHAIN_ID, DEVNET_DEFAULT_DATA_GAS_PRICE,
-    DEVNET_DEFAULT_GAS_PRICE, DEVNET_DEFAULT_HOST, DEVNET_DEFAULT_INITIAL_BALANCE,
-    DEVNET_DEFAULT_PORT, DEVNET_DEFAULT_REQUEST_BODY_SIZE_LIMIT, DEVNET_DEFAULT_TEST_SEED,
-    DEVNET_DEFAULT_TIMEOUT, DEVNET_DEFAULT_TOTAL_ACCOUNTS,
+    DEVNET_DEFAULT_GAS_PRICE, DEVNET_DEFAULT_INITIAL_BALANCE, DEVNET_DEFAULT_TEST_SEED,
+    DEVNET_DEFAULT_TOTAL_ACCOUNTS,
 };
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, clap::ValueEnum)]
@@ -43,10 +41,7 @@ pub struct StarknetConfig {
     pub account_contract_class: ContractClass,
     pub account_contract_class_hash: Felt,
     pub predeployed_accounts_initial_balance: Balance,
-    pub host: IpAddr,
-    pub port: u16,
     pub start_time: Option<u64>,
-    pub timeout: u16,
     pub gas_price: NonZeroU128,
     pub data_gas_price: NonZeroU128,
     pub chain_id: ChainId,
@@ -56,7 +51,6 @@ pub struct StarknetConfig {
     pub re_execute_on_init: bool,
     pub state_archive: StateArchiveCapacity,
     pub fork_config: ForkConfig,
-    pub request_body_size_limit: usize,
 }
 
 impl Default for StarknetConfig {
@@ -69,10 +63,7 @@ impl Default for StarknetConfig {
             account_contract_class_hash: account_contract_class.generate_hash().unwrap(),
             account_contract_class,
             predeployed_accounts_initial_balance: DEVNET_DEFAULT_INITIAL_BALANCE.into(),
-            host: DEVNET_DEFAULT_HOST,
-            port: DEVNET_DEFAULT_PORT,
             start_time: None,
-            timeout: DEVNET_DEFAULT_TIMEOUT,
             gas_price: DEVNET_DEFAULT_GAS_PRICE,
             data_gas_price: DEVNET_DEFAULT_DATA_GAS_PRICE,
             chain_id: DEVNET_DEFAULT_CHAIN_ID,
@@ -81,7 +72,6 @@ impl Default for StarknetConfig {
             re_execute_on_init: true,
             state_archive: StateArchiveCapacity::default(),
             fork_config: ForkConfig::default(),
-            request_body_size_limit: DEVNET_DEFAULT_REQUEST_BODY_SIZE_LIMIT,
         }
     }
 }

--- a/crates/starknet-devnet-server/src/builder.rs
+++ b/crates/starknet-devnet-server/src/builder.rs
@@ -3,12 +3,12 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use axum::extract::DefaultBodyLimit;
+use axum::http::HeaderValue;
 use axum::response::Response;
 use axum::routing::{post, IntoMakeService};
 use axum::{Extension, Router};
 use hyper::server::conn::AddrIncoming;
 use hyper::{header, Method, Request, Server};
-use starknet_core::starknet::starknet_config::StarknetConfig;
 use tower::Service;
 use tower_http::cors::CorsLayer;
 use tower_http::timeout::TimeoutLayer;
@@ -34,7 +34,6 @@ pub struct Builder<TJsonRpcHandler: RpcHandler, THttpApiHandler: Clone + Send + 
     routes: Router,
     json_rpc_handler: TJsonRpcHandler,
     http_api_handler: THttpApiHandler,
-    config: Option<ServerConfig>,
 }
 
 impl<TJsonRpcHandler: RpcHandler, THttpApiHandler: Clone + Send + Sync + 'static>
@@ -50,7 +49,6 @@ impl<TJsonRpcHandler: RpcHandler, THttpApiHandler: Clone + Send + Sync + 'static
             routes: Router::<hyper::Body>::new(),
             json_rpc_handler,
             http_api_handler,
-            config: None,
         }
     }
 
@@ -84,36 +82,26 @@ impl<TJsonRpcHandler: RpcHandler, THttpApiHandler: Clone + Send + Sync + 'static
         }
     }
 
-    /// Sets additional configuration for the [`StarknetDevnetServer`]
-    pub fn set_config(self, config: ServerConfig) -> Self {
-        Self { config: Some(config), ..self }
-    }
-
     /// Creates the http server - [`StarknetDevnetServer`] from all the configured routes, provided
     /// [`ServerConfig`] and all handlers that have Some value. If TJsonRpcHandler and/or
     /// THttpApiHandler are set each methods that serves the route will be able to use it.
     /// https://docs.rs/axum/latest/axum/#using-request-extensions
-    pub fn build(self, starknet_config: &StarknetConfig) -> ServerResult<StarknetDevnetServer> {
+    pub fn build(self, config: &ServerConfig) -> ServerResult<StarknetDevnetServer> {
         let mut svc = self.routes;
 
-        println!("DEBUG setting request body size: {}", starknet_config.request_body_size_limit);
         svc = svc
             .layer(Extension(self.json_rpc_handler))
             .layer(Extension(self.http_api_handler))
             .layer(TraceLayer::new_for_http())
-            .layer(TimeoutLayer::new(Duration::from_secs(starknet_config.timeout.into())))
-            .layer(DefaultBodyLimit::max(starknet_config.request_body_size_limit));
-
-        if let Some(ServerConfig { allow_origin }) = self.config {
-            svc = svc.layer(
-                // see https://docs.rs/tower-http/latest/tower_http/cors/index.html
-                // for more details
+            .layer(TimeoutLayer::new(Duration::from_secs(config.timeout.into())))
+            .layer(DefaultBodyLimit::max(config.request_body_size_limit))
+            .layer(
                 CorsLayer::new()
-                    .allow_origin(allow_origin.0)
+                    // More details: https://docs.rs/tower-http/latest/tower_http/cors/index.html
+                    .allow_origin("*".parse::<HeaderValue>().unwrap())
                     .allow_headers(vec![header::CONTENT_TYPE])
                     .allow_methods(vec![Method::GET, Method::POST]),
-            )
-        }
+            );
 
         Ok(Server::try_bind(&self.address)?.serve(svc.into_make_service()))
     }

--- a/crates/starknet-devnet-server/src/config.rs
+++ b/crates/starknet-devnet-server/src/config.rs
@@ -1,8 +1,4 @@
 use std::net::IpAddr;
-use std::str::FromStr;
-
-use hyper::header::HeaderValue;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Debug, Clone)]
 pub struct ServerConfig {
@@ -10,54 +6,4 @@ pub struct ServerConfig {
     pub port: u16,
     pub timeout: u16,
     pub request_body_size_limit: usize,
-}
-
-#[derive(Debug, Clone)]
-pub struct HeaderValueWrapper(pub HeaderValue);
-
-impl FromStr for HeaderValueWrapper {
-    type Err = <HeaderValue as FromStr>::Err;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(HeaderValueWrapper(s.parse()?))
-    }
-}
-
-impl Serialize for HeaderValueWrapper {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(self.0.to_str().map_err(serde::ser::Error::custom)?)
-    }
-}
-
-impl<'de> Deserialize<'de> for HeaderValueWrapper {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        Ok(Self(s.parse().map_err(serde::de::Error::custom)?))
-    }
-}
-
-impl std::ops::Deref for HeaderValueWrapper {
-    type Target = HeaderValue;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl From<HeaderValueWrapper> for HeaderValue {
-    fn from(wrapper: HeaderValueWrapper) -> Self {
-        wrapper.0
-    }
-}
-
-impl From<HeaderValue> for HeaderValueWrapper {
-    fn from(header: HeaderValue) -> Self {
-        HeaderValueWrapper(header)
-    }
 }

--- a/crates/starknet-devnet-server/src/config.rs
+++ b/crates/starknet-devnet-server/src/config.rs
@@ -1,19 +1,15 @@
+use std::net::IpAddr;
 use std::str::FromStr;
 
 use hyper::header::HeaderValue;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-/// Additional server options.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct ServerConfig {
-    /// The cors `allow_origin` header
-    pub allow_origin: HeaderValueWrapper,
-}
-
-impl Default for ServerConfig {
-    fn default() -> Self {
-        Self { allow_origin: "*".parse::<HeaderValue>().unwrap().into() }
-    }
+    pub host: IpAddr,
+    pub port: u16,
+    pub timeout: u16,
+    pub request_body_size_limit: usize,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/starknet-devnet-server/src/server.rs
+++ b/crates/starknet-devnet-server/src/server.rs
@@ -15,9 +15,9 @@ use crate::ServerConfig;
 /// Configures an [axum::Server] that handles related JSON-RPC calls and WEB API calls via HTTP
 pub fn serve_http_api_json_rpc(
     addr: SocketAddr,
-    config: ServerConfig,
     api: Api,
     starknet_config: &StarknetConfig,
+    server_config: &ServerConfig,
 ) -> ServerResult<StarknetDevnetServer> {
     let http = HttpApiHandler { api: api.clone() };
     let origin_caller = if let (Some(url), Some(block_number)) =
@@ -31,7 +31,6 @@ pub fn serve_http_api_json_rpc(
     let json_rpc = JsonRpcHandler { api, origin_caller };
 
     crate::builder::Builder::<JsonRpcHandler, HttpApiHandler>::new(addr, json_rpc, http)
-        .set_config(config)
         .json_rpc_route("/")
         .json_rpc_route("/rpc")
         .http_api_route("/is_alive", get(http::is_alive))
@@ -56,5 +55,5 @@ pub fn serve_http_api_json_rpc(
         .http_api_route("/account_balance", get(http::accounts::get_account_balance))
         .http_api_route("/mint", post(http::mint_token::mint))
         .http_api_route("/fork_status", get(http::get_fork_status))
-        .build(starknet_config)
+        .build(server_config)
 }

--- a/crates/starknet-devnet/src/cli.rs
+++ b/crates/starknet-devnet/src/cli.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroU128;
 use clap::Parser;
 use starknet_core::constants::{
     DEVNET_DEFAULT_DATA_GAS_PRICE, DEVNET_DEFAULT_GAS_PRICE, DEVNET_DEFAULT_PORT,
-    DEVNET_DEFAULT_TIMEOUT, DEVNET_DEFAULT_TOTAL_ACCOUNTS,
+    DEVNET_DEFAULT_REQUEST_BODY_SIZE_LIMIT, DEVNET_DEFAULT_TIMEOUT, DEVNET_DEFAULT_TOTAL_ACCOUNTS,
 };
 use starknet_core::contract_class_choice::{AccountClassWrapper, AccountContractClassChoice};
 use starknet_core::random_number_generator::generate_u32_random_number;
@@ -130,6 +130,12 @@ pub(crate) struct Args {
     #[arg(help = "Specify the number of the block to fork at;")]
     #[arg(requires = "fork_network")]
     fork_block: Option<u64>,
+
+    #[arg(long = "request-body-size-limit")]
+    #[arg(value_name = "BYTES")]
+    #[arg(help = "Specify the maximum HTTP request body size;")]
+    #[arg(default_value_t = DEVNET_DEFAULT_REQUEST_BODY_SIZE_LIMIT)]
+    request_body_size_limit: usize,
 }
 
 impl Args {
@@ -164,6 +170,7 @@ impl Args {
                 url: self.fork_network.clone(),
                 block_number: self.fork_block,
             },
+            request_body_size_limit: self.request_body_size_limit,
         })
     }
 }

--- a/crates/starknet-devnet/src/main.rs
+++ b/crates/starknet-devnet/src/main.rs
@@ -6,7 +6,6 @@ use cli::Args;
 use server::api::json_rpc::RPC_SPEC_VERSION;
 use server::api::Api;
 use server::server::serve_http_api_json_rpc;
-use server::ServerConfig;
 use starknet_core::account::Account;
 use starknet_core::constants::{
     CAIRO_1_ERC20_CONTRACT_CLASS_HASH, ETH_ERC20_CONTRACT_ADDRESS, STRK_ERC20_CONTRACT_ADDRESS,
@@ -149,11 +148,11 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // parse arguments
     let args = Args::parse();
-    let mut starknet_config = args.to_starknet_config()?;
+    let (mut starknet_config, server_config) = args.to_config()?;
 
     set_and_log_fork_config(&mut starknet_config.fork_config, starknet_config.chain_id).await?;
 
-    let mut addr: SocketAddr = SocketAddr::new(starknet_config.host, starknet_config.port);
+    let mut addr: SocketAddr = SocketAddr::new(server_config.host, server_config.port);
 
     let api = Api::new(Starknet::new(&starknet_config)?);
 
@@ -174,8 +173,7 @@ async fn main() -> Result<(), anyhow::Error> {
         starknet_config.predeployed_accounts_initial_balance.clone(),
     );
 
-    let server =
-        serve_http_api_json_rpc(addr, ServerConfig::default(), api.clone(), &starknet_config)?;
+    let server = serve_http_api_json_rpc(addr, api.clone(), &starknet_config, &server_config)?;
     addr = server.local_addr();
 
     info!("Starknet Devnet listening on {}", addr);

--- a/crates/starknet-devnet/tests/general_integration_tests.rs
+++ b/crates/starknet-devnet/tests/general_integration_tests.rs
@@ -2,11 +2,62 @@
 pub mod common;
 
 mod general_integration_tests {
+    use hyper::{Body, StatusCode};
+    use serde_json::json;
+
     use crate::common::background_devnet::BackgroundDevnet;
+    use crate::common::utils::get_json_body;
 
     #[tokio::test]
     /// Asserts that a background instance can be spawned
     async fn spawnable() {
         BackgroundDevnet::spawn().await.expect("Could not start Devnet");
+    }
+
+    #[tokio::test]
+    async fn too_big_request_rejected() {
+        let limit = 1_000;
+        let devnet = BackgroundDevnet::spawn_with_additional_args(&[
+            "--request-body-size-limit",
+            &limit.to_string(),
+        ])
+        .await
+        .unwrap();
+
+        let too_big_path = "a".repeat(limit);
+        match devnet
+            .post_json("/load".into(), Body::from(json!({ "path": too_big_path }).to_string()))
+            .await
+        {
+            Ok(resp) => {
+                assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
+            }
+            other => panic!("Unexpected response: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn request_size_below_limit() {
+        let limit = 100;
+        let devnet = BackgroundDevnet::spawn_with_additional_args(&[
+            "--request-body-size-limit",
+            &limit.to_string(),
+        ])
+        .await
+        .unwrap();
+
+        // subtract enough so that the rest of the json body doesn't overflow the limit
+        let ok_path = "0".repeat(limit - 20);
+        match devnet
+            .post_json("/load".into(), Body::from(json!({ "path": ok_path }).to_string()))
+            .await
+        {
+            Ok(resp) => {
+                assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+                let load_resp = get_json_body(resp).await;
+                assert_eq!(load_resp, json!({ "error": "The file does not exist" }));
+            }
+            other => panic!("Unexpected response: {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Usage related changes

- Close #408
- Introduce a new CLI parameter: `--request-body-size-limit <BYTES>`
  - Default: `2000000` (2 MB) - so far this was the only value used
  - This is more flexible than implementing a boolean flag parameter

## Development related changes

- Refactor: extract host, port, timeout and request_body_size_limit to ServerConfig
- Remove redundant code from ServerConfig

## Checklist:

- [x] Checked the relevant parts of [development docs](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#development)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
- [x] Updated the docs if needed, including the [TODO section](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#todo-to-reach-feature-parity-with-the-pythonic-devnet)
- [x] Linked the issues which this PR resolves
- [x] Updated the tests if needed; all passing ([execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#test-execution))
