### PR TITLE
Add empty genesis block and remove init state

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ If you're using [**the Hardhat plugin**](https://github.com/0xSpaceShard/starkne
 
 ## Blocks
 
-Devnet starts with a genesis block (with a block number equal to 0).
+Devnet starts with a genesis block (with a block number equal to 0). In forking mode, the genesis block number will be equal to forked block number plus one.
 
 A new block is generated with each new transaction, and you can create an empty block by yourself.
 

--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ If you're using [**the Hardhat plugin**](https://github.com/0xSpaceShard/starkne
 
 ## Blocks
 
+Devnet starts with a genesis block (with a block number equal to 0).
+
 A new block is generated with each new transaction, and you can create an empty block by yourself.
 
 ### Create an empty block

--- a/crates/starknet-devnet-core/src/starknet/events.rs
+++ b/crates/starknet-devnet-core/src/starknet/events.rs
@@ -347,14 +347,14 @@ mod tests {
 
         // returns all events from the first 2 blocks, skip 3, but limit the result to 1
         let (events, has_more) =
-            get_events(&starknet, None, Some(BlockId::Number(1)), None, None, 3, Some(1)).unwrap();
+            get_events(&starknet, None, Some(BlockId::Number(2)), None, None, 3, Some(1)).unwrap();
         assert_eq!(events.len(), 0);
         assert!(!has_more);
 
         // returns all events from the first 2 blocks, skip 1, but limit the result to 1, it should
         // return 1 event and should be more
         let (events, has_more) =
-            get_events(&starknet, None, Some(BlockId::Number(1)), None, None, 1, Some(1)).unwrap();
+            get_events(&starknet, None, Some(BlockId::Number(2)), None, None, 1, Some(1)).unwrap();
         assert_eq!(events.len(), 1);
         assert!(has_more);
     }
@@ -409,7 +409,7 @@ mod tests {
                 .unwrap();
         }
 
-        assert_eq!(starknet.blocks.get_blocks(None, None).unwrap().len(), 5);
+        assert_eq!(starknet.blocks.get_blocks(None, None).unwrap().len(), 6);
         for idx in 0..5 {
             starknet.transactions.get_by_hash(Felt::from(idx as u128 + 100)).unwrap();
         }

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -218,7 +218,7 @@ impl Starknet {
 
         this.restart_pending_block()?;
 
-        // Create empty genesis block, set start_time before if it's set
+        // Create an empty genesis block, set start_time before if it's set
         if let Some(start_time) = config.start_time {
             this.set_next_block_timestamp(start_time);
         };
@@ -802,7 +802,15 @@ impl Starknet {
             return Err(Error::UnsupportedAction { msg: "Block is already aborted".into() });
         }
 
-        let genesis_block = self.blocks.get_by_block_id(&BlockId::Number(0)).unwrap();
+        let genesis_block_number = if let Some(block_number) = self.config.fork_config.block_number
+        {
+            block_number + 1
+        } else {
+            0
+        };
+        let genesis_block =
+            self.blocks.get_by_block_id(&BlockId::Number(genesis_block_number)).unwrap();
+
         if starting_block_hash == genesis_block.block_hash() {
             return Err(Error::UnsupportedAction { msg: "Genesis block can't be aborted".into() });
         }

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -806,7 +806,7 @@ impl Starknet {
         {
             block_number + 1
         } else {
-            0
+            DEVNET_DEFAULT_STARTING_BLOCK_NUMBER
         };
         let genesis_block =
             self.blocks.get_by_block_id(&BlockId::Number(genesis_block_number)).unwrap();

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -1277,11 +1277,11 @@ mod tests {
         // pending block has some transactions
         assert!(!starknet.pending_block().get_transactions().is_empty());
         // blocks collection should not be empty
-        assert!(!starknet.blocks.hash_to_block.is_empty());
+        assert_eq!(starknet.blocks.hash_to_block.len(), 1);
 
         starknet.generate_new_block(StateDiff::default()).unwrap();
         // blocks collection should not be empty
-        assert!(!starknet.blocks.hash_to_block.is_empty());
+        assert_eq!(starknet.blocks.hash_to_block.len(), 2);
 
         // get latest block and check that the transactions in the block are correct
         let added_block =

--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -278,6 +278,18 @@ impl BackgroundDevnet {
         BackgroundDevnet::spawn_with_additional_args(&args).await
     }
 
+    pub async fn fork_with_full_state_archive(&self) -> Result<Self, TestError> {
+        let args = [
+            "--fork-network",
+            self.url.as_str(),
+            "--accounts",
+            "0",
+            "--state-archive-capacity",
+            "full",
+        ];
+        BackgroundDevnet::spawn_with_additional_args(&args).await
+    }
+
     /// Mines a new block and returns its hash
     pub async fn create_block(&self) -> Result<FieldElement, anyhow::Error> {
         let block_creation_resp =

--- a/crates/starknet-devnet/tests/get_transaction_by_block_id_and_index.rs
+++ b/crates/starknet-devnet/tests/get_transaction_by_block_id_and_index.rs
@@ -71,7 +71,7 @@ mod get_transaction_by_block_id_and_index_integration_tests {
         let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
         let result = devnet
             .json_rpc_client
-            .get_transaction_by_block_id_and_index(BlockId::Tag(BlockTag::Latest), 1)
+            .get_transaction_by_block_id_and_index(BlockId::Number(1), 1)
             .await
             .unwrap_err();
 

--- a/crates/starknet-devnet/tests/test_abort_blocks.rs
+++ b/crates/starknet-devnet/tests/test_abort_blocks.rs
@@ -4,8 +4,7 @@ mod abort_blocks_tests {
     use hyper::Body;
     use serde_json::json;
     use server::api::json_rpc::error::ApiError;
-    use starknet_rs_core::types::{BlockId, BlockTag, FieldElement, MaybePendingBlockWithTxHashes};
-    use starknet_rs_providers::Provider;
+    use starknet_rs_core::types::FieldElement;
     use starknet_types::rpc::transaction_receipt::FeeUnit;
 
     use crate::common::background_devnet::BackgroundDevnet;
@@ -59,12 +58,7 @@ mod abort_blocks_tests {
                 .await
                 .expect("Could not start Devnet");
 
-        let genesis_block =
-            devnet.json_rpc_client.get_block_with_tx_hashes(BlockId::Tag(BlockTag::Latest)).await;
-        let genesis_block_hash = match genesis_block {
-            Ok(MaybePendingBlockWithTxHashes::Block(b)) => b.block_hash,
-            _ => panic!("Unexpected resp: {genesis_block:?}"),
-        };
+        let genesis_block_hash = devnet.get_latest_block_with_tx_hashes().await.unwrap().block_hash;
 
         let new_block_hash = devnet.create_block().await.unwrap();
         let aborted_blocks = abort_blocks(&devnet, &new_block_hash).await;

--- a/crates/starknet-devnet/tests/test_advancing_time.rs
+++ b/crates/starknet-devnet/tests/test_advancing_time.rs
@@ -542,7 +542,7 @@ mod advancing_time_tests {
         devnet.create_block().await.unwrap();
         let latest_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
 
-        assert_eq!(latest_block.block_number, 0);
+        assert_eq!(latest_block.block_number, 1);
         assert_eq!(latest_block.timestamp, past_time);
     }
 }

--- a/crates/starknet-devnet/tests/test_dump_and_load.rs
+++ b/crates/starknet-devnet/tests/test_dump_and_load.rs
@@ -54,7 +54,7 @@ mod dump_and_load_tests {
         .expect("Could not start Devnet");
 
         let last_block = devnet_load.get_latest_block_with_tx_hashes().await.unwrap();
-        assert_eq!(last_block.block_number, 3);
+        assert_eq!(last_block.block_number, 4);
     }
 
     #[tokio::test]
@@ -435,7 +435,7 @@ mod dump_and_load_tests {
 
         let latest_block = devnet_load.get_latest_block_with_tx_hashes().await.unwrap();
 
-        assert_eq!(latest_block.block_number, 0);
+        assert_eq!(latest_block.block_number, 1);
         assert_eq!(latest_block.timestamp, past_time);
     }
 }

--- a/crates/starknet-devnet/tests/test_fork.rs
+++ b/crates/starknet-devnet/tests/test_fork.rs
@@ -111,19 +111,16 @@ mod fork_tests {
 
         let fork_devnet = origin_devnet.fork().await.unwrap();
 
-        let resp_block_hash =
+        let resp_block_by_hash =
             &fork_devnet.json_rpc_client.get_block_with_tx_hashes(BlockId::Hash(block_hash)).await;
-        match resp_block_hash {
+        match resp_block_by_hash {
             Ok(MaybePendingBlockWithTxHashes::Block(b)) => assert_eq!(b.block_number, 1),
-            _ => panic!("Unexpected resp: {resp_block_hash:?}"),
+            _ => panic!("Unexpected resp: {resp_block_by_hash:?}"),
         };
 
-        let resp_latest_block = &fork_devnet
-            .json_rpc_client
-            .get_block_with_tx_hashes(BlockId::Tag(BlockTag::Latest))
-            .await;
+        let resp_latest_block = &fork_devnet.get_latest_block_with_tx_hashes().await;
         match resp_latest_block {
-            Ok(MaybePendingBlockWithTxHashes::Block(b)) => assert_eq!(b.block_number, 2),
+            Ok(b) => assert_eq!(b.block_number, 2),
             _ => panic!("Unexpected resp: {resp_latest_block:?}"),
         };
     }

--- a/crates/starknet-devnet/tests/test_fork.rs
+++ b/crates/starknet-devnet/tests/test_fork.rs
@@ -115,7 +115,7 @@ mod fork_tests {
             &fork_devnet.json_rpc_client.get_block_with_tx_hashes(BlockId::Hash(block_hash)).await;
 
         match resp {
-            Ok(MaybePendingBlockWithTxHashes::Block(b)) => assert_eq!(b.block_number, 0),
+            Ok(MaybePendingBlockWithTxHashes::Block(b)) => assert_eq!(b.block_number, 1),
             _ => panic!("Unexpected resp: {resp:?}"),
         };
     }
@@ -524,7 +524,7 @@ mod fork_tests {
 
         match block_after_fork {
             Ok(MaybePendingBlockWithTxHashes::Block(b)) => {
-                assert_eq!((b.block_hash, b.block_number), (forking_block_hash, 2))
+                assert_eq!((b.block_hash, b.block_number), (forking_block_hash, 3))
             }
             _ => panic!("Unexpected resp: {block_after_fork:?}"),
         };

--- a/crates/starknet-devnet/tests/test_fork.rs
+++ b/crates/starknet-devnet/tests/test_fork.rs
@@ -517,14 +517,12 @@ mod fork_tests {
         // create another block on origin - shouldn't affect fork - asserted later
         origin_devnet.create_block().await.unwrap();
 
-        let block_after_fork = fork_devnet
-            .json_rpc_client
-            .get_block_with_tx_hashes(BlockId::Tag(BlockTag::Latest))
-            .await;
+        let block_after_fork =
+            fork_devnet.json_rpc_client.get_block_with_tx_hashes(BlockId::Number(2)).await;
 
         match block_after_fork {
             Ok(MaybePendingBlockWithTxHashes::Block(b)) => {
-                assert_eq!((b.block_hash, b.block_number), (forking_block_hash, 3))
+                assert_eq!((b.block_hash, b.block_number), (forking_block_hash, 2))
             }
             _ => panic!("Unexpected resp: {block_after_fork:?}"),
         };
@@ -537,7 +535,7 @@ mod fork_tests {
 
         match new_fork_block {
             Ok(MaybePendingBlockWithTxHashes::Block(b)) => {
-                assert_eq!((b.block_hash, b.block_number), (new_fork_block_hash, 3));
+                assert_eq!((b.block_hash, b.block_number), (new_fork_block_hash, 4));
             }
             _ => panic!("Unexpected resp: {new_fork_block:?}"),
         };
@@ -574,7 +572,7 @@ mod fork_tests {
             .call(contract_call.clone(), BlockId::Tag(BlockTag::Latest))
             .await
             .unwrap();
-        assert_eq!(first_fork_block_number, [FieldElement::THREE]); // origin block + declare + deploy
+        assert_eq!(first_fork_block_number, [FieldElement::from(4_u8)]); // origin block + declare + deploy
 
         fork_devnet.create_block().await.unwrap();
 
@@ -583,6 +581,6 @@ mod fork_tests {
             .call(contract_call, BlockId::Tag(BlockTag::Latest))
             .await
             .unwrap();
-        assert_eq!(second_fork_block_number, [FieldElement::from(4_u8)]); // origin block + declare + deploy
+        assert_eq!(second_fork_block_number, [FieldElement::from(5_u8)]); // origin block + declare + deploy
     }
 }

--- a/crates/starknet-devnet/tests/test_fork.rs
+++ b/crates/starknet-devnet/tests/test_fork.rs
@@ -38,7 +38,6 @@ mod fork_tests {
     async fn spawn_forkable_devnet() -> Result<BackgroundDevnet, anyhow::Error> {
         let args = ["--state-archive-capacity", "full"];
         let devnet = BackgroundDevnet::spawn_with_additional_args(&args).await?;
-        devnet.create_block().await?;
         Ok(devnet)
     }
 

--- a/crates/starknet-devnet/tests/test_fork.rs
+++ b/crates/starknet-devnet/tests/test_fork.rs
@@ -106,6 +106,8 @@ mod fork_tests {
             BackgroundDevnet::spawn_with_additional_args(&["--state-archive-capacity", "full"])
                 .await
                 .unwrap();
+        let origin_devnet_genesis_block =
+            &origin_devnet.get_latest_block_with_tx_hashes().await.unwrap();
 
         let block_hash = origin_devnet.create_block().await.unwrap();
 
@@ -120,7 +122,10 @@ mod fork_tests {
 
         let resp_latest_block = &fork_devnet.get_latest_block_with_tx_hashes().await;
         match resp_latest_block {
-            Ok(b) => assert_eq!(b.block_number, 2),
+            Ok(b) => {
+                assert_eq!(b.block_number, 2);
+                assert_ne!(b.block_hash, origin_devnet_genesis_block.block_hash);
+            }
             _ => panic!("Unexpected resp: {resp_latest_block:?}"),
         };
     }

--- a/crates/starknet-devnet/tests/test_fork.rs
+++ b/crates/starknet-devnet/tests/test_fork.rs
@@ -111,12 +111,20 @@ mod fork_tests {
 
         let fork_devnet = origin_devnet.fork().await.unwrap();
 
-        let resp =
+        let resp_block_hash =
             &fork_devnet.json_rpc_client.get_block_with_tx_hashes(BlockId::Hash(block_hash)).await;
-
-        match resp {
+        match resp_block_hash {
             Ok(MaybePendingBlockWithTxHashes::Block(b)) => assert_eq!(b.block_number, 1),
-            _ => panic!("Unexpected resp: {resp:?}"),
+            _ => panic!("Unexpected resp: {resp_block_hash:?}"),
+        };
+
+        let resp_latest_block = &fork_devnet
+            .json_rpc_client
+            .get_block_with_tx_hashes(BlockId::Tag(BlockTag::Latest))
+            .await;
+        match resp_latest_block {
+            Ok(MaybePendingBlockWithTxHashes::Block(b)) => assert_eq!(b.block_number, 2),
+            _ => panic!("Unexpected resp: {resp_latest_block:?}"),
         };
     }
 

--- a/crates/starknet-devnet/tests/test_get_class_hash_at.rs
+++ b/crates/starknet-devnet/tests/test_get_class_hash_at.rs
@@ -50,10 +50,8 @@ mod get_class_hash_at_integration_tests {
                 .expect("Could not start Devnet");
         let contract_address = FieldElement::from_hex_be(PREDEPLOYED_ACCOUNT_ADDRESS).unwrap();
 
-        let result = devnet
-            .json_rpc_client
-            .get_class_hash_at(BlockId::Number(0), contract_address)
-            .await;
+        let result =
+            devnet.json_rpc_client.get_class_hash_at(BlockId::Number(0), contract_address).await;
         assert!(result.is_ok());
     }
 

--- a/crates/starknet-devnet/tests/test_get_class_hash_at.rs
+++ b/crates/starknet-devnet/tests/test_get_class_hash_at.rs
@@ -50,16 +50,11 @@ mod get_class_hash_at_integration_tests {
                 .expect("Could not start Devnet");
         let contract_address = FieldElement::from_hex_be(PREDEPLOYED_ACCOUNT_ADDRESS).unwrap();
 
-        let err = devnet
+        let result = devnet
             .json_rpc_client
             .get_class_hash_at(BlockId::Number(0), contract_address)
-            .await
-            .expect_err("Should have failed");
-
-        match err {
-            ProviderError::StarknetError(StarknetError::BlockNotFound) => (),
-            _ => panic!("Invalid error: {err:?}"),
-        }
+            .await;
+        assert!(result.is_ok());
     }
 
     #[tokio::test]

--- a/crates/starknet-devnet/tests/test_restart.rs
+++ b/crates/starknet-devnet/tests/test_restart.rs
@@ -46,7 +46,7 @@ mod test_restart {
             other => panic!("Unexpected result: {other:?}"),
         }
 
-        match devnet.json_rpc_client.get_block_with_txs(BlockId::Tag(BlockTag::Latest)).await {
+        match devnet.json_rpc_client.get_block_with_txs(BlockId::Number(1)).await {
             Err(ProviderError::StarknetError(StarknetError::BlockNotFound)) => (),
             other => panic!("Unexpected result: {other:?}"),
         }


### PR DESCRIPTION
## Usage related changes

- An empty genesis block was added.

## Development related changes

- An empty genesis block was added which caused some test changes.

## Checklist:

- [x] Checked the relevant parts of [development docs](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#development)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
- [x] Updated the docs if needed, including the [TODO section](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#todo-to-reach-feature-parity-with-the-pythonic-devnet)
- [x] Linked the issues which this PR resolves
- [x] Updated the tests if needed; all passing ([execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#test-execution))
