### PR TITLE
Refactor Transaction enum

### DIFF
--- a/crates/starknet-devnet-core/src/messaging/mod.rs
+++ b/crates/starknet-devnet-core/src/messaging/mod.rs
@@ -35,7 +35,7 @@ use std::collections::HashMap;
 use starknet_rs_core::types::{BlockId, ExecutionResult, Hash256};
 use starknet_types::felt::TransactionHash;
 use starknet_types::rpc::messaging::{MessageToL1, MessageToL2};
-use starknet_types::rpc::transactions::L1HandlerTransaction;
+use starknet_types::rpc::transactions::l1_handler_transaction::L1HandlerTransaction;
 
 use crate::error::{DevnetResult, Error, MessagingError};
 use crate::starknet::Starknet;
@@ -225,15 +225,13 @@ impl Starknet {
         &mut self,
         messages: &[MessageToL2],
     ) -> DevnetResult<Vec<TransactionHash>> {
-        let chain_id = self.chain_id().to_felt();
         let mut transactions_hashes = vec![];
 
         for message in messages {
-            let transaction =
-                L1HandlerTransaction::try_from_message_to_l2(message.clone())?.with_hash(chain_id);
-            transactions_hashes.push(transaction.transaction_hash);
+            let transaction = L1HandlerTransaction::try_from_message_to_l2(message.clone())?;
 
-            self.add_l1_handler_transaction(transaction)?;
+            let transaction_hash = self.add_l1_handler_transaction(transaction)?;
+            transactions_hashes.push(transaction_hash);
         }
 
         Ok(transactions_hashes)

--- a/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
@@ -5,7 +5,7 @@ use starknet_types::rpc::transactions::broadcasted_declare_transaction_v2::Broad
 use starknet_types::rpc::transactions::broadcasted_declare_transaction_v3::BroadcastedDeclareTransactionV3;
 use starknet_types::rpc::transactions::declare_transaction_v3::DeclareTransactionV3;
 use starknet_types::rpc::transactions::{
-    BroadcastedDeclareTransaction, DeclareTransaction, TransactionWithHash,
+    BroadcastedDeclareTransaction, DeclareTransaction, Transaction, TransactionWithHash,
 };
 
 use super::dump::DumpEvent;
@@ -26,12 +26,14 @@ pub fn add_declare_transaction_v3(
     let transaction_hash = blockifier_declare_transaction.tx_hash().0.into();
     let class_hash = blockifier_declare_transaction.class_hash().0.into();
 
-    let transaction =
-        TransactionWithHash::Declare(DeclareTransaction::Version3(DeclareTransactionV3::new(
+    let transaction = TransactionWithHash::new(
+        transaction_hash,
+        Transaction::Declare(DeclareTransaction::Version3(DeclareTransactionV3::new(
             broadcasted_declare_transaction.clone(),
             class_hash,
             transaction_hash,
-        )));
+        ))),
+    );
 
     let blockifier_execution_result =
         blockifier::transaction::account_transaction::AccountTransaction::Declare(
@@ -65,9 +67,12 @@ pub fn add_declare_transaction_v2(
     let transaction_hash = blockifier_declare_transaction.tx_hash().0.into();
     let class_hash = blockifier_declare_transaction.class_hash().0.into();
 
-    let transaction = TransactionWithHash::Declare(DeclareTransaction::Version2(
-        broadcasted_declare_transaction.create_declare(class_hash, transaction_hash),
-    ));
+    let transaction = TransactionWithHash::new(
+        transaction_hash,
+        Transaction::Declare(DeclareTransaction::Version2(
+            broadcasted_declare_transaction.create_declare(class_hash, transaction_hash),
+        )),
+    );
 
     let blockifier_execution_result =
         blockifier::transaction::account_transaction::AccountTransaction::Declare(
@@ -101,8 +106,10 @@ pub fn add_declare_transaction_v1(
 
     let declare_transaction =
         broadcasted_declare_transaction.create_declare(class_hash, transaction_hash);
-    let transaction =
-        TransactionWithHash::Declare(DeclareTransaction::Version1(declare_transaction));
+    let transaction = TransactionWithHash::new(
+        transaction_hash,
+        Transaction::Declare(DeclareTransaction::Version1(declare_transaction)),
+    );
 
     let blockifier_declare_transaction =
         broadcasted_declare_transaction.create_blockifier_declare(class_hash, transaction_hash)?;

--- a/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
@@ -3,6 +3,8 @@ use starknet_types::felt::{ClassHash, TransactionHash};
 use starknet_types::rpc::transactions::broadcasted_declare_transaction_v1::BroadcastedDeclareTransactionV1;
 use starknet_types::rpc::transactions::broadcasted_declare_transaction_v2::BroadcastedDeclareTransactionV2;
 use starknet_types::rpc::transactions::broadcasted_declare_transaction_v3::BroadcastedDeclareTransactionV3;
+use starknet_types::rpc::transactions::declare_transaction_v0v1::DeclareTransactionV0V1;
+use starknet_types::rpc::transactions::declare_transaction_v2::DeclareTransactionV2;
 use starknet_types::rpc::transactions::declare_transaction_v3::DeclareTransactionV3;
 use starknet_types::rpc::transactions::{
     BroadcastedDeclareTransaction, DeclareTransaction, Transaction, TransactionWithHash,
@@ -29,9 +31,8 @@ pub fn add_declare_transaction_v3(
     let transaction = TransactionWithHash::new(
         transaction_hash,
         Transaction::Declare(DeclareTransaction::Version3(DeclareTransactionV3::new(
-            broadcasted_declare_transaction.clone(),
+            &broadcasted_declare_transaction,
             class_hash,
-            transaction_hash,
         ))),
     );
 
@@ -69,9 +70,10 @@ pub fn add_declare_transaction_v2(
 
     let transaction = TransactionWithHash::new(
         transaction_hash,
-        Transaction::Declare(DeclareTransaction::Version2(
-            broadcasted_declare_transaction.create_declare(class_hash, transaction_hash),
-        )),
+        Transaction::Declare(DeclareTransaction::Version2(DeclareTransactionV2::new(
+            &broadcasted_declare_transaction,
+            class_hash,
+        ))),
     );
 
     let blockifier_execution_result =
@@ -105,7 +107,8 @@ pub fn add_declare_transaction_v1(
         .calculate_transaction_hash(&starknet.config.chain_id.to_felt(), &class_hash)?;
 
     let declare_transaction =
-        broadcasted_declare_transaction.create_declare(class_hash, transaction_hash);
+        DeclareTransactionV0V1::new(&broadcasted_declare_transaction, class_hash);
+
     let transaction = TransactionWithHash::new(
         transaction_hash,
         Transaction::Declare(DeclareTransaction::Version1(declare_transaction)),

--- a/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
@@ -5,7 +5,7 @@ use starknet_types::rpc::transactions::broadcasted_declare_transaction_v2::Broad
 use starknet_types::rpc::transactions::broadcasted_declare_transaction_v3::BroadcastedDeclareTransactionV3;
 use starknet_types::rpc::transactions::declare_transaction_v3::DeclareTransactionV3;
 use starknet_types::rpc::transactions::{
-    BroadcastedDeclareTransaction, DeclareTransaction, Transaction,
+    BroadcastedDeclareTransaction, DeclareTransaction, TransactionWithHash,
 };
 
 use super::dump::DumpEvent;
@@ -27,7 +27,7 @@ pub fn add_declare_transaction_v3(
     let class_hash = blockifier_declare_transaction.class_hash().0.into();
 
     let transaction =
-        Transaction::Declare(DeclareTransaction::Version3(DeclareTransactionV3::new(
+        TransactionWithHash::Declare(DeclareTransaction::Version3(DeclareTransactionV3::new(
             broadcasted_declare_transaction.clone(),
             class_hash,
             transaction_hash,
@@ -65,7 +65,7 @@ pub fn add_declare_transaction_v2(
     let transaction_hash = blockifier_declare_transaction.tx_hash().0.into();
     let class_hash = blockifier_declare_transaction.class_hash().0.into();
 
-    let transaction = Transaction::Declare(DeclareTransaction::Version2(
+    let transaction = TransactionWithHash::Declare(DeclareTransaction::Version2(
         broadcasted_declare_transaction.create_declare(class_hash, transaction_hash),
     ));
 
@@ -101,7 +101,8 @@ pub fn add_declare_transaction_v1(
 
     let declare_transaction =
         broadcasted_declare_transaction.create_declare(class_hash, transaction_hash);
-    let transaction = Transaction::Declare(DeclareTransaction::Version1(declare_transaction));
+    let transaction =
+        TransactionWithHash::Declare(DeclareTransaction::Version1(declare_transaction));
 
     let blockifier_declare_transaction =
         broadcasted_declare_transaction.create_blockifier_declare(class_hash, transaction_hash)?;

--- a/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
@@ -30,7 +30,7 @@ pub fn add_declare_transaction_v3(
 
     let transaction = TransactionWithHash::new(
         transaction_hash,
-        Transaction::Declare(DeclareTransaction::Version3(DeclareTransactionV3::new(
+        Transaction::Declare(DeclareTransaction::V3(DeclareTransactionV3::new(
             &broadcasted_declare_transaction,
             class_hash,
         ))),
@@ -70,7 +70,7 @@ pub fn add_declare_transaction_v2(
 
     let transaction = TransactionWithHash::new(
         transaction_hash,
-        Transaction::Declare(DeclareTransaction::Version2(DeclareTransactionV2::new(
+        Transaction::Declare(DeclareTransaction::V2(DeclareTransactionV2::new(
             &broadcasted_declare_transaction,
             class_hash,
         ))),
@@ -111,7 +111,7 @@ pub fn add_declare_transaction_v1(
 
     let transaction = TransactionWithHash::new(
         transaction_hash,
-        Transaction::Declare(DeclareTransaction::Version1(declare_transaction)),
+        Transaction::Declare(DeclareTransaction::V1(declare_transaction)),
     );
 
     let blockifier_declare_transaction =

--- a/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
@@ -5,7 +5,7 @@ use starknet_types::rpc::transactions::broadcasted_deploy_account_transaction_v1
 use starknet_types::rpc::transactions::broadcasted_deploy_account_transaction_v3::BroadcastedDeployAccountTransactionV3;
 use starknet_types::rpc::transactions::deploy_account_transaction_v3::DeployAccountTransactionV3;
 use starknet_types::rpc::transactions::{
-    BroadcastedDeployAccountTransaction, DeployAccountTransaction, TransactionWithHash,
+    BroadcastedDeployAccountTransaction, DeployAccountTransaction, Transaction, TransactionWithHash,
 };
 
 use super::dump::DumpEvent;
@@ -38,9 +38,12 @@ pub fn add_deploy_account_transaction_v3(
         transaction_hash,
     );
 
-    let transaction = TransactionWithHash::DeployAccount(DeployAccountTransaction::Version3(
-        Box::new(deploy_account_transaction_v3),
-    ));
+    let transaction = TransactionWithHash::new(
+        transaction_hash,
+        Transaction::DeployAccount(DeployAccountTransaction::Version3(Box::new(
+            deploy_account_transaction_v3,
+        ))),
+    );
 
     let blockifier_execution_result =
         blockifier::transaction::account_transaction::AccountTransaction::DeployAccount(
@@ -78,9 +81,12 @@ pub fn add_deploy_account_transaction_v1(
     let deploy_account_transaction_v1 = broadcasted_deploy_account_transaction
         .compile_deploy_account_transaction_v1(&transaction_hash, address);
 
-    let transaction = TransactionWithHash::DeployAccount(DeployAccountTransaction::Version1(
-        Box::new(deploy_account_transaction_v1),
-    ));
+    let transaction = TransactionWithHash::new(
+        transaction_hash,
+        Transaction::DeployAccount(DeployAccountTransaction::Version1(Box::new(
+            deploy_account_transaction_v1,
+        ))),
+    );
 
     let blockifier_execution_result =
         blockifier::transaction::account_transaction::AccountTransaction::DeployAccount(

--- a/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
@@ -5,7 +5,7 @@ use starknet_types::rpc::transactions::broadcasted_deploy_account_transaction_v1
 use starknet_types::rpc::transactions::broadcasted_deploy_account_transaction_v3::BroadcastedDeployAccountTransactionV3;
 use starknet_types::rpc::transactions::deploy_account_transaction_v3::DeployAccountTransactionV3;
 use starknet_types::rpc::transactions::{
-    BroadcastedDeployAccountTransaction, DeployAccountTransaction, Transaction,
+    BroadcastedDeployAccountTransaction, DeployAccountTransaction, TransactionWithHash,
 };
 
 use super::dump::DumpEvent;
@@ -38,9 +38,9 @@ pub fn add_deploy_account_transaction_v3(
         transaction_hash,
     );
 
-    let transaction = Transaction::DeployAccount(DeployAccountTransaction::Version3(Box::new(
-        deploy_account_transaction_v3,
-    )));
+    let transaction = TransactionWithHash::DeployAccount(DeployAccountTransaction::Version3(
+        Box::new(deploy_account_transaction_v3),
+    ));
 
     let blockifier_execution_result =
         blockifier::transaction::account_transaction::AccountTransaction::DeployAccount(
@@ -78,9 +78,9 @@ pub fn add_deploy_account_transaction_v1(
     let deploy_account_transaction_v1 = broadcasted_deploy_account_transaction
         .compile_deploy_account_transaction_v1(&transaction_hash, address);
 
-    let transaction = Transaction::DeployAccount(DeployAccountTransaction::Version1(Box::new(
-        deploy_account_transaction_v1,
-    )));
+    let transaction = TransactionWithHash::DeployAccount(DeployAccountTransaction::Version1(
+        Box::new(deploy_account_transaction_v1),
+    ));
 
     let blockifier_execution_result =
         blockifier::transaction::account_transaction::AccountTransaction::DeployAccount(

--- a/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
@@ -3,6 +3,7 @@ use starknet_types::contract_address::ContractAddress;
 use starknet_types::felt::TransactionHash;
 use starknet_types::rpc::transactions::broadcasted_deploy_account_transaction_v1::BroadcastedDeployAccountTransactionV1;
 use starknet_types::rpc::transactions::broadcasted_deploy_account_transaction_v3::BroadcastedDeployAccountTransactionV3;
+use starknet_types::rpc::transactions::deploy_account_transaction_v1::DeployAccountTransactionV1;
 use starknet_types::rpc::transactions::deploy_account_transaction_v3::DeployAccountTransactionV3;
 use starknet_types::rpc::transactions::{
     BroadcastedDeployAccountTransaction, DeployAccountTransaction, Transaction, TransactionWithHash,
@@ -32,11 +33,8 @@ pub fn add_deploy_account_transaction_v3(
 
     let transaction_hash = blockifier_deploy_account_transaction.tx_hash.0.into();
     let address: ContractAddress = blockifier_deploy_account_transaction.contract_address.into();
-    let deploy_account_transaction_v3 = DeployAccountTransactionV3::new(
-        broadcasted_deploy_account_transaction.clone(),
-        address,
-        transaction_hash,
-    );
+    let deploy_account_transaction_v3 =
+        DeployAccountTransactionV3::new(&broadcasted_deploy_account_transaction, address);
 
     let transaction = TransactionWithHash::new(
         transaction_hash,
@@ -78,8 +76,8 @@ pub fn add_deploy_account_transaction_v1(
 
     let transaction_hash = blockifier_deploy_account_transaction.tx_hash.0.into();
     let address: ContractAddress = blockifier_deploy_account_transaction.contract_address.into();
-    let deploy_account_transaction_v1 = broadcasted_deploy_account_transaction
-        .compile_deploy_account_transaction_v1(&transaction_hash, address);
+    let deploy_account_transaction_v1 =
+        DeployAccountTransactionV1::new(&broadcasted_deploy_account_transaction, address);
 
     let transaction = TransactionWithHash::new(
         transaction_hash,

--- a/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
@@ -38,7 +38,7 @@ pub fn add_deploy_account_transaction_v3(
 
     let transaction = TransactionWithHash::new(
         transaction_hash,
-        Transaction::DeployAccount(DeployAccountTransaction::Version3(Box::new(
+        Transaction::DeployAccount(DeployAccountTransaction::V3(Box::new(
             deploy_account_transaction_v3,
         ))),
     );
@@ -81,7 +81,7 @@ pub fn add_deploy_account_transaction_v1(
 
     let transaction = TransactionWithHash::new(
         transaction_hash,
-        Transaction::DeployAccount(DeployAccountTransaction::Version1(Box::new(
+        Transaction::DeployAccount(DeployAccountTransaction::V1(Box::new(
             deploy_account_transaction_v1,
         ))),
     );

--- a/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
@@ -2,6 +2,7 @@ use blockifier::transaction::transactions::ExecutableTransaction;
 use starknet_types::felt::TransactionHash;
 use starknet_types::rpc::transactions::broadcasted_invoke_transaction_v1::BroadcastedInvokeTransactionV1;
 use starknet_types::rpc::transactions::broadcasted_invoke_transaction_v3::BroadcastedInvokeTransactionV3;
+use starknet_types::rpc::transactions::invoke_transaction_v1::InvokeTransactionV1;
 use starknet_types::rpc::transactions::invoke_transaction_v3::InvokeTransactionV3;
 use starknet_types::rpc::transactions::{
     BroadcastedInvokeTransaction, InvokeTransaction, Transaction, TransactionWithHash,
@@ -23,8 +24,7 @@ pub fn add_invoke_transaction_v1(
         .create_blockifier_invoke_transaction(starknet.chain_id().to_felt(), false)?;
     let transaction_hash = blockifier_invoke_transaction.tx_hash.0.into();
 
-    let invoke_transaction =
-        broadcasted_invoke_transaction.create_invoke_transaction(transaction_hash);
+    let invoke_transaction = InvokeTransactionV1::new(&broadcasted_invoke_transaction);
     let transaction = TransactionWithHash::new(
         transaction_hash,
         Transaction::Invoke(InvokeTransaction::Version1(invoke_transaction)),
@@ -66,8 +66,7 @@ pub fn add_invoke_transaction_v3(
     let transaction = TransactionWithHash::new(
         transaction_hash,
         Transaction::Invoke(InvokeTransaction::Version3(InvokeTransactionV3::new(
-            broadcasted_invoke_transaction.clone(),
-            transaction_hash,
+            &broadcasted_invoke_transaction,
         ))),
     );
 

--- a/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
@@ -27,7 +27,7 @@ pub fn add_invoke_transaction_v1(
     let invoke_transaction = InvokeTransactionV1::new(&broadcasted_invoke_transaction);
     let transaction = TransactionWithHash::new(
         transaction_hash,
-        Transaction::Invoke(InvokeTransaction::Version1(invoke_transaction)),
+        Transaction::Invoke(InvokeTransaction::V1(invoke_transaction)),
     );
 
     let blockifier_execution_result =
@@ -65,7 +65,7 @@ pub fn add_invoke_transaction_v3(
 
     let transaction = TransactionWithHash::new(
         transaction_hash,
-        Transaction::Invoke(InvokeTransaction::Version3(InvokeTransactionV3::new(
+        Transaction::Invoke(InvokeTransaction::V3(InvokeTransactionV3::new(
             &broadcasted_invoke_transaction,
         ))),
     );

--- a/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
@@ -4,7 +4,7 @@ use starknet_types::rpc::transactions::broadcasted_invoke_transaction_v1::Broadc
 use starknet_types::rpc::transactions::broadcasted_invoke_transaction_v3::BroadcastedInvokeTransactionV3;
 use starknet_types::rpc::transactions::invoke_transaction_v3::InvokeTransactionV3;
 use starknet_types::rpc::transactions::{
-    BroadcastedInvokeTransaction, InvokeTransaction, Transaction,
+    BroadcastedInvokeTransaction, InvokeTransaction, TransactionWithHash,
 };
 
 use super::dump::DumpEvent;
@@ -25,7 +25,7 @@ pub fn add_invoke_transaction_v1(
 
     let invoke_transaction =
         broadcasted_invoke_transaction.create_invoke_transaction(transaction_hash);
-    let transaction = Transaction::Invoke(InvokeTransaction::Version1(invoke_transaction));
+    let transaction = TransactionWithHash::Invoke(InvokeTransaction::Version1(invoke_transaction));
 
     let blockifier_execution_result =
         blockifier::transaction::account_transaction::AccountTransaction::Invoke(
@@ -60,10 +60,9 @@ pub fn add_invoke_transaction_v3(
         )
         .execute(&mut starknet.state.state, &starknet.block_context, true, true);
 
-    let transaction = Transaction::Invoke(InvokeTransaction::Version3(InvokeTransactionV3::new(
-        broadcasted_invoke_transaction.clone(),
-        transaction_hash,
-    )));
+    let transaction = TransactionWithHash::Invoke(InvokeTransaction::Version3(
+        InvokeTransactionV3::new(broadcasted_invoke_transaction.clone(), transaction_hash),
+    ));
 
     starknet.handle_transaction_result(transaction, None, blockifier_execution_result)?;
     starknet.handle_dump_event(DumpEvent::AddInvokeTransaction(

--- a/crates/starknet-devnet-core/src/starknet/add_l1_handler_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_l1_handler_transaction.rs
@@ -1,6 +1,6 @@
 use blockifier::transaction::transactions::ExecutableTransaction;
 use starknet_types::felt::TransactionHash;
-use starknet_types::rpc::transactions::{L1HandlerTransaction, TransactionWithHash};
+use starknet_types::rpc::transactions::{L1HandlerTransaction, Transaction, TransactionWithHash};
 use tracing::trace;
 
 use super::Starknet;
@@ -30,7 +30,7 @@ pub fn add_l1_handler_transaction(
     );
 
     starknet.handle_transaction_result(
-        TransactionWithHash::L1Handler(transaction.clone()),
+        TransactionWithHash::new(transaction_hash, Transaction::L1Handler(transaction.clone())),
         None,
         blockifier_execution_result,
     )?;

--- a/crates/starknet-devnet-core/src/starknet/add_l1_handler_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_l1_handler_transaction.rs
@@ -1,6 +1,7 @@
 use blockifier::transaction::transactions::ExecutableTransaction;
 use starknet_types::felt::TransactionHash;
-use starknet_types::rpc::transactions::{L1HandlerTransaction, Transaction, TransactionWithHash};
+use starknet_types::rpc::transactions::l1_handler_transaction::L1HandlerTransaction;
+use starknet_types::rpc::transactions::{Transaction, TransactionWithHash};
 use tracing::trace;
 
 use super::Starknet;
@@ -11,10 +12,10 @@ pub fn add_l1_handler_transaction(
     starknet: &mut Starknet,
     transaction: L1HandlerTransaction,
 ) -> DevnetResult<TransactionHash> {
-    let transaction_hash = transaction.transaction_hash;
-    trace!("Executing L1 handler transaction [{:#064x}]", transaction.transaction_hash);
-
-    let blockifier_transaction = transaction.create_blockifier_transaction()?;
+    let blockifier_transaction =
+        transaction.create_blockifier_transaction(starknet.chain_id().to_felt())?;
+    let transaction_hash = blockifier_transaction.tx_hash.0.into();
+    trace!("Executing L1 handler transaction [{:#064x}]", transaction_hash);
 
     // Fees are charges on L1 as `L1HandlerTransaction` is not executed by an
     // account, but directly by the sequencer.
@@ -55,7 +56,7 @@ mod tests {
     use starknet_types::contract_class::{Cairo0ContractClass, ContractClass};
     use starknet_types::felt::Felt;
     use starknet_types::rpc::state::Balance;
-    use starknet_types::rpc::transactions::L1HandlerTransaction;
+    use starknet_types::rpc::transactions::l1_handler_transaction::L1HandlerTransaction;
     use starknet_types::traits::HashProducer;
 
     use crate::account::Account;
@@ -91,8 +92,9 @@ mod tests {
             nonce: nonce.into(),
             paid_fee_on_l1: fee,
             ..Default::default()
-        }
-        .with_hash(ChainId::Testnet.to_felt());
+        };
+
+        let l1_handler_transaction_hash = transaction.compute_hash(ChainId::Testnet.to_felt());
 
         let transaction_hash = Felt::from_prefixed_hex_str(
             "0x1b24ea8dd9e0cb603043958b27a8569635ea13568883cc155130591b7ffe37a",
@@ -100,7 +102,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(transaction.version, Felt::from(0));
-        assert_eq!(transaction.transaction_hash, transaction_hash);
+        assert_eq!(l1_handler_transaction_hash, transaction_hash);
     }
 
     #[test]
@@ -174,7 +176,6 @@ mod tests {
             paid_fee_on_l1: fee,
             ..Default::default()
         }
-        .with_hash(ChainId::Testnet.to_felt())
     }
 
     /// Initializes a starknet object with: l1l2 dummy contract that has two functions for

--- a/crates/starknet-devnet-core/src/starknet/add_l1_handler_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_l1_handler_transaction.rs
@@ -1,6 +1,6 @@
 use blockifier::transaction::transactions::ExecutableTransaction;
 use starknet_types::felt::TransactionHash;
-use starknet_types::rpc::transactions::{L1HandlerTransaction, Transaction};
+use starknet_types::rpc::transactions::{L1HandlerTransaction, TransactionWithHash};
 use tracing::trace;
 
 use super::Starknet;
@@ -30,7 +30,7 @@ pub fn add_l1_handler_transaction(
     );
 
     starknet.handle_transaction_result(
-        Transaction::L1Handler(transaction.clone()),
+        TransactionWithHash::L1Handler(transaction.clone()),
         None,
         blockifier_execution_result,
     )?;

--- a/crates/starknet-devnet-core/src/starknet/dump.rs
+++ b/crates/starknet-devnet-core/src/starknet/dump.rs
@@ -3,9 +3,10 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
+use starknet_types::rpc::transactions::l1_handler_transaction::L1HandlerTransaction;
 use starknet_types::rpc::transactions::{
     BroadcastedDeclareTransaction, BroadcastedDeployAccountTransaction,
-    BroadcastedInvokeTransaction, L1HandlerTransaction,
+    BroadcastedInvokeTransaction,
 };
 
 use super::{DumpOn, Starknet};

--- a/crates/starknet-devnet-core/src/starknet/events.rs
+++ b/crates/starknet-devnet-core/src/starknet/events.rs
@@ -394,14 +394,9 @@ mod tests {
         // each transaction should have events count equal to the order of the transaction
         let mut starknet = Starknet::new(&StarknetConfig::default()).unwrap();
 
-        let declare_txn = dummy_declare_transaction_v1();
+        let transaction = dummy_declare_transaction_v1();
 
         for idx in 0..5 {
-            let transaction = TransactionWithHash::new(
-                *declare_txn.get_transaction_hash(),
-                Transaction::Declare(DeclareTransaction::Version1(declare_txn.clone())),
-            );
-
             let txn_info = blockifier::transaction::objects::TransactionExecutionInfo {
                 execute_call_info: Some(dummy_call_info(idx + 1)),
                 ..Default::default()

--- a/crates/starknet-devnet-core/src/starknet/events.rs
+++ b/crates/starknet-devnet-core/src/starknet/events.rs
@@ -130,7 +130,7 @@ mod tests {
     use starknet_types::contract_address::ContractAddress;
     use starknet_types::emitted_event::Event;
     use starknet_types::felt::Felt;
-    use starknet_types::rpc::transactions::{DeclareTransaction, Transaction};
+    use starknet_types::rpc::transactions::{DeclareTransaction, TransactionWithHash};
 
     use super::{check_if_filter_applies_for_event, get_events};
     use crate::starknet::events::check_if_filter_applies_for_event_keys;
@@ -395,8 +395,9 @@ mod tests {
         let mut starknet = Starknet::new(&StarknetConfig::default()).unwrap();
 
         for idx in 0..5 {
-            let transaction =
-                Transaction::Declare(DeclareTransaction::Version1(dummy_declare_transaction_v1()));
+            let transaction = TransactionWithHash::Declare(DeclareTransaction::Version1(
+                dummy_declare_transaction_v1(),
+            ));
 
             let txn_info = blockifier::transaction::objects::TransactionExecutionInfo {
                 execute_call_info: Some(dummy_call_info(idx + 1)),

--- a/crates/starknet-devnet-core/src/starknet/events.rs
+++ b/crates/starknet-devnet-core/src/starknet/events.rs
@@ -130,7 +130,7 @@ mod tests {
     use starknet_types::contract_address::ContractAddress;
     use starknet_types::emitted_event::Event;
     use starknet_types::felt::Felt;
-    use starknet_types::rpc::transactions::{DeclareTransaction, TransactionWithHash};
+    use starknet_types::rpc::transactions::{DeclareTransaction, Transaction, TransactionWithHash};
 
     use super::{check_if_filter_applies_for_event, get_events};
     use crate::starknet::events::check_if_filter_applies_for_event_keys;
@@ -394,10 +394,13 @@ mod tests {
         // each transaction should have events count equal to the order of the transaction
         let mut starknet = Starknet::new(&StarknetConfig::default()).unwrap();
 
+        let declare_txn = dummy_declare_transaction_v1();
+
         for idx in 0..5 {
-            let transaction = TransactionWithHash::Declare(DeclareTransaction::Version1(
-                dummy_declare_transaction_v1(),
-            ));
+            let transaction = TransactionWithHash::new(
+                *declare_txn.get_transaction_hash(),
+                Transaction::Declare(DeclareTransaction::Version1(declare_txn.clone())),
+            );
 
             let txn_info = blockifier::transaction::objects::TransactionExecutionInfo {
                 execute_call_info: Some(dummy_call_info(idx + 1)),

--- a/crates/starknet-devnet-core/src/starknet/events.rs
+++ b/crates/starknet-devnet-core/src/starknet/events.rs
@@ -130,7 +130,6 @@ mod tests {
     use starknet_types::contract_address::ContractAddress;
     use starknet_types::emitted_event::Event;
     use starknet_types::felt::Felt;
-    
 
     use super::{check_if_filter_applies_for_event, get_events};
     use crate::starknet::events::check_if_filter_applies_for_event_keys;

--- a/crates/starknet-devnet-core/src/starknet/events.rs
+++ b/crates/starknet-devnet-core/src/starknet/events.rs
@@ -130,7 +130,7 @@ mod tests {
     use starknet_types::contract_address::ContractAddress;
     use starknet_types::emitted_event::Event;
     use starknet_types::felt::Felt;
-    use starknet_types::rpc::transactions::{DeclareTransaction, Transaction, TransactionWithHash};
+    
 
     use super::{check_if_filter_applies_for_event, get_events};
     use crate::starknet::events::check_if_filter_applies_for_event_keys;

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -1257,7 +1257,7 @@ mod tests {
         let tx = dummy_declare_transaction_v1();
 
         // add transaction hash to pending block
-        starknet.blocks.pending_block.add_transaction(tx.transaction_hash);
+        starknet.blocks.pending_block.add_transaction(*tx.get_transaction_hash());
 
         // pending block has some transactions
         assert!(!starknet.pending_block().get_transactions().is_empty());
@@ -1273,7 +1273,7 @@ mod tests {
             starknet.blocks.get_by_hash(starknet.blocks.last_block_hash.unwrap()).unwrap();
 
         assert!(added_block.get_transactions().len() == 1);
-        assert_eq!(*added_block.get_transactions().first().unwrap(), tx.transaction_hash);
+        assert_eq!(*added_block.get_transactions().first().unwrap(), *tx.get_transaction_hash());
     }
 
     #[test]
@@ -1526,7 +1526,7 @@ mod tests {
         let tx = dummy_declare_transaction_v1();
 
         // add transaction hash to pending block
-        starknet.blocks.pending_block.add_transaction(tx.transaction_hash);
+        starknet.blocks.pending_block.add_transaction(*tx.get_transaction_hash());
 
         starknet.generate_new_block(StateDiff::default()).unwrap();
 

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -343,21 +343,21 @@ impl Starknet {
                 // then save the contract class in the state cache for Declare transactions
                 if !tx_info.is_reverted() {
                     match &transaction.transaction {
-                        Transaction::Declare(DeclareTransaction::Version1(declare_v1)) => {
+                        Transaction::Declare(DeclareTransaction::V1(declare_v1)) => {
                             declare_contract_class(
                                 &declare_v1.class_hash,
                                 contract_class,
                                 &mut self.state,
                             )?
                         }
-                        Transaction::Declare(DeclareTransaction::Version2(declare_v2)) => {
+                        Transaction::Declare(DeclareTransaction::V2(declare_v2)) => {
                             declare_contract_class(
                                 &declare_v2.class_hash,
                                 contract_class,
                                 &mut self.state,
                             )?
                         }
-                        Transaction::Declare(DeclareTransaction::Version3(declare_v3)) => {
+                        Transaction::Declare(DeclareTransaction::V3(declare_v3)) => {
                             declare_contract_class(
                                 declare_v3.get_class_hash(),
                                 contract_class,

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -42,7 +42,7 @@ use starknet_types::rpc::transactions::broadcasted_invoke_transaction_v1::Broadc
 use starknet_types::rpc::transactions::broadcasted_invoke_transaction_v3::BroadcastedInvokeTransactionV3;
 use starknet_types::rpc::transactions::{
     BlockTransactionTrace, BroadcastedTransaction, BroadcastedTransactionCommon,
-    DeclareTransaction, L1HandlerTransaction, SimulatedTransaction, SimulationFlag,
+    DeclareTransaction, L1HandlerTransaction, SimulatedTransaction, SimulationFlag, Transaction,
     TransactionTrace, TransactionWithHash, TransactionWithReceipt, Transactions,
 };
 use starknet_types::traits::HashProducer;
@@ -341,22 +341,22 @@ impl Starknet {
                 // If transaction is not reverted
                 // then save the contract class in the state cache for Declare transactions
                 if !tx_info.is_reverted() {
-                    match &transaction {
-                        TransactionWithHash::Declare(DeclareTransaction::Version1(declare_v1)) => {
+                    match &transaction.transaction {
+                        Transaction::Declare(DeclareTransaction::Version1(declare_v1)) => {
                             declare_contract_class(
                                 &declare_v1.class_hash,
                                 contract_class,
                                 &mut self.state,
                             )?
                         }
-                        TransactionWithHash::Declare(DeclareTransaction::Version2(declare_v2)) => {
+                        Transaction::Declare(DeclareTransaction::Version2(declare_v2)) => {
                             declare_contract_class(
                                 &declare_v2.class_hash,
                                 contract_class,
                                 &mut self.state,
                             )?
                         }
-                        TransactionWithHash::Declare(DeclareTransaction::Version3(declare_v3)) => {
+                        Transaction::Declare(DeclareTransaction::Version3(declare_v3)) => {
                             declare_contract_class(
                                 declare_v3.get_class_hash(),
                                 contract_class,

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -922,7 +922,8 @@ impl Starknet {
             common_field.maybe_pending_properties.block_hash = None;
             common_field.maybe_pending_properties.block_number = None;
 
-            transaction_receipts.push(TransactionWithReceipt { receipt, transaction });
+            transaction_receipts
+                .push(TransactionWithReceipt { receipt, transaction: transaction.transaction });
         }
 
         Ok(Block {

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -826,7 +826,7 @@ impl Starknet {
         // starting block is reached in while loop.
         if last_reached_block_hash == Felt::from(0) && reached_starting_block {
             self.blocks.last_block_hash = None;
-            self.state = self.init_state.clone_historic(); // This will be refactored during the genesis block PR 
+            self.state = self.init_state.clone_historic(); // TODO: This will be refactored during the genesis block PR
         } else if reached_starting_block {
             let current_block =
                 self.blocks.hash_to_block.get(&last_reached_block_hash).ok_or(Error::NoBlock)?;

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -40,10 +40,11 @@ use starknet_types::rpc::transactions::broadcasted_deploy_account_transaction_v1
 use starknet_types::rpc::transactions::broadcasted_deploy_account_transaction_v3::BroadcastedDeployAccountTransactionV3;
 use starknet_types::rpc::transactions::broadcasted_invoke_transaction_v1::BroadcastedInvokeTransactionV1;
 use starknet_types::rpc::transactions::broadcasted_invoke_transaction_v3::BroadcastedInvokeTransactionV3;
+use starknet_types::rpc::transactions::l1_handler_transaction::L1HandlerTransaction;
 use starknet_types::rpc::transactions::{
     BlockTransactionTrace, BroadcastedTransaction, BroadcastedTransactionCommon,
-    DeclareTransaction, L1HandlerTransaction, SimulatedTransaction, SimulationFlag, Transaction,
-    TransactionTrace, TransactionWithHash, TransactionWithReceipt, Transactions,
+    DeclareTransaction, SimulatedTransaction, SimulationFlag, Transaction, TransactionTrace,
+    TransactionWithHash, TransactionWithReceipt, Transactions,
 };
 use starknet_types::traits::HashProducer;
 use tracing::{error, info};

--- a/crates/starknet-devnet-core/src/transactions.rs
+++ b/crates/starknet-devnet-core/src/transactions.rs
@@ -175,9 +175,9 @@ impl StarknetTransaction {
         let fee_amount = FeeAmount { amount: self.execution_info.actual_fee };
         let actual_fee_in_units = match self.inner.transaction {
             Transaction::L1Handler(_) => FeeInUnits::WEI(fee_amount),
-            Transaction::Declare(DeclareTransaction::Version3(_))
-            | Transaction::DeployAccount(DeployAccountTransaction::Version3(_))
-            | Transaction::Invoke(InvokeTransaction::Version3(_)) => FeeInUnits::FRI(fee_amount),
+            Transaction::Declare(DeclareTransaction::V3(_))
+            | Transaction::DeployAccount(DeployAccountTransaction::V3(_))
+            | Transaction::Invoke(InvokeTransaction::V3(_)) => FeeInUnits::FRI(fee_amount),
             _ => FeeInUnits::WEI(fee_amount),
         };
 

--- a/crates/starknet-devnet-core/src/transactions.rs
+++ b/crates/starknet-devnet-core/src/transactions.rs
@@ -299,12 +299,7 @@ mod tests {
 
     #[test]
     fn get_transaction_by_hash() {
-        let declare_transaction = dummy_declare_transaction_v1();
-        let hash = declare_transaction.generate_hash().unwrap();
-        let tx = TransactionWithHash::new(
-            hash,
-            Transaction::Declare(DeclareTransaction::Version1(declare_transaction)),
-        );
+        let tx = dummy_declare_transaction_v1();
 
         let trace = dummy_trace(&tx);
         let sn_tx = StarknetTransaction::create_accepted(
@@ -314,11 +309,11 @@ mod tests {
         );
         let mut sn_txs = StarknetTransactions::default();
         sn_txs.insert(
-            &hash,
+            tx.get_transaction_hash(),
             StarknetTransaction::create_accepted(&tx, TransactionExecutionInfo::default(), trace),
         );
 
-        let extracted_tran = sn_txs.get_by_hash_mut(&hash).unwrap();
+        let extracted_tran = sn_txs.get_by_hash_mut(tx.get_transaction_hash()).unwrap();
 
         assert_eq!(sn_tx.block_hash, extracted_tran.block_hash);
         assert_eq!(sn_tx.block_number, extracted_tran.block_number);
@@ -329,11 +324,7 @@ mod tests {
 
     #[test]
     fn check_correct_successful_transaction_creation() {
-        let declare_txn = dummy_declare_transaction_v1();
-        let tx = TransactionWithHash::new(
-            declare_txn.transaction_hash,
-            Transaction::Declare(DeclareTransaction::Version1(dummy_declare_transaction_v1())),
-        );
+        let tx = dummy_declare_transaction_v1();
         let trace = dummy_trace(&tx);
         let sn_tran =
             StarknetTransaction::create_accepted(&tx, TransactionExecutionInfo::default(), trace);

--- a/crates/starknet-devnet-core/src/transactions.rs
+++ b/crates/starknet-devnet-core/src/transactions.rs
@@ -278,9 +278,9 @@ mod tests {
     use blockifier::transaction::objects::TransactionExecutionInfo;
     use starknet_rs_core::types::{TransactionExecutionStatus, TransactionFinalityStatus};
     use starknet_types::rpc::transactions::{
-        DeclareTransaction, Transaction, TransactionTrace, TransactionWithHash,
+        TransactionTrace, TransactionWithHash,
     };
-    use starknet_types::traits::HashProducer;
+    
 
     use super::{StarknetTransaction, StarknetTransactions};
     use crate::starknet::transaction_trace::create_trace;

--- a/crates/starknet-devnet-core/src/transactions.rs
+++ b/crates/starknet-devnet-core/src/transactions.rs
@@ -277,10 +277,7 @@ impl StarknetTransaction {
 mod tests {
     use blockifier::transaction::objects::TransactionExecutionInfo;
     use starknet_rs_core::types::{TransactionExecutionStatus, TransactionFinalityStatus};
-    use starknet_types::rpc::transactions::{
-        TransactionTrace, TransactionWithHash,
-    };
-    
+    use starknet_types::rpc::transactions::{TransactionTrace, TransactionWithHash};
 
     use super::{StarknetTransaction, StarknetTransactions};
     use crate::starknet::transaction_trace::create_trace;

--- a/crates/starknet-devnet-core/src/utils.rs
+++ b/crates/starknet-devnet-core/src/utils.rs
@@ -115,7 +115,7 @@ pub(crate) mod test_utils {
 
         TransactionWithHash::new(
             transaction_hash,
-            Transaction::Declare(DeclareTransaction::Version1(DeclareTransactionV0V1::new(
+            Transaction::Declare(DeclareTransaction::V1(DeclareTransactionV0V1::new(
                 &broadcasted_tx,
                 class_hash,
             ))),

--- a/crates/starknet-devnet-core/src/utils.rs
+++ b/crates/starknet-devnet-core/src/utils.rs
@@ -67,7 +67,8 @@ pub(crate) mod test_utils {
     use starknet_types::rpc::transactions::broadcasted_declare_transaction_v3::BroadcastedDeclareTransactionV3;
     use starknet_types::rpc::transactions::declare_transaction_v0v1::DeclareTransactionV0V1;
     use starknet_types::rpc::transactions::{
-        BroadcastedTransactionCommonV3, ResourceBoundsWrapper,
+        BroadcastedTransactionCommonV3, DeclareTransaction, ResourceBoundsWrapper, Transaction,
+        TransactionWithHash,
     };
     use starknet_types::traits::HashProducer;
 
@@ -97,7 +98,7 @@ pub(crate) mod test_utils {
         ContractAddress::new(Felt::from_prefixed_hex_str("0xADD4E55").unwrap()).unwrap()
     }
 
-    pub(crate) fn dummy_declare_transaction_v1() -> DeclareTransactionV0V1 {
+    pub(crate) fn dummy_declare_transaction_v1() -> TransactionWithHash {
         let chain_id = DEVNET_DEFAULT_CHAIN_ID.to_felt();
         let contract_class = dummy_cairo_0_contract_class();
         let broadcasted_tx = BroadcastedDeclareTransactionV1::new(
@@ -112,7 +113,13 @@ pub(crate) mod test_utils {
         let transaction_hash =
             broadcasted_tx.calculate_transaction_hash(&chain_id, &class_hash).unwrap();
 
-        broadcasted_tx.create_declare(class_hash, transaction_hash)
+        TransactionWithHash::new(
+            transaction_hash,
+            Transaction::Declare(DeclareTransaction::Version1(DeclareTransactionV0V1::new(
+                &broadcasted_tx,
+                class_hash,
+            ))),
+        )
     }
 
     pub(crate) fn dummy_broadcasted_declare_transaction_v2(

--- a/crates/starknet-devnet-server/src/api/http/models.rs
+++ b/crates/starknet-devnet-server/src/api/http/models.rs
@@ -6,7 +6,6 @@ use starknet_types::num_bigint::BigUint;
 use starknet_types::rpc::eth_address::EthAddressWrapper;
 use starknet_types::rpc::messaging::{MessageToL1, MessageToL2};
 use starknet_types::rpc::transaction_receipt::FeeUnit;
-use starknet_types::rpc::transactions::L1HandlerTransaction;
 use starknet_types::serde_helpers::dec_string::deserialize_biguint;
 
 use crate::api::http::error::HttpApiError;

--- a/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
@@ -325,7 +325,7 @@ impl JsonRpcHandler {
     pub async fn chain_id(&self) -> StrictRpcResult {
         let chain_id = self.api.starknet.read().await.chain_id();
 
-        Ok(StarknetResponse::String(chain_id.to_felt().to_prefixed_hex_str()))
+        Ok(StarknetResponse::Felt(chain_id.to_felt()))
     }
 
     /// starknet_syncing

--- a/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
@@ -8,7 +8,6 @@ use starknet_types::rpc::state::StateUpdate;
 use starknet_types::rpc::transactions::{
     BroadcastedTransaction, EventFilter, EventsChunk, FunctionCall, SimulationFlag,
 };
-use starknet_types::traits::ToHexString;
 
 use super::error::{ApiError, StrictRpcResult};
 use super::models::{BlockHashAndNumberOutput, SyncingOutput, TransactionStatusOutput};

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -22,7 +22,7 @@ use starknet_types::rpc::estimate_message_fee::{
 use starknet_types::rpc::state::StateUpdate;
 use starknet_types::rpc::transaction_receipt::TransactionReceipt;
 use starknet_types::rpc::transactions::{
-    BlockTransactionTrace, EventsChunk, SimulatedTransaction, Transaction, TransactionTrace,
+    BlockTransactionTrace, EventsChunk, SimulatedTransaction, TransactionTrace, TransactionWithHash,
 };
 use starknet_types::starknet_api::block::BlockNumber;
 use tracing::{error, info, trace};
@@ -354,7 +354,7 @@ pub enum StarknetResponse {
     Block(Block),
     StateUpdate(StateUpdate),
     Felt(Felt),
-    Transaction(Transaction),
+    Transaction(TransactionWithHash),
     TransactionReceiptByTransactionHash(Box<TransactionReceipt>),
     TransactionStatusByHash(TransactionStatusOutput),
     ContractClass(CodegenContractClass),

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -14,7 +14,7 @@ use models::{
 };
 use serde::{Deserialize, Serialize};
 use starknet_rs_core::types::ContractClass as CodegenContractClass;
-use starknet_types::felt::{ClassHash, Felt};
+use starknet_types::felt::Felt;
 use starknet_types::rpc::block::Block;
 use starknet_types::rpc::estimate_message_fee::{
     EstimateMessageFeeRequestWrapper, FeeEstimateWrapper,
@@ -351,33 +351,26 @@ impl std::fmt::Display for StarknetRequest {
 #[cfg_attr(test, derive(Deserialize))]
 #[serde(untagged)]
 pub enum StarknetResponse {
-    BlockWithTransactionHashes(Block),
-    BlockWithFullTransactions(Block),
-    BlockWithReceipts(Block),
+    Block(Block),
     StateUpdate(StateUpdate),
-    StorageAt(Felt),
-    TransactionByHash(Transaction),
-    TransactionByBlockAndIndex(Transaction),
+    Felt(Felt),
+    Transaction(Transaction),
     TransactionReceiptByTransactionHash(Box<TransactionReceipt>),
     TransactionStatusByHash(TransactionStatusOutput),
-    ClassByHash(CodegenContractClass),
-    ClassHashAtContractAddress(ClassHash),
-    ClassAtContractAddress(CodegenContractClass),
+    ContractClass(CodegenContractClass),
     BlockTransactionCount(u64),
     Call(Vec<Felt>),
     EstimateFee(Vec<FeeEstimateWrapper>),
     BlockNumber(BlockNumber),
     BlockHashAndNumber(BlockHashAndNumberOutput),
-    ChainId(String),
+    String(String),
     Syncing(SyncingOutput),
     Events(EventsChunk),
-    ContractNonce(Felt),
     AddDeclareTransaction(DeclareTransactionOutput),
     AddDeployAccountTransaction(DeployAccountTransactionOutput),
     AddInvokeTransaction(InvokeTransactionOutput),
     EstimateMessageFee(FeeEstimateWrapper),
     SimulateTransactions(Vec<SimulatedTransaction>),
-    SpecVersion(String),
     TraceTransaction(TransactionTrace),
     BlockTransactionTraces(Vec<BlockTransactionTrace>),
 }

--- a/crates/starknet-devnet-server/src/api/json_rpc/spec_reader/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/spec_reader/mod.rs
@@ -243,18 +243,20 @@ mod tests {
                                 StarknetResponse::TransactionReceiptByTransactionHash(_)
                             ));
                         }
-                        StarknetRequest::BlockWithTransactionHashes(_) => {
+                        StarknetRequest::BlockWithTransactionHashes(_)
+                        | StarknetRequest::BlockWithFullTransactions(_)
+                        | StarknetRequest::BlockWithReceipts(_) => {
                             assert!(matches!(sn_response, StarknetResponse::Block(_)));
                         }
                         StarknetRequest::BlockHashAndNumber => {
                             assert!(matches!(sn_response, StarknetResponse::BlockHashAndNumber(_)));
                         }
-                        StarknetRequest::BlockNumber
-                        | StarknetRequest::BlockTransactionCount(_) => {
+                        StarknetRequest::BlockTransactionCount(_)
+                        | StarknetRequest::BlockNumber => {
                             assert!(matches!(
                                 sn_response,
-                                StarknetResponse::BlockNumber(_)
-                                    | StarknetResponse::BlockTransactionCount(_)
+                                StarknetResponse::BlockTransactionCount(_)
+                                    | StarknetResponse::BlockNumber(_)
                             ));
                         }
                         StarknetRequest::Call(_) => {
@@ -309,13 +311,29 @@ mod tests {
                                 StarknetResponse::AddInvokeTransaction(_)
                             ));
                         }
-                        _ => {
-                            // Remaining responses are not implemented, because
-                            // multiple requests return the same response format either u64, Felt,
-                            // etc. so its impossible to know which
-                            // response variant is generated based on
-                            // serde untagged deserialization. This is due to the fact that the
-                            // first variant which complies with the response format is returned
+                        StarknetRequest::SpecVersion | StarknetRequest::ChainId => {
+                            assert!(matches!(
+                                sn_response,
+                                StarknetResponse::String(_) | StarknetResponse::Felt(_)
+                            ));
+                        }
+                        StarknetRequest::TransactionByHash(_)
+                        | StarknetRequest::TransactionByBlockAndIndex(_) => {
+                            assert!(matches!(sn_response, StarknetResponse::Transaction(_)));
+                        }
+                        StarknetRequest::ContractNonce(_)
+                        | StarknetRequest::ClassHashAtContractAddress(_)
+                        | StarknetRequest::StorageAt(_) => {
+                            assert!(matches!(sn_response, StarknetResponse::Felt(_)));
+                        }
+                        StarknetRequest::TraceTransaction(_) => {
+                            assert!(matches!(sn_response, StarknetResponse::TraceTransaction(_)));
+                        }
+                        StarknetRequest::BlockTransactionTraces(_) => {
+                            assert!(matches!(
+                                sn_response,
+                                StarknetResponse::BlockTransactionTraces(_)
+                            ));
                         }
                     }
                 }

--- a/crates/starknet-devnet-server/src/api/json_rpc/spec_reader/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/spec_reader/mod.rs
@@ -203,9 +203,7 @@ mod tests {
         for _ in 0..1000 {
             for spec in specs.iter() {
                 // Iterate over the methods in the spec
-                for method in
-                    spec.methods.iter().filter(|m| m.name != "starknet_getBlockWithReceipts")
-                {
+                for method in spec.methods.iter() {
                     // Create a JSON-RPC request for each method
                     let request = generate_json_rpc_request(method, &combined_schema)
                         .expect("Could not generate the JSON-RPC request");
@@ -246,10 +244,7 @@ mod tests {
                             ));
                         }
                         StarknetRequest::BlockWithTransactionHashes(_) => {
-                            assert!(matches!(
-                                sn_response,
-                                StarknetResponse::BlockWithTransactionHashes(_)
-                            ));
+                            assert!(matches!(sn_response, StarknetResponse::Block(_)));
                         }
                         StarknetRequest::BlockHashAndNumber => {
                             assert!(matches!(sn_response, StarknetResponse::BlockHashAndNumber(_)));
@@ -267,11 +262,7 @@ mod tests {
                         }
                         StarknetRequest::ClassAtContractAddress(_)
                         | StarknetRequest::ClassByHash(_) => {
-                            assert!(matches!(
-                                sn_response,
-                                StarknetResponse::ClassAtContractAddress(_)
-                                    | StarknetResponse::ClassByHash(_)
-                            ));
+                            assert!(matches!(sn_response, StarknetResponse::ContractClass(_)));
                         }
                         StarknetRequest::EsimateFee(_) => {
                             assert!(matches!(sn_response, StarknetResponse::EstimateFee(_)));

--- a/crates/starknet-devnet-server/src/api/json_rpc/spec_reader/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/spec_reader/mod.rs
@@ -311,17 +311,15 @@ mod tests {
                                 StarknetResponse::AddInvokeTransaction(_)
                             ));
                         }
-                        StarknetRequest::SpecVersion | StarknetRequest::ChainId => {
-                            assert!(matches!(
-                                sn_response,
-                                StarknetResponse::String(_) | StarknetResponse::Felt(_)
-                            ));
+                        StarknetRequest::SpecVersion => {
+                            assert!(matches!(sn_response, StarknetResponse::String(_)));
                         }
                         StarknetRequest::TransactionByHash(_)
                         | StarknetRequest::TransactionByBlockAndIndex(_) => {
                             assert!(matches!(sn_response, StarknetResponse::Transaction(_)));
                         }
                         StarknetRequest::ContractNonce(_)
+                        | StarknetRequest::ChainId
                         | StarknetRequest::ClassHashAtContractAddress(_)
                         | StarknetRequest::StorageAt(_) => {
                             assert!(matches!(sn_response, StarknetResponse::Felt(_)));

--- a/crates/starknet-devnet-types/src/rpc/transactions.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions.rs
@@ -173,30 +173,30 @@ pub struct TransactionWithReceipt {
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DeclareTransaction {
-    Version1(DeclareTransactionV0V1),
-    Version2(DeclareTransactionV2),
-    Version3(DeclareTransactionV3),
+    V1(DeclareTransactionV0V1),
+    V2(DeclareTransactionV2),
+    V3(DeclareTransactionV3),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum InvokeTransaction {
-    Version1(InvokeTransactionV1),
-    Version3(InvokeTransactionV3),
+    V1(InvokeTransactionV1),
+    V3(InvokeTransactionV3),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DeployAccountTransaction {
-    Version1(Box<DeployAccountTransactionV1>),
-    Version3(Box<DeployAccountTransactionV3>),
+    V1(Box<DeployAccountTransactionV1>),
+    V3(Box<DeployAccountTransactionV3>),
 }
 
 impl DeployAccountTransaction {
     pub fn get_contract_address(&self) -> &ContractAddress {
         match self {
-            DeployAccountTransaction::Version1(tx) => tx.get_contract_address(),
-            DeployAccountTransaction::Version3(tx) => tx.get_contract_address(),
+            DeployAccountTransaction::V1(tx) => tx.get_contract_address(),
+            DeployAccountTransaction::V3(tx) => tx.get_contract_address(),
         }
     }
 }

--- a/crates/starknet-devnet-types/src/rpc/transactions.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions.rs
@@ -92,7 +92,7 @@ pub enum TransactionType {
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", deny_unknown_fields)]
-pub enum TransactionWithHash {
+pub enum Transaction {
     #[serde(rename = "DECLARE")]
     Declare(DeclareTransaction),
     #[serde(rename = "DEPLOY_ACCOUNT")]
@@ -105,47 +105,29 @@ pub enum TransactionWithHash {
     L1Handler(L1HandlerTransaction),
 }
 
-// #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-// pub struct TransactionWithHash {
-//     transaction_hash: TransactionHash,
-//     #[serde(flatten)]
-//     transaction: Transaction,
-// }
-
-// impl TransactionWithHash {
-//     pub fn new(transaction_hash: TransactionHash, transaction: Transaction) -> Self {
-//         Self { transaction_hash, transaction }
-//     }
-
-//     pub fn get_transaction_hash(&self) -> &TransactionHash {
-//         &self.transaction_hash
-//     }
-// }
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TransactionWithReceipt {
-    pub receipt: TransactionReceipt,
-    pub transaction: TransactionWithHash,
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct TransactionWithHash {
+    transaction_hash: TransactionHash,
+    #[serde(flatten)]
+    pub transaction: Transaction,
 }
 
 impl TransactionWithHash {
-    pub fn get_type(&self) -> TransactionType {
-        match self {
-            TransactionWithHash::Declare(_) => TransactionType::Declare,
-            TransactionWithHash::DeployAccount(_) => TransactionType::DeployAccount,
-            TransactionWithHash::Deploy(_) => TransactionType::Deploy,
-            TransactionWithHash::Invoke(_) => TransactionType::Invoke,
-            TransactionWithHash::L1Handler(_) => TransactionType::L1Handler,
-        }
+    pub fn new(transaction_hash: TransactionHash, transaction: Transaction) -> Self {
+        Self { transaction_hash, transaction }
     }
 
     pub fn get_transaction_hash(&self) -> &TransactionHash {
-        match self {
-            TransactionWithHash::Declare(tx) => tx.get_transaction_hash(),
-            TransactionWithHash::L1Handler(tx) => tx.get_transaction_hash(),
-            TransactionWithHash::DeployAccount(tx) => tx.get_transaction_hash(),
-            TransactionWithHash::Invoke(tx) => tx.get_transaction_hash(),
-            TransactionWithHash::Deploy(tx) => tx.get_transaction_hash(),
+        &self.transaction_hash
+    }
+
+    pub fn get_type(&self) -> TransactionType {
+        match self.transaction {
+            Transaction::Declare(_) => TransactionType::Declare,
+            Transaction::DeployAccount(_) => TransactionType::DeployAccount,
+            Transaction::Deploy(_) => TransactionType::Deploy,
+            Transaction::Invoke(_) => TransactionType::Invoke,
+            Transaction::L1Handler(_) => TransactionType::L1Handler,
         }
     }
 
@@ -178,6 +160,12 @@ impl TransactionWithHash {
             execution_resources,
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransactionWithReceipt {
+    pub receipt: TransactionReceipt,
+    pub transaction: TransactionWithHash,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/crates/starknet-devnet-types/src/rpc/transactions.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions.rs
@@ -71,7 +71,7 @@ pub mod l1_handler_transaction;
 #[serde(untagged)]
 pub enum Transactions {
     Hashes(Vec<TransactionHash>),
-    Full(Vec<Transaction>),
+    Full(Vec<TransactionWithHash>),
     FullWithReceipts(Vec<TransactionWithReceipt>),
 }
 
@@ -91,8 +91,8 @@ pub enum TransactionType {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "type")]
-pub enum Transaction {
+#[serde(tag = "type", deny_unknown_fields)]
+pub enum TransactionWithHash {
     #[serde(rename = "DECLARE")]
     Declare(DeclareTransaction),
     #[serde(rename = "DEPLOY_ACCOUNT")]
@@ -105,30 +105,47 @@ pub enum Transaction {
     L1Handler(L1HandlerTransaction),
 }
 
+// #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+// pub struct TransactionWithHash {
+//     transaction_hash: TransactionHash,
+//     #[serde(flatten)]
+//     transaction: Transaction,
+// }
+
+// impl TransactionWithHash {
+//     pub fn new(transaction_hash: TransactionHash, transaction: Transaction) -> Self {
+//         Self { transaction_hash, transaction }
+//     }
+
+//     pub fn get_transaction_hash(&self) -> &TransactionHash {
+//         &self.transaction_hash
+//     }
+// }
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TransactionWithReceipt {
     pub receipt: TransactionReceipt,
-    pub transaction: Transaction,
+    pub transaction: TransactionWithHash,
 }
 
-impl Transaction {
+impl TransactionWithHash {
     pub fn get_type(&self) -> TransactionType {
         match self {
-            Transaction::Declare(_) => TransactionType::Declare,
-            Transaction::DeployAccount(_) => TransactionType::DeployAccount,
-            Transaction::Deploy(_) => TransactionType::Deploy,
-            Transaction::Invoke(_) => TransactionType::Invoke,
-            Transaction::L1Handler(_) => TransactionType::L1Handler,
+            TransactionWithHash::Declare(_) => TransactionType::Declare,
+            TransactionWithHash::DeployAccount(_) => TransactionType::DeployAccount,
+            TransactionWithHash::Deploy(_) => TransactionType::Deploy,
+            TransactionWithHash::Invoke(_) => TransactionType::Invoke,
+            TransactionWithHash::L1Handler(_) => TransactionType::L1Handler,
         }
     }
 
     pub fn get_transaction_hash(&self) -> &TransactionHash {
         match self {
-            Transaction::Declare(tx) => tx.get_transaction_hash(),
-            Transaction::L1Handler(tx) => tx.get_transaction_hash(),
-            Transaction::DeployAccount(tx) => tx.get_transaction_hash(),
-            Transaction::Invoke(tx) => tx.get_transaction_hash(),
-            Transaction::Deploy(tx) => tx.get_transaction_hash(),
+            TransactionWithHash::Declare(tx) => tx.get_transaction_hash(),
+            TransactionWithHash::L1Handler(tx) => tx.get_transaction_hash(),
+            TransactionWithHash::DeployAccount(tx) => tx.get_transaction_hash(),
+            TransactionWithHash::Invoke(tx) => tx.get_transaction_hash(),
+            TransactionWithHash::Deploy(tx) => tx.get_transaction_hash(),
         }
     }
 

--- a/crates/starknet-devnet-types/src/rpc/transactions.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions.rs
@@ -176,30 +176,11 @@ pub enum DeclareTransaction {
     Version3(DeclareTransactionV3),
 }
 
-impl DeclareTransaction {
-    pub fn get_transaction_hash(&self) -> &TransactionHash {
-        match self {
-            DeclareTransaction::Version1(tx) => tx.get_transaction_hash(),
-            DeclareTransaction::Version2(tx) => tx.get_transaction_hash(),
-            DeclareTransaction::Version3(tx) => tx.get_transaction_hash(),
-        }
-    }
-}
-
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum InvokeTransaction {
     Version1(InvokeTransactionV1),
     Version3(InvokeTransactionV3),
-}
-
-impl InvokeTransaction {
-    pub fn get_transaction_hash(&self) -> &TransactionHash {
-        match self {
-            InvokeTransaction::Version1(tx) => tx.get_transaction_hash(),
-            InvokeTransaction::Version3(tx) => tx.get_transaction_hash(),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
@@ -212,15 +193,8 @@ pub enum DeployAccountTransaction {
 impl DeployAccountTransaction {
     pub fn get_contract_address(&self) -> &ContractAddress {
         match self {
-            DeployAccountTransaction::Version1(tx) => &tx.contract_address,
+            DeployAccountTransaction::Version1(tx) => tx.get_contract_address(),
             DeployAccountTransaction::Version3(tx) => tx.get_contract_address(),
-        }
-    }
-
-    pub fn get_transaction_hash(&self) -> &TransactionHash {
-        match self {
-            DeployAccountTransaction::Version1(tx) => tx.get_transaction_hash(),
-            DeployAccountTransaction::Version3(tx) => tx.get_transaction_hash(),
         }
     }
 }
@@ -257,12 +231,6 @@ pub struct L1HandlerTransaction {
         deserialize_with = "deserialize_paid_fee_on_l1"
     )]
     pub paid_fee_on_l1: u128,
-}
-
-impl L1HandlerTransaction {
-    pub fn get_transaction_hash(&self) -> &TransactionHash {
-        &self.transaction_hash
-    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/crates/starknet-devnet-types/src/rpc/transactions.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions.rs
@@ -29,6 +29,7 @@ use self::declare_transaction_v3::DeclareTransactionV3;
 use self::deploy_account_transaction_v1::DeployAccountTransactionV1;
 use self::deploy_account_transaction_v3::DeployAccountTransactionV3;
 use self::invoke_transaction_v3::InvokeTransactionV3;
+use self::l1_handler_transaction::L1HandlerTransaction;
 use super::estimate_message_fee::FeeEstimateWrapper;
 use super::messaging::{MessageToL1, OrderedMessageToL1};
 use super::state::ThinStateDiff;
@@ -216,21 +217,6 @@ where
     S: Serializer,
 {
     s.serialize_str(&format!("{paid_fee_on_l1:#x}"))
-}
-
-#[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
-pub struct L1HandlerTransaction {
-    pub transaction_hash: TransactionHash,
-    pub version: TransactionVersion,
-    pub nonce: Nonce,
-    pub contract_address: ContractAddress,
-    pub entry_point_selector: EntryPointSelector,
-    pub calldata: Calldata,
-    #[serde(
-        serialize_with = "serialize_paid_fee_on_l1",
-        deserialize_with = "deserialize_paid_fee_on_l1"
-    )]
-    pub paid_fee_on_l1: u128,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/crates/starknet-devnet-types/src/rpc/transactions.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions.rs
@@ -164,9 +164,10 @@ impl TransactionWithHash {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TransactionWithReceipt {
     pub receipt: TransactionReceipt,
-    pub transaction: TransactionWithHash,
+    pub transaction: Transaction,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v1.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v1.rs
@@ -19,7 +19,6 @@ use crate::error::DevnetResult;
 use crate::felt::{
     ClassHash, Felt, Nonce, TransactionHash, TransactionSignature, TransactionVersion,
 };
-use crate::rpc::transactions::declare_transaction_v0v1::DeclareTransactionV0V1;
 use crate::rpc::transactions::BroadcastedTransactionCommon;
 use crate::traits::HashProducer;
 

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v1.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v1.rs
@@ -80,22 +80,6 @@ impl BroadcastedDeclareTransactionV1 {
         )?)
     }
 
-    pub fn create_declare(
-        &self,
-        class_hash: ClassHash,
-        transaction_hash: TransactionHash,
-    ) -> DeclareTransactionV0V1 {
-        DeclareTransactionV0V1 {
-            class_hash,
-            sender_address: self.sender_address,
-            nonce: self.common.nonce,
-            max_fee: self.common.max_fee,
-            version: self.common.version,
-            transaction_hash,
-            signature: self.common.signature.clone(),
-        }
-    }
-
     pub fn generate_class_hash(&self) -> DevnetResult<Felt> {
         self.contract_class.generate_hash()
     }

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v2.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v2.rs
@@ -51,23 +51,6 @@ impl BroadcastedDeclareTransactionV2 {
         }
     }
 
-    pub fn create_declare(
-        &self,
-        class_hash: ClassHash,
-        transaction_hash: TransactionHash,
-    ) -> DeclareTransactionV2 {
-        DeclareTransactionV2 {
-            class_hash,
-            compiled_class_hash: self.compiled_class_hash,
-            sender_address: self.sender_address,
-            nonce: self.common.nonce,
-            max_fee: self.common.max_fee,
-            version: self.common.version,
-            transaction_hash,
-            signature: self.common.signature.clone(),
-        }
-    }
-
     pub fn create_blockifier_declare(&self, chain_id: Felt) -> DevnetResult<DeclareTransaction> {
         let sierra_class_hash: Felt = compute_sierra_class_hash(&self.contract_class)?;
 

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v2.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v2.rs
@@ -9,11 +9,7 @@ use super::broadcasted_declare_transaction_v1::PREFIX_DECLARE;
 use crate::contract_address::ContractAddress;
 use crate::contract_class::{compute_sierra_class_hash, ContractClass};
 use crate::error::DevnetResult;
-use crate::felt::{
-    ClassHash, CompiledClassHash, Felt, Nonce, TransactionHash, TransactionSignature,
-    TransactionVersion,
-};
-use crate::rpc::transactions::declare_transaction_v2::DeclareTransactionV2;
+use crate::felt::{CompiledClassHash, Felt, Nonce, TransactionSignature, TransactionVersion};
 use crate::rpc::transactions::BroadcastedTransactionCommon;
 use crate::serde_helpers::rpc_sierra_contract_class_to_sierra_contract_class::deserialize_to_sierra_contract_class;
 

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_deploy_account_transaction_v1.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_deploy_account_transaction_v1.rs
@@ -110,24 +110,6 @@ impl BroadcastedDeployAccountTransactionV1 {
             only_query,
         })
     }
-
-    pub fn compile_deploy_account_transaction_v1(
-        &self,
-        transaction_hash: &TransactionHash,
-        contract_address: ContractAddress,
-    ) -> DeployAccountTransactionV1 {
-        DeployAccountTransactionV1 {
-            transaction_hash: *transaction_hash,
-            max_fee: self.common.max_fee,
-            version: self.common.version,
-            signature: self.common.signature.clone(),
-            nonce: self.common.nonce,
-            class_hash: self.class_hash,
-            contract_address_salt: self.contract_address_salt,
-            constructor_calldata: self.constructor_calldata.clone(),
-            contract_address,
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_deploy_account_transaction_v1.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_deploy_account_transaction_v1.rs
@@ -6,12 +6,10 @@ use starknet_api::transaction::Fee;
 use starknet_rs_core::crypto::compute_hash_on_elements;
 use starknet_rs_ff::FieldElement;
 
-use super::deploy_account_transaction_v1::DeployAccountTransactionV1;
 use crate::contract_address::ContractAddress;
 use crate::error::DevnetResult;
 use crate::felt::{
-    Calldata, ClassHash, ContractAddressSalt, Felt, Nonce, TransactionHash, TransactionSignature,
-    TransactionVersion,
+    Calldata, ClassHash, ContractAddressSalt, Felt, Nonce, TransactionSignature, TransactionVersion,
 };
 use crate::rpc::transactions::BroadcastedTransactionCommon;
 

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_invoke_transaction_v1.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_invoke_transaction_v1.rs
@@ -9,10 +9,7 @@ use starknet_rs_ff::FieldElement;
 
 use crate::contract_address::ContractAddress;
 use crate::error::DevnetResult;
-use crate::felt::{
-    Calldata, Felt, Nonce, TransactionHash, TransactionSignature, TransactionVersion,
-};
-use crate::rpc::transactions::invoke_transaction_v1::InvokeTransactionV1;
+use crate::felt::{Calldata, Felt, Nonce, TransactionSignature, TransactionVersion};
 use crate::rpc::transactions::BroadcastedTransactionCommon;
 
 /// Cairo string for "invoke" from starknet-rs
@@ -93,21 +90,6 @@ impl BroadcastedInvokeTransactionV1 {
             tx_hash: starknet_api::transaction::TransactionHash(txn_hash.into()),
             only_query,
         })
-    }
-
-    pub fn create_invoke_transaction(
-        &self,
-        transaction_hash: TransactionHash,
-    ) -> InvokeTransactionV1 {
-        InvokeTransactionV1 {
-            transaction_hash,
-            max_fee: self.common.max_fee,
-            version: self.common.version,
-            signature: self.common.signature.clone(),
-            nonce: self.common.nonce,
-            sender_address: self.sender_address,
-            calldata: self.calldata.clone(),
-        }
     }
 }
 

--- a/crates/starknet-devnet-types/src/rpc/transactions/declare_transaction_v0v1.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/declare_transaction_v0v1.rs
@@ -1,13 +1,9 @@
 use serde::{Deserialize, Serialize};
 use starknet_api::transaction::Fee;
 
+use super::broadcasted_declare_transaction_v1::BroadcastedDeclareTransactionV1;
 use crate::contract_address::ContractAddress;
-use crate::error::{DevnetResult, Error};
-use crate::felt::{
-    ClassHash, Felt, Nonce, TransactionHash, TransactionSignature, TransactionVersion,
-};
-use crate::traits::HashProducer;
-
+use crate::felt::{ClassHash, Nonce, TransactionSignature, TransactionVersion};
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeclareTransactionV0V1 {
@@ -16,19 +12,18 @@ pub struct DeclareTransactionV0V1 {
     pub nonce: Nonce,
     pub max_fee: Fee,
     pub version: TransactionVersion,
-    pub transaction_hash: TransactionHash,
     pub signature: TransactionSignature,
 }
 
 impl DeclareTransactionV0V1 {
-    pub fn get_transaction_hash(&self) -> &TransactionHash {
-        &self.transaction_hash
-    }
-}
-
-impl HashProducer for DeclareTransactionV0V1 {
-    type Error = Error;
-    fn generate_hash(&self) -> DevnetResult<Felt> {
-        Ok(self.transaction_hash)
+    pub fn new(broadcasted_txn: &BroadcastedDeclareTransactionV1, class_hash: ClassHash) -> Self {
+        Self {
+            class_hash,
+            sender_address: broadcasted_txn.sender_address,
+            nonce: broadcasted_txn.common.nonce,
+            max_fee: broadcasted_txn.common.max_fee,
+            version: broadcasted_txn.common.version,
+            signature: broadcasted_txn.common.signature.clone(),
+        }
     }
 }

--- a/crates/starknet-devnet-types/src/rpc/transactions/declare_transaction_v2.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/declare_transaction_v2.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use starknet_api::transaction::Fee;
 
+use super::broadcasted_declare_transaction_v2::BroadcastedDeclareTransactionV2;
 use crate::contract_address::ContractAddress;
 use crate::felt::{
     ClassHash, CompiledClassHash, Nonce, TransactionHash, TransactionSignature, TransactionVersion,
@@ -15,12 +16,19 @@ pub struct DeclareTransactionV2 {
     pub nonce: Nonce,
     pub max_fee: Fee,
     pub version: TransactionVersion,
-    pub transaction_hash: TransactionHash,
     pub signature: TransactionSignature,
 }
 
 impl DeclareTransactionV2 {
-    pub fn get_transaction_hash(&self) -> &TransactionHash {
-        &self.transaction_hash
+    pub fn new(broadcasted_txn: &BroadcastedDeclareTransactionV2, class_hash: ClassHash) -> Self {
+        Self {
+            class_hash,
+            compiled_class_hash: broadcasted_txn.compiled_class_hash,
+            sender_address: broadcasted_txn.sender_address,
+            nonce: broadcasted_txn.common.nonce,
+            max_fee: broadcasted_txn.common.max_fee,
+            version: broadcasted_txn.common.version,
+            signature: broadcasted_txn.common.signature.clone(),
+        }
     }
 }

--- a/crates/starknet-devnet-types/src/rpc/transactions/declare_transaction_v2.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/declare_transaction_v2.rs
@@ -3,9 +3,7 @@ use starknet_api::transaction::Fee;
 
 use super::broadcasted_declare_transaction_v2::BroadcastedDeclareTransactionV2;
 use crate::contract_address::ContractAddress;
-use crate::felt::{
-    ClassHash, CompiledClassHash, Nonce, TransactionHash, TransactionSignature, TransactionVersion,
-};
+use crate::felt::{ClassHash, CompiledClassHash, Nonce, TransactionSignature, TransactionVersion};
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/starknet-devnet-types/src/rpc/transactions/declare_transaction_v3.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/declare_transaction_v3.rs
@@ -6,8 +6,7 @@ use super::broadcasted_declare_transaction_v3::BroadcastedDeclareTransactionV3;
 use super::ResourceBoundsWrapper;
 use crate::contract_address::ContractAddress;
 use crate::felt::{
-    ClassHash, CompiledClassHash, Felt, Nonce, TransactionHash, TransactionSignature,
-    TransactionVersion,
+    ClassHash, CompiledClassHash, Felt, Nonce, TransactionSignature, TransactionVersion,
 };
 
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
@@ -25,34 +24,24 @@ pub struct DeclareTransactionV3 {
     compiled_class_hash: CompiledClassHash,
     class_hash: ClassHash,
     account_deployment_data: Vec<Felt>,
-    transaction_hash: TransactionHash,
 }
 
 impl DeclareTransactionV3 {
-    pub fn new(
-        broadcasted_txn: BroadcastedDeclareTransactionV3,
-        class_hash: ClassHash,
-        transaction_hash: TransactionHash,
-    ) -> Self {
+    pub fn new(broadcasted_txn: &BroadcastedDeclareTransactionV3, class_hash: ClassHash) -> Self {
         Self {
             version: broadcasted_txn.common.version,
-            signature: broadcasted_txn.common.signature,
+            signature: broadcasted_txn.common.signature.clone(),
             nonce: broadcasted_txn.common.nonce,
-            resource_bounds: broadcasted_txn.common.resource_bounds,
+            resource_bounds: broadcasted_txn.common.resource_bounds.clone(),
             tip: broadcasted_txn.common.tip,
-            paymaster_data: broadcasted_txn.common.paymaster_data,
+            paymaster_data: broadcasted_txn.common.paymaster_data.clone(),
             nonce_data_availability_mode: broadcasted_txn.common.nonce_data_availability_mode,
             fee_data_availability_mode: broadcasted_txn.common.fee_data_availability_mode,
             sender_address: broadcasted_txn.sender_address,
-            account_deployment_data: broadcasted_txn.account_deployment_data,
-            transaction_hash,
+            account_deployment_data: broadcasted_txn.account_deployment_data.clone(),
             compiled_class_hash: broadcasted_txn.compiled_class_hash,
             class_hash,
         }
-    }
-
-    pub fn get_transaction_hash(&self) -> &TransactionHash {
-        &self.transaction_hash
     }
 
     pub fn get_class_hash(&self) -> &ClassHash {

--- a/crates/starknet-devnet-types/src/rpc/transactions/deploy_account_transaction_v1.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/deploy_account_transaction_v1.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use starknet_api::transaction::Fee;
+use starknet_rs_core::types::BroadcastedDeployAccountTransaction;
 
+use super::broadcasted_deploy_account_transaction_v1::BroadcastedDeployAccountTransactionV1;
 use crate::contract_address::ContractAddress;
 use crate::error::{DevnetResult, Error};
 use crate::felt::{
@@ -11,7 +13,6 @@ use crate::traits::HashProducer;
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct DeployAccountTransactionV1 {
-    pub transaction_hash: TransactionHash,
     pub max_fee: Fee,
     pub version: TransactionVersion,
     pub signature: TransactionSignature,
@@ -24,14 +25,23 @@ pub struct DeployAccountTransactionV1 {
 }
 
 impl DeployAccountTransactionV1 {
-    pub fn get_transaction_hash(&self) -> &TransactionHash {
-        &self.transaction_hash
+    pub fn new(
+        broadcasted_txn: &BroadcastedDeployAccountTransactionV1,
+        contract_address: ContractAddress,
+    ) -> Self {
+        Self {
+            max_fee: broadcasted_txn.common.max_fee,
+            version: broadcasted_txn.common.version,
+            signature: broadcasted_txn.common.signature.clone(),
+            nonce: broadcasted_txn.common.nonce,
+            class_hash: broadcasted_txn.class_hash,
+            contract_address_salt: broadcasted_txn.contract_address_salt,
+            constructor_calldata: broadcasted_txn.constructor_calldata.clone(),
+            contract_address,
+        }
     }
-}
 
-impl HashProducer for DeployAccountTransactionV1 {
-    type Error = Error;
-    fn generate_hash(&self) -> DevnetResult<Felt> {
-        Ok(self.transaction_hash)
+    pub fn get_contract_address(&self) -> &ContractAddress {
+        &self.contract_address
     }
 }

--- a/crates/starknet-devnet-types/src/rpc/transactions/deploy_account_transaction_v1.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/deploy_account_transaction_v1.rs
@@ -1,15 +1,11 @@
 use serde::{Deserialize, Serialize};
 use starknet_api::transaction::Fee;
-use starknet_rs_core::types::BroadcastedDeployAccountTransaction;
 
 use super::broadcasted_deploy_account_transaction_v1::BroadcastedDeployAccountTransactionV1;
 use crate::contract_address::ContractAddress;
-use crate::error::{DevnetResult, Error};
 use crate::felt::{
-    Calldata, ClassHash, ContractAddressSalt, Felt, Nonce, TransactionHash, TransactionSignature,
-    TransactionVersion,
+    Calldata, ClassHash, ContractAddressSalt, Nonce, TransactionSignature, TransactionVersion,
 };
-use crate::traits::HashProducer;
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct DeployAccountTransactionV1 {

--- a/crates/starknet-devnet-types/src/rpc/transactions/deploy_account_transaction_v1.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/deploy_account_transaction_v1.rs
@@ -8,6 +8,7 @@ use crate::felt::{
 };
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DeployAccountTransactionV1 {
     pub max_fee: Fee,
     pub version: TransactionVersion,

--- a/crates/starknet-devnet-types/src/rpc/transactions/deploy_account_transaction_v3.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/deploy_account_transaction_v3.rs
@@ -26,33 +26,27 @@ pub struct DeployAccountTransactionV3 {
     class_hash: ClassHash,
     #[serde(skip)]
     contract_address: ContractAddress,
-    transaction_hash: TransactionHash,
 }
 
 impl DeployAccountTransactionV3 {
     pub fn new(
-        broadcasted_txn: BroadcastedDeployAccountTransactionV3,
+        broadcasted_txn: &BroadcastedDeployAccountTransactionV3,
         contract_address: ContractAddress,
-        transaction_hash: TransactionHash,
     ) -> Self {
         Self {
             version: broadcasted_txn.common.version,
-            signature: broadcasted_txn.common.signature,
+            signature: broadcasted_txn.common.signature.clone(),
             nonce: broadcasted_txn.common.nonce,
-            resource_bounds: broadcasted_txn.common.resource_bounds,
+            resource_bounds: broadcasted_txn.common.resource_bounds.clone(),
             tip: broadcasted_txn.common.tip,
-            paymaster_data: broadcasted_txn.common.paymaster_data,
+            paymaster_data: broadcasted_txn.common.paymaster_data.clone(),
             nonce_data_availability_mode: broadcasted_txn.common.nonce_data_availability_mode,
             fee_data_availability_mode: broadcasted_txn.common.fee_data_availability_mode,
             contract_address_salt: broadcasted_txn.contract_address_salt,
-            constructor_calldata: broadcasted_txn.constructor_calldata,
+            constructor_calldata: broadcasted_txn.constructor_calldata.clone(),
             class_hash: broadcasted_txn.class_hash,
             contract_address,
-            transaction_hash,
         }
-    }
-    pub fn get_transaction_hash(&self) -> &TransactionHash {
-        &self.transaction_hash
     }
 
     pub fn get_contract_address(&self) -> &ContractAddress {

--- a/crates/starknet-devnet-types/src/rpc/transactions/deploy_account_transaction_v3.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/deploy_account_transaction_v3.rs
@@ -6,8 +6,7 @@ use super::broadcasted_deploy_account_transaction_v3::BroadcastedDeployAccountTr
 use super::{BroadcastedTransactionCommonV3, ResourceBoundsWrapper};
 use crate::contract_address::ContractAddress;
 use crate::felt::{
-    Calldata, ClassHash, ContractAddressSalt, Felt, Nonce, TransactionHash, TransactionSignature,
-    TransactionVersion,
+    Calldata, ClassHash, ContractAddressSalt, Felt, Nonce, TransactionSignature, TransactionVersion,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]

--- a/crates/starknet-devnet-types/src/rpc/transactions/deploy_transaction.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/deploy_transaction.rs
@@ -1,18 +1,11 @@
 use serde::{Deserialize, Serialize};
 
-use crate::felt::{Calldata, ClassHash, ContractAddressSalt, TransactionHash, TransactionVersion};
+use crate::felt::{Calldata, ClassHash, ContractAddressSalt, TransactionVersion};
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct DeployTransaction {
-    pub transaction_hash: TransactionHash,
     pub version: TransactionVersion,
     pub class_hash: ClassHash,
     pub contract_address_salt: ContractAddressSalt,
     pub constructor_calldata: Calldata,
-}
-
-impl DeployTransaction {
-    pub fn get_transaction_hash(&self) -> &TransactionHash {
-        &self.transaction_hash
-    }
 }

--- a/crates/starknet-devnet-types/src/rpc/transactions/deploy_transaction.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/deploy_transaction.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::felt::{Calldata, ClassHash, ContractAddressSalt, TransactionVersion};
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DeployTransaction {
     pub version: TransactionVersion,
     pub class_hash: ClassHash,

--- a/crates/starknet-devnet-types/src/rpc/transactions/invoke_transaction_v1.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/invoke_transaction_v1.rs
@@ -1,16 +1,12 @@
 use serde::{Deserialize, Serialize};
 use starknet_api::transaction::Fee;
 
+use super::broadcasted_invoke_transaction_v1::BroadcastedInvokeTransactionV1;
 use crate::contract_address::ContractAddress;
-use crate::error::{DevnetResult, Error};
-use crate::felt::{
-    Calldata, Felt, Nonce, TransactionHash, TransactionSignature, TransactionVersion,
-};
-use crate::traits::HashProducer;
+use crate::felt::{Calldata, Nonce, TransactionSignature, TransactionVersion};
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct InvokeTransactionV1 {
-    pub transaction_hash: TransactionHash,
     pub max_fee: Fee,
     pub version: TransactionVersion,
     pub signature: TransactionSignature,
@@ -20,14 +16,14 @@ pub struct InvokeTransactionV1 {
 }
 
 impl InvokeTransactionV1 {
-    pub fn get_transaction_hash(&self) -> &TransactionHash {
-        &self.transaction_hash
-    }
-}
-
-impl HashProducer for InvokeTransactionV1 {
-    type Error = Error;
-    fn generate_hash(&self) -> DevnetResult<Felt> {
-        Ok(self.transaction_hash)
+    pub fn new(broadcasted_txn: &BroadcastedInvokeTransactionV1) -> InvokeTransactionV1 {
+        InvokeTransactionV1 {
+            max_fee: broadcasted_txn.common.max_fee,
+            version: broadcasted_txn.common.version,
+            signature: broadcasted_txn.common.signature.clone(),
+            nonce: broadcasted_txn.common.nonce,
+            sender_address: broadcasted_txn.sender_address,
+            calldata: broadcasted_txn.calldata.clone(),
+        }
     }
 }

--- a/crates/starknet-devnet-types/src/rpc/transactions/invoke_transaction_v1.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/invoke_transaction_v1.rs
@@ -6,6 +6,7 @@ use crate::contract_address::ContractAddress;
 use crate::felt::{Calldata, Nonce, TransactionSignature, TransactionVersion};
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct InvokeTransactionV1 {
     pub max_fee: Fee,
     pub version: TransactionVersion,

--- a/crates/starknet-devnet-types/src/rpc/transactions/invoke_transaction_v3.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/invoke_transaction_v3.rs
@@ -5,9 +5,7 @@ use starknet_api::transaction::Tip;
 use super::broadcasted_invoke_transaction_v3::BroadcastedInvokeTransactionV3;
 use super::{BroadcastedTransactionCommonV3, ResourceBoundsWrapper};
 use crate::contract_address::ContractAddress;
-use crate::felt::{
-    Calldata, Felt, Nonce, TransactionHash, TransactionSignature, TransactionVersion,
-};
+use crate::felt::{Calldata, Felt, Nonce, TransactionSignature, TransactionVersion};
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/starknet-devnet-types/src/rpc/transactions/invoke_transaction_v3.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/invoke_transaction_v3.rs
@@ -23,31 +23,23 @@ pub struct InvokeTransactionV3 {
     account_deployment_data: Vec<Felt>,
     sender_address: ContractAddress,
     calldata: Calldata,
-    transaction_hash: TransactionHash,
 }
 
 impl InvokeTransactionV3 {
-    pub fn new(
-        broadcasted_txn: BroadcastedInvokeTransactionV3,
-        transaction_hash: TransactionHash,
-    ) -> Self {
+    pub fn new(broadcasted_txn: &BroadcastedInvokeTransactionV3) -> Self {
         Self {
             version: broadcasted_txn.common.version,
-            signature: broadcasted_txn.common.signature,
+            signature: broadcasted_txn.common.signature.clone(),
             nonce: broadcasted_txn.common.nonce,
-            resource_bounds: broadcasted_txn.common.resource_bounds,
+            resource_bounds: broadcasted_txn.common.resource_bounds.clone(),
             tip: broadcasted_txn.common.tip,
-            paymaster_data: broadcasted_txn.common.paymaster_data,
+            paymaster_data: broadcasted_txn.common.paymaster_data.clone(),
             nonce_data_availability_mode: broadcasted_txn.common.nonce_data_availability_mode,
             fee_data_availability_mode: broadcasted_txn.common.fee_data_availability_mode,
             sender_address: broadcasted_txn.sender_address,
-            calldata: broadcasted_txn.calldata,
-            account_deployment_data: broadcasted_txn.account_deployment_data,
-            transaction_hash,
+            calldata: broadcasted_txn.calldata.clone(),
+            account_deployment_data: broadcasted_txn.account_deployment_data.clone(),
         }
-    }
-    pub fn get_transaction_hash(&self) -> &TransactionHash {
-        &self.transaction_hash
     }
 }
 

--- a/crates/starknet-devnet-types/src/rpc/transactions/l1_handler_transaction.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/l1_handler_transaction.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use blockifier::transaction::transactions::L1HandlerTransaction as BlockifierL1HandlerTransaction;
+use serde::{Deserialize, Serialize};
 use starknet_api::core::{
     ContractAddress as ApiContractAddress, EntryPointSelector as ApiEntryPointSelector,
     Nonce as ApiNonce,
@@ -12,11 +13,11 @@ use starknet_api::transaction::{
 use starknet_rs_core::crypto::compute_hash_on_elements;
 use starknet_rs_core::types::FieldElement;
 
+use super::{deserialize_paid_fee_on_l1, serialize_paid_fee_on_l1};
 use crate::contract_address::ContractAddress;
 use crate::error::{ConversionError, DevnetResult, Error};
-use crate::felt::Felt;
+use crate::felt::{Calldata, EntryPointSelector, Felt, Nonce, TransactionVersion};
 use crate::rpc::messaging::MessageToL2;
-use crate::rpc::transactions::L1HandlerTransaction;
 
 /// Cairo string for "l1_handler"
 const PREFIX_L1_HANDLER: FieldElement = FieldElement::from_mont([
@@ -26,13 +27,21 @@ const PREFIX_L1_HANDLER: FieldElement = FieldElement::from_mont([
     157895833347907735,
 ]);
 
-impl L1HandlerTransaction {
-    /// Instantiates a new `L1HandlerTransaction`.
-    pub fn with_hash(mut self, chain_id: Felt) -> Self {
-        self.transaction_hash = self.compute_hash(chain_id);
-        self
-    }
+#[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
+pub struct L1HandlerTransaction {
+    pub version: TransactionVersion,
+    pub nonce: Nonce,
+    pub contract_address: ContractAddress,
+    pub entry_point_selector: EntryPointSelector,
+    pub calldata: Calldata,
+    #[serde(
+        serialize_with = "serialize_paid_fee_on_l1",
+        deserialize_with = "deserialize_paid_fee_on_l1"
+    )]
+    pub paid_fee_on_l1: u128,
+}
 
+impl L1HandlerTransaction {
     /// Computes the hash of a `L1HandlerTransaction`.
     ///
     /// # Arguments
@@ -62,7 +71,10 @@ impl L1HandlerTransaction {
     }
 
     /// Creates a blockifier version of `L1HandlerTransaction`.
-    pub fn create_blockifier_transaction(&self) -> DevnetResult<BlockifierL1HandlerTransaction> {
+    pub fn create_blockifier_transaction(
+        &self,
+        chain_id: Felt,
+    ) -> DevnetResult<BlockifierL1HandlerTransaction> {
         let transaction = BlockifierL1HandlerTransaction {
             tx: ApiL1HandlerTransaction {
                 contract_address: ApiContractAddress::try_from(self.contract_address)?,
@@ -72,7 +84,7 @@ impl L1HandlerTransaction {
                 version: ApiTransactionVersion(self.version.into()),
             },
             paid_fee_on_l1: ApiFee(self.paid_fee_on_l1),
-            tx_hash: ApiTransactionHash(self.transaction_hash.into()),
+            tx_hash: ApiTransactionHash(self.compute_hash(chain_id).into()),
         };
 
         Ok(transaction)
@@ -198,13 +210,12 @@ mod tests {
             calldata,
             nonce: nonce.into(),
             paid_fee_on_l1: fee,
-            transaction_hash,
             ..Default::default()
         };
 
-        let transaction =
-            L1HandlerTransaction::try_from_message_to_l2(message).unwrap().with_hash(chain_id);
+        let transaction = L1HandlerTransaction::try_from_message_to_l2(message).unwrap();
 
         assert_eq!(transaction, expected_tx);
+        assert_eq!(transaction.compute_hash(chain_id), transaction_hash);
     }
 }

--- a/crates/starknet-devnet-types/src/rpc/transactions/l1_handler_transaction.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/l1_handler_transaction.rs
@@ -28,6 +28,7 @@ const PREFIX_L1_HANDLER: FieldElement = FieldElement::from_mont([
 ]);
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct L1HandlerTransaction {
     pub version: TransactionVersion,
     pub nonce: Nonce,


### PR DESCRIPTION
## Development related changes

- Extract transaction_hash out of Transaction enum variants. The reason is starknet_getBlockWithReceipts RPC method, returns transaction and receipt. According to the spec the transaction_hash is present in the receipt property of the response.
- StarknetResponse enum variants are refactored to reflect the return type, not the method that the variant corresponds to.

## Checklist:

- [ ] Checked the relevant parts of [development docs](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#development)
- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
- [ ] Performed code self-review
- [ ] Rebased to the latest commit of the target branch (or merged it into my branch)
- [ ] Updated the docs if needed, including the [TODO section](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#todo-to-reach-feature-parity-with-the-pythonic-devnet)
- [ ] Linked the issues which this PR resolves
- [ ] Updated the tests if needed; all passing ([execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#test-execution))
