### PR TITLE
Refactor add_<declare/invoke/deploy_account>_transactions

### DIFF
--- a/crates/starknet-devnet-core/src/constants.rs
+++ b/crates/starknet-devnet-core/src/constants.rs
@@ -2,7 +2,6 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::num::NonZeroU128;
 
 use nonzero_ext::nonzero;
-use starknet_rs_ff::FieldElement;
 use starknet_types::chain_id::ChainId;
 
 pub const CAIRO_0_ACCOUNT_CONTRACT_PATH: &str = concat!(
@@ -76,12 +75,12 @@ pub const DEVNET_DEFAULT_STARTING_BLOCK_NUMBER: u64 = 0;
 pub const DEVNET_DEFAULT_REQUEST_BODY_SIZE_LIMIT: usize = 2_000_000;
 
 pub const SUPPORTED_TX_VERSION: u32 = 1;
-pub const QUERY_VERSION_BASE: FieldElement = FieldElement::from_mont([
-    18446744073700081665,
-    17407,
-    18446744073709551584,
-    576460752142434320,
-]); // 2 ** 128
+// pub const QUERY_VERSION_OFFSET: FieldElement = FieldElement::from_mont([
+//     18446744073700081665,
+//     17407,
+//     18446744073709551584,
+//     576460752142434320,
+// ]); // 2 ** 128
 
 // chargeable account
 pub const CHARGEABLE_ACCOUNT_PUBLIC_KEY: &str =

--- a/crates/starknet-devnet-core/src/constants.rs
+++ b/crates/starknet-devnet-core/src/constants.rs
@@ -75,12 +75,6 @@ pub const DEVNET_DEFAULT_STARTING_BLOCK_NUMBER: u64 = 0;
 pub const DEVNET_DEFAULT_REQUEST_BODY_SIZE_LIMIT: usize = 2_000_000;
 
 pub const SUPPORTED_TX_VERSION: u32 = 1;
-// pub const QUERY_VERSION_OFFSET: FieldElement = FieldElement::from_mont([
-//     18446744073700081665,
-//     17407,
-//     18446744073709551584,
-//     576460752142434320,
-// ]); // 2 ** 128
 
 // chargeable account
 pub const CHARGEABLE_ACCOUNT_PUBLIC_KEY: &str =

--- a/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
@@ -99,7 +99,7 @@ pub fn add_declare_transaction(
 
     if blockifier_declare_transaction.only_query() {
         return Err(Error::UnsupportedAction {
-            msg: "Only query transactions are not supported".to_string(),
+            msg: "query-only transactions are not supported".to_string(),
         });
     }
 
@@ -195,7 +195,7 @@ mod tests {
         assert!(result.is_err());
         match result.err().unwrap() {
             err @ crate::error::Error::UnsupportedAction { .. } => {
-                assert_eq!(err.to_string(), "Only query transactions are not supported")
+                assert_eq!(err.to_string(), "query-only transactions are not supported")
             }
             _ => {
                 panic!("Wrong error type")

--- a/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
@@ -178,7 +178,7 @@ mod tests {
         assert!(result.is_err());
         match result.err().unwrap() {
             err @ crate::error::Error::MaxFeeZeroError { .. } => {
-                assert_eq!(err.to_string(), "declare transaction v3: max_fee cannot be zero")
+                assert_eq!(err.to_string(), "Declare transaction V3: max_fee cannot be zero")
             }
             _ => panic!("Wrong error type"),
         }
@@ -203,7 +203,7 @@ mod tests {
         assert!(result.is_err());
         match result.err().unwrap() {
             err @ crate::error::Error::MaxFeeZeroError { .. } => {
-                assert_eq!(err.to_string(), "declare transaction v2: max_fee cannot be zero")
+                assert_eq!(err.to_string(), "Declare transaction V2: max_fee cannot be zero")
             }
             _ => panic!("Wrong error type"),
         }
@@ -334,7 +334,7 @@ mod tests {
         assert!(result.is_err());
         match result.err().unwrap() {
             err @ crate::error::Error::MaxFeeZeroError { .. } => {
-                assert_eq!(err.to_string(), "declare transaction v1: max_fee cannot be zero")
+                assert_eq!(err.to_string(), "Declare transaction V1: max_fee cannot be zero")
             }
             _ => panic!("Wrong error type"),
         }

--- a/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
@@ -22,8 +22,8 @@ pub fn add_declare_transaction_v3(
         return Err(Error::MaxFeeZeroError { tx_type: "declare transaction v3".to_string() });
     }
 
-    let blockifier_declare_transaction = broadcasted_declare_transaction
-        .create_blockifier_declare(starknet.chain_id().to_felt(), false)?;
+    let blockifier_declare_transaction =
+        broadcasted_declare_transaction.create_blockifier_declare(starknet.chain_id().to_felt())?;
 
     let transaction_hash = blockifier_declare_transaction.tx_hash().0.into();
     let class_hash = blockifier_declare_transaction.class_hash().0.into();

--- a/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
@@ -32,7 +32,7 @@ pub fn add_declare_transaction(
                 v1.calculate_transaction_hash(&starknet.config.chain_id.to_felt(), &class_hash)?;
 
             let declare_transaction = Transaction::Declare(DeclareTransaction::V1(
-                DeclareTransactionV0V1::new(&v1, class_hash),
+                DeclareTransactionV0V1::new(v1, class_hash),
             ));
 
             let blockifier_declare_transaction =
@@ -60,7 +60,7 @@ pub fn add_declare_transaction(
             let class_hash = blockifier_declare_transaction.class_hash().0.into();
 
             let declare_transaction = Transaction::Declare(DeclareTransaction::V2(
-                DeclareTransactionV2::new(&v2, class_hash),
+                DeclareTransactionV2::new(v2, class_hash),
             ));
 
             (
@@ -85,7 +85,7 @@ pub fn add_declare_transaction(
             let class_hash = blockifier_declare_transaction.class_hash().0.into();
 
             let declare_transaction = Transaction::Declare(DeclareTransaction::V3(
-                DeclareTransactionV3::new(&v3, class_hash),
+                DeclareTransactionV3::new(v3, class_hash),
             ));
 
             (

--- a/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
@@ -98,6 +98,12 @@ pub fn add_declare_transaction(
         }
     };
 
+    if blockifier_declare_transaction.only_query() {
+        return Err(Error::UnsupportedAction {
+            msg: "Only query transactions are not supported".to_string(),
+        });
+    }
+
     let transaction = TransactionWithHash::new(transaction_hash, declare_transaction);
     let blockifier_execution_result =
         blockifier::transaction::account_transaction::AccountTransaction::Declare(

--- a/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
@@ -79,6 +79,12 @@ pub fn add_deploy_account_transaction(
         }
     };
 
+    if blockifier_deploy_account_transaction.only_query {
+        return Err(Error::UnsupportedAction {
+            msg: "Only query transactions are not supported".to_string(),
+        });
+    }
+
     if !starknet.state.is_contract_declared(class_hash) {
         return Err(Error::StateError(crate::error::StateError::NoneClassHash(class_hash)));
     }

--- a/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
@@ -81,7 +81,7 @@ pub fn add_deploy_account_transaction(
 
     if blockifier_deploy_account_transaction.only_query {
         return Err(Error::UnsupportedAction {
-            msg: "Only query transactions are not supported".to_string(),
+            msg: "query-only transactions are not supported".to_string(),
         });
     }
 
@@ -175,7 +175,7 @@ mod tests {
 
         match txn_err {
             Error::UnsupportedAction { msg } => {
-                assert_eq!(msg, "Only query transactions are not supported")
+                assert_eq!(msg, "query-only transactions are not supported")
             }
             _ => panic!("Wrong error type"),
         }

--- a/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
@@ -37,16 +37,17 @@ pub fn add_deploy_account_transaction(
             let address: ContractAddress =
                 blockifier_deploy_account_transaction.contract_address.into();
 
-            let transaction = Transaction::DeployAccount(DeployAccountTransaction::V1(Box::new(
-                DeployAccountTransactionV1::new(&v1, address),
-            )));
+            let deploy_account_transaction =
+                Transaction::DeployAccount(DeployAccountTransaction::V1(Box::new(
+                    DeployAccountTransactionV1::new(v1, address),
+                )));
 
             (
                 transaction_hash,
                 v1.class_hash,
                 address,
                 blockifier_deploy_account_transaction,
-                transaction,
+                deploy_account_transaction,
             )
         }
         BroadcastedDeployAccountTransaction::V3(ref v3) => {
@@ -63,16 +64,17 @@ pub fn add_deploy_account_transaction(
             let address: ContractAddress =
                 blockifier_deploy_account_transaction.contract_address.into();
 
-            let transaction = Transaction::DeployAccount(DeployAccountTransaction::V3(Box::new(
-                DeployAccountTransactionV3::new(&v3, address),
-            )));
+            let deploy_account_transaction =
+                Transaction::DeployAccount(DeployAccountTransaction::V3(Box::new(
+                    DeployAccountTransactionV3::new(v3, address),
+                )));
 
             (
                 transaction_hash,
                 v3.class_hash,
                 address,
                 blockifier_deploy_account_transaction,
-                transaction,
+                deploy_account_transaction,
             )
         }
     };

--- a/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
@@ -17,7 +17,7 @@ pub fn add_deploy_account_transaction(
     broadcasted_deploy_account_transaction: BroadcastedDeployAccountTransaction,
 ) -> DevnetResult<(TransactionHash, ContractAddress)> {
     let blockifier_deploy_account_transaction = broadcasted_deploy_account_transaction
-        .create_blockifier_deploy_account(starknet.chain_id().to_felt())?;
+        .create_blockifier_deploy_account(&starknet.chain_id().to_felt())?;
 
     let address = blockifier_deploy_account_transaction.contract_address.into();
 
@@ -260,7 +260,7 @@ mod tests {
         );
 
         let blockifier_transaction = BroadcastedDeployAccountTransaction::V1(transaction.clone())
-            .create_blockifier_deploy_account(DEVNET_DEFAULT_CHAIN_ID.to_felt())
+            .create_blockifier_deploy_account(&DEVNET_DEFAULT_CHAIN_ID.to_felt())
             .unwrap();
 
         // change balance at address
@@ -302,7 +302,7 @@ mod tests {
         let transaction = test_deploy_account_transaction_v3(account_class_hash, 0, 4000);
 
         let blockifier_transaction = BroadcastedDeployAccountTransaction::V3(transaction.clone())
-            .create_blockifier_deploy_account(DEVNET_DEFAULT_CHAIN_ID.to_felt())
+            .create_blockifier_deploy_account(&DEVNET_DEFAULT_CHAIN_ID.to_felt())
             .unwrap();
 
         // change balance at address
@@ -358,7 +358,7 @@ mod tests {
             Felt::from(1),
         );
         let blockifier_transaction = BroadcastedDeployAccountTransaction::V1(transaction.clone())
-            .create_blockifier_deploy_account(DEVNET_DEFAULT_CHAIN_ID.to_felt())
+            .create_blockifier_deploy_account(&DEVNET_DEFAULT_CHAIN_ID.to_felt())
             .unwrap();
 
         // change balance at address

--- a/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
@@ -29,7 +29,7 @@ pub fn add_deploy_account_transaction_v3(
     }
 
     let blockifier_deploy_account_transaction = broadcasted_deploy_account_transaction
-        .create_blockifier_deploy_account(starknet.chain_id().to_felt(), false)?;
+        .create_blockifier_deploy_account(starknet.chain_id().to_felt())?;
 
     let transaction_hash = blockifier_deploy_account_transaction.tx_hash.0.into();
     let address: ContractAddress = blockifier_deploy_account_transaction.contract_address.into();
@@ -72,7 +72,7 @@ pub fn add_deploy_account_transaction_v1(
     }
 
     let blockifier_deploy_account_transaction = broadcasted_deploy_account_transaction
-        .create_blockifier_deploy_account(starknet.chain_id().to_felt(), false)?;
+        .create_blockifier_deploy_account(starknet.chain_id().to_felt())?;
 
     let transaction_hash = blockifier_deploy_account_transaction.tx_hash.0.into();
     let address: ContractAddress = blockifier_deploy_account_transaction.contract_address.into();
@@ -250,7 +250,7 @@ mod tests {
         );
 
         let blockifier_transaction = transaction
-            .create_blockifier_deploy_account(DEVNET_DEFAULT_CHAIN_ID.to_felt(), false)
+            .create_blockifier_deploy_account(DEVNET_DEFAULT_CHAIN_ID.to_felt())
             .unwrap();
 
         // change balance at address
@@ -289,7 +289,7 @@ mod tests {
         let transaction = test_deploy_account_transaction_v3(account_class_hash, 0, 4000);
 
         let blockifier_transaction = transaction
-            .create_blockifier_deploy_account(DEVNET_DEFAULT_CHAIN_ID.to_felt(), false)
+            .create_blockifier_deploy_account(DEVNET_DEFAULT_CHAIN_ID.to_felt())
             .unwrap();
 
         // change balance at address
@@ -343,7 +343,7 @@ mod tests {
             Felt::from(1),
         );
         let blockifier_transaction = transaction
-            .create_blockifier_deploy_account(DEVNET_DEFAULT_CHAIN_ID.to_felt(), false)
+            .create_blockifier_deploy_account(DEVNET_DEFAULT_CHAIN_ID.to_felt())
             .unwrap();
 
         // change balance at address

--- a/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
@@ -166,7 +166,7 @@ mod tests {
         assert!(result.is_err());
         match result.err().unwrap() {
             err @ crate::error::Error::MaxFeeZeroError { .. } => {
-                assert_eq!(err.to_string(), "deploy account transaction: max_fee cannot be zero")
+                assert_eq!(err.to_string(), "Deploy account transaction V1: max_fee cannot be zero")
             }
             _ => panic!("Wrong error type"),
         }
@@ -185,7 +185,7 @@ mod tests {
             .unwrap_err();
         match txn_err {
             err @ crate::error::Error::MaxFeeZeroError { .. } => {
-                assert_eq!(err.to_string(), "deploy account transaction v3: max_fee cannot be zero")
+                assert_eq!(err.to_string(), "Deploy account transaction V3: max_fee cannot be zero")
             }
             _ => panic!("Wrong error type"),
         }

--- a/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
@@ -173,8 +173,6 @@ mod tests {
             ))
             .unwrap_err();
 
-        println!("{:?}", txn_err);
-
         match txn_err {
             Error::UnsupportedAction { msg } => {
                 assert_eq!(msg, "Only query transactions are not supported")

--- a/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
@@ -46,6 +46,12 @@ pub fn add_invoke_transaction(
             }
         };
 
+    if blockifier_invoke_transaction.only_query {
+        return Err(Error::UnsupportedAction {
+            msg: "Only query transactions are not supported".to_string(),
+        });
+    }
+
     let blockifier_execution_result =
         blockifier::transaction::account_transaction::AccountTransaction::Invoke(
             blockifier_invoke_transaction,

--- a/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
@@ -20,20 +20,14 @@ pub fn add_invoke_transaction(
                 return Err(Error::MaxFeeZeroError { tx_type: "invoke transaction".into() });
             }
 
-            let invoke_transaction =
-                Transaction::Invoke(InvokeTransaction::V1(InvokeTransactionV1::new(v1)));
-
-            invoke_transaction
+            Transaction::Invoke(InvokeTransaction::V1(InvokeTransactionV1::new(v1)))
         }
         BroadcastedInvokeTransaction::V3(ref v3) => {
             if v3.common.is_max_fee_zero_value() {
                 return Err(Error::MaxFeeZeroError { tx_type: "invoke transaction v3".into() });
             }
 
-            let invoke_transaction =
-                Transaction::Invoke(InvokeTransaction::V3(InvokeTransactionV3::new(v3)));
-
-            invoke_transaction
+            Transaction::Invoke(InvokeTransaction::V3(InvokeTransactionV3::new(v3)))
         }
     };
 

--- a/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
@@ -32,7 +32,7 @@ pub fn add_invoke_transaction(
     };
 
     let blockifier_invoke_transaction = broadcasted_invoke_transaction
-        .create_blockifier_invoke_transaction(starknet.chain_id().to_felt())?;
+        .create_blockifier_invoke_transaction(&starknet.chain_id().to_felt())?;
     let transaction_hash = blockifier_invoke_transaction.tx_hash.0.into();
 
     if blockifier_invoke_transaction.only_query {

--- a/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
@@ -21,7 +21,7 @@ pub fn add_invoke_transaction_v1(
     }
 
     let blockifier_invoke_transaction = broadcasted_invoke_transaction
-        .create_blockifier_invoke_transaction(starknet.chain_id().to_felt(), false)?;
+        .create_blockifier_invoke_transaction(starknet.chain_id().to_felt())?;
     let transaction_hash = blockifier_invoke_transaction.tx_hash.0.into();
 
     let invoke_transaction = InvokeTransactionV1::new(&broadcasted_invoke_transaction);
@@ -53,7 +53,7 @@ pub fn add_invoke_transaction_v3(
     }
 
     let blockifier_invoke_transaction = broadcasted_invoke_transaction
-        .create_blockifier_invoke_transaction(starknet.chain_id().to_felt(), false)?;
+        .create_blockifier_invoke_transaction(starknet.chain_id().to_felt())?;
 
     let transaction_hash = blockifier_invoke_transaction.tx_hash.0.into();
 

--- a/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
@@ -48,7 +48,7 @@ pub fn add_invoke_transaction(
 
     if blockifier_invoke_transaction.only_query {
         return Err(Error::UnsupportedAction {
-            msg: "Only query transactions are not supported".to_string(),
+            msg: "query-only transactions are not supported".to_string(),
         });
     }
 
@@ -185,7 +185,7 @@ mod tests {
         let txn_err = Starknet::default().add_invoke_transaction(invoke_transaction).unwrap_err();
         match txn_err {
             crate::error::Error::UnsupportedAction { msg } => {
-                assert_eq!(msg, "Only query transactions are not supported".to_string());
+                assert_eq!(msg, "query-only transactions are not supported".to_string());
             }
             _ => panic!("Wrong error type"),
         }

--- a/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
@@ -183,7 +183,6 @@ mod tests {
         }
 
         let txn_err = Starknet::default().add_invoke_transaction(invoke_transaction).unwrap_err();
-        println!("{:?}", txn_err);
         match txn_err {
             crate::error::Error::UnsupportedAction { msg } => {
                 assert_eq!(msg, "Only query transactions are not supported".to_string());

--- a/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
@@ -199,7 +199,7 @@ mod tests {
             err @ crate::error::Error::MaxFeeZeroError { .. } => {
                 assert_eq!(
                     err.to_string(),
-                    "invoke transaction v3: max_fee cannot be zero".to_string()
+                    "Invoke transaction V3: max_fee cannot be zero".to_string()
                 );
             }
             _ => panic!("Wrong error type"),
@@ -331,7 +331,7 @@ mod tests {
         assert!(result.is_err());
         match result.err().unwrap() {
             err @ crate::error::Error::MaxFeeZeroError { .. } => {
-                assert_eq!(err.to_string(), "invoke transaction: max_fee cannot be zero")
+                assert_eq!(err.to_string(), "Invoke transaction V1: max_fee cannot be zero")
             }
             _ => panic!("Wrong error type"),
         }

--- a/crates/starknet-devnet-core/src/starknet/dump.rs
+++ b/crates/starknet-devnet-core/src/starknet/dump.rs
@@ -33,11 +33,8 @@ impl Starknet {
                 DumpEvent::AddDeployAccountTransaction(tx) => {
                     self.add_deploy_account_transaction(tx)?;
                 }
-                DumpEvent::AddInvokeTransaction(BroadcastedInvokeTransaction::V1(tx)) => {
-                    self.add_invoke_transaction_v1(tx)?;
-                }
-                DumpEvent::AddInvokeTransaction(BroadcastedInvokeTransaction::V3(tx)) => {
-                    self.add_invoke_transaction_v3(tx)?;
+                DumpEvent::AddInvokeTransaction(tx) => {
+                    self.add_invoke_transaction(tx)?;
                 }
                 DumpEvent::AddL1HandlerTransaction(tx) => {
                     self.add_l1_handler_transaction(tx)?;

--- a/crates/starknet-devnet-core/src/starknet/dump.rs
+++ b/crates/starknet-devnet-core/src/starknet/dump.rs
@@ -30,15 +30,8 @@ impl Starknet {
                 DumpEvent::AddDeclareTransaction(tx) => {
                     self.add_declare_transaction(tx)?;
                 }
-                DumpEvent::AddDeployAccountTransaction(
-                    BroadcastedDeployAccountTransaction::V1(tx),
-                ) => {
-                    self.add_deploy_account_transaction_v1(tx)?;
-                }
-                DumpEvent::AddDeployAccountTransaction(
-                    BroadcastedDeployAccountTransaction::V3(tx),
-                ) => {
-                    self.add_deploy_account_transaction_v3(tx)?;
+                DumpEvent::AddDeployAccountTransaction(tx) => {
+                    self.add_deploy_account_transaction(tx)?;
                 }
                 DumpEvent::AddInvokeTransaction(BroadcastedInvokeTransaction::V1(tx)) => {
                     self.add_invoke_transaction_v1(tx)?;

--- a/crates/starknet-devnet-core/src/starknet/dump.rs
+++ b/crates/starknet-devnet-core/src/starknet/dump.rs
@@ -27,14 +27,8 @@ impl Starknet {
     pub fn re_execute(&mut self, events: Vec<DumpEvent>) -> DevnetResult<()> {
         for event in events.into_iter() {
             match event {
-                DumpEvent::AddDeclareTransaction(BroadcastedDeclareTransaction::V1(tx)) => {
-                    self.add_declare_transaction_v1(*tx)?;
-                }
-                DumpEvent::AddDeclareTransaction(BroadcastedDeclareTransaction::V2(tx)) => {
-                    self.add_declare_transaction_v2(*tx)?;
-                }
-                DumpEvent::AddDeclareTransaction(BroadcastedDeclareTransaction::V3(tx)) => {
-                    self.add_declare_transaction_v3(*tx)?;
+                DumpEvent::AddDeclareTransaction(tx) => {
+                    self.add_declare_transaction(tx)?;
                 }
                 DumpEvent::AddDeployAccountTransaction(
                     BroadcastedDeployAccountTransaction::V1(tx),

--- a/crates/starknet-devnet-core/src/starknet/estimations.rs
+++ b/crates/starknet-devnet-core/src/starknet/estimations.rs
@@ -30,7 +30,7 @@ pub fn estimate_fee(
 
     let transactions = transactions
         .iter()
-        .map(|txn| Ok(txn.to_blockifier_account_transaction(chain_id)?))
+        .map(|txn| Ok(txn.to_blockifier_account_transaction(&chain_id)?))
         .collect::<DevnetResult<Vec<AccountTransaction>>>()?;
 
     transactions

--- a/crates/starknet-devnet-core/src/starknet/estimations.rs
+++ b/crates/starknet-devnet-core/src/starknet/estimations.rs
@@ -30,7 +30,7 @@ pub fn estimate_fee(
 
     let transactions = transactions
         .iter()
-        .map(|txn| Ok(txn.to_blockifier_account_transaction(chain_id, true)?))
+        .map(|txn| Ok(txn.to_blockifier_account_transaction(chain_id)?))
         .collect::<DevnetResult<Vec<AccountTransaction>>>()?;
 
     transactions

--- a/crates/starknet-devnet-core/src/starknet/get_class_impls.rs
+++ b/crates/starknet-devnet-core/src/starknet/get_class_impls.rs
@@ -116,7 +116,13 @@ mod tests {
         let declare_txn = dummy_broadcasted_declare_transaction_v2(&account.account_address);
 
         let expected: ContractClass = declare_txn.contract_class.clone().into();
-        let (_, class_hash) = starknet.add_declare_transaction_v2(declare_txn).unwrap();
+        let (_, class_hash) = starknet
+            .add_declare_transaction(
+                starknet_types::rpc::transactions::BroadcastedDeclareTransaction::V2(Box::new(
+                    declare_txn,
+                )),
+            )
+            .unwrap();
 
         let block_number = starknet.get_latest_block().unwrap().block_number();
         let contract_class =

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -42,9 +42,9 @@ use starknet_types::rpc::transactions::broadcasted_invoke_transaction_v1::Broadc
 use starknet_types::rpc::transactions::broadcasted_invoke_transaction_v3::BroadcastedInvokeTransactionV3;
 use starknet_types::rpc::transactions::l1_handler_transaction::L1HandlerTransaction;
 use starknet_types::rpc::transactions::{
-    BlockTransactionTrace, BroadcastedTransaction, BroadcastedTransactionCommon,
-    DeclareTransaction, SimulatedTransaction, SimulationFlag, Transaction, TransactionTrace,
-    TransactionWithHash, TransactionWithReceipt, Transactions,
+    BlockTransactionTrace, BroadcastedDeclareTransaction, BroadcastedTransaction,
+    BroadcastedTransactionCommon, DeclareTransaction, SimulatedTransaction, SimulationFlag,
+    Transaction, TransactionTrace, TransactionWithHash, TransactionWithReceipt, Transactions,
 };
 use starknet_types::traits::HashProducer;
 use tracing::{error, info};
@@ -666,11 +666,23 @@ impl Starknet {
         estimations::estimate_message_fee(self, block_id, message)
     }
 
+    pub fn add_declare_transaction(
+        &mut self,
+        declare_transaction: BroadcastedDeclareTransaction,
+    ) -> DevnetResult<(TransactionHash, ClassHash)> {
+        add_declare_transaction::add_declare_tranaction(self, declare_transaction)
+    }
+
     pub fn add_declare_transaction_v1(
         &mut self,
         declare_transaction: BroadcastedDeclareTransactionV1,
     ) -> DevnetResult<(TransactionHash, ClassHash)> {
-        add_declare_transaction::add_declare_transaction_v1(self, declare_transaction)
+        add_declare_transaction::add_declare_tranaction(
+            self,
+            starknet_types::rpc::transactions::BroadcastedDeclareTransaction::V1(Box::new(
+                declare_transaction,
+            )),
+        )
     }
 
     pub fn add_declare_transaction_v2(

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -34,13 +34,12 @@ use starknet_types::rpc::transaction_receipt::{
     DeployTransactionReceipt, L1HandlerTransactionReceipt, TransactionReceipt,
 };
 use starknet_types::rpc::transactions::broadcasted_invoke_transaction_v1::BroadcastedInvokeTransactionV1;
-use starknet_types::rpc::transactions::broadcasted_invoke_transaction_v3::BroadcastedInvokeTransactionV3;
 use starknet_types::rpc::transactions::l1_handler_transaction::L1HandlerTransaction;
 use starknet_types::rpc::transactions::{
     BlockTransactionTrace, BroadcastedDeclareTransaction, BroadcastedDeployAccountTransaction,
-    BroadcastedTransaction, BroadcastedTransactionCommon, DeclareTransaction, SimulatedTransaction,
-    SimulationFlag, Transaction, TransactionTrace, TransactionWithHash, TransactionWithReceipt,
-    Transactions,
+    BroadcastedInvokeTransaction, BroadcastedTransaction, BroadcastedTransactionCommon,
+    DeclareTransaction, SimulatedTransaction, SimulationFlag, Transaction, TransactionTrace,
+    TransactionWithHash, TransactionWithReceipt, Transactions,
 };
 use starknet_types::traits::HashProducer;
 use tracing::{error, info};
@@ -684,18 +683,11 @@ impl Starknet {
         )
     }
 
-    pub fn add_invoke_transaction_v1(
+    pub fn add_invoke_transaction(
         &mut self,
-        invoke_transaction: BroadcastedInvokeTransactionV1,
+        invoke_transaction: BroadcastedInvokeTransaction,
     ) -> DevnetResult<TransactionHash> {
-        add_invoke_transaction::add_invoke_transaction_v1(self, invoke_transaction)
-    }
-
-    pub fn add_invoke_transaction_v3(
-        &mut self,
-        invoke_transaction: BroadcastedInvokeTransactionV3,
-    ) -> DevnetResult<TransactionHash> {
-        add_invoke_transaction::add_invoke_transaction_v3(self, invoke_transaction)
+        add_invoke_transaction::add_invoke_transaction(self, invoke_transaction)
     }
 
     pub fn add_l1_handler_transaction(
@@ -757,7 +749,10 @@ impl Starknet {
         };
 
         // apply the invoke tx
-        add_invoke_transaction::add_invoke_transaction_v1(self, invoke_tx)
+        add_invoke_transaction::add_invoke_transaction(
+            self,
+            BroadcastedInvokeTransaction::V1(invoke_tx),
+        )
     }
 
     pub fn block_state_update(&self, block_id: &BlockId) -> DevnetResult<StateUpdate> {

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -1068,7 +1068,7 @@ impl Starknet {
         );
         for broadcasted_transaction in transactions.iter() {
             let blockifier_transaction =
-                broadcasted_transaction.to_blockifier_account_transaction(chain_id, true)?;
+                broadcasted_transaction.to_blockifier_account_transaction(chain_id)?;
             let tx_execution_info = blockifier_transaction.execute(
                 &mut transactional_state,
                 &block_context,

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -1035,7 +1035,7 @@ impl Starknet {
         );
         for broadcasted_transaction in transactions.iter() {
             let blockifier_transaction =
-                broadcasted_transaction.to_blockifier_account_transaction(chain_id)?;
+                broadcasted_transaction.to_blockifier_account_transaction(&chain_id)?;
             let tx_execution_info = blockifier_transaction.execute(
                 &mut transactional_state,
                 &block_context,

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -33,15 +33,14 @@ use starknet_types::rpc::state::ThinStateDiff;
 use starknet_types::rpc::transaction_receipt::{
     DeployTransactionReceipt, L1HandlerTransactionReceipt, TransactionReceipt,
 };
-use starknet_types::rpc::transactions::broadcasted_deploy_account_transaction_v1::BroadcastedDeployAccountTransactionV1;
-use starknet_types::rpc::transactions::broadcasted_deploy_account_transaction_v3::BroadcastedDeployAccountTransactionV3;
 use starknet_types::rpc::transactions::broadcasted_invoke_transaction_v1::BroadcastedInvokeTransactionV1;
 use starknet_types::rpc::transactions::broadcasted_invoke_transaction_v3::BroadcastedInvokeTransactionV3;
 use starknet_types::rpc::transactions::l1_handler_transaction::L1HandlerTransaction;
 use starknet_types::rpc::transactions::{
-    BlockTransactionTrace, BroadcastedDeclareTransaction, BroadcastedTransaction,
-    BroadcastedTransactionCommon, DeclareTransaction, SimulatedTransaction, SimulationFlag,
-    Transaction, TransactionTrace, TransactionWithHash, TransactionWithReceipt, Transactions,
+    BlockTransactionTrace, BroadcastedDeclareTransaction, BroadcastedDeployAccountTransaction,
+    BroadcastedTransaction, BroadcastedTransactionCommon, DeclareTransaction, SimulatedTransaction,
+    SimulationFlag, Transaction, TransactionTrace, TransactionWithHash, TransactionWithReceipt,
+    Transactions,
 };
 use starknet_types::traits::HashProducer;
 use tracing::{error, info};
@@ -675,21 +674,11 @@ impl Starknet {
         self.config.chain_id
     }
 
-    pub fn add_deploy_account_transaction_v1(
+    pub fn add_deploy_account_transaction(
         &mut self,
-        deploy_account_transaction: BroadcastedDeployAccountTransactionV1,
+        deploy_account_transaction: BroadcastedDeployAccountTransaction,
     ) -> DevnetResult<(TransactionHash, ContractAddress)> {
-        add_deploy_account_transaction::add_deploy_account_transaction_v1(
-            self,
-            deploy_account_transaction,
-        )
-    }
-
-    pub fn add_deploy_account_transaction_v3(
-        &mut self,
-        deploy_account_transaction: BroadcastedDeployAccountTransactionV3,
-    ) -> DevnetResult<(TransactionHash, ContractAddress)> {
-        add_deploy_account_transaction::add_deploy_account_transaction_v3(
+        add_deploy_account_transaction::add_deploy_account_transaction(
             self,
             deploy_account_transaction,
         )

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -33,9 +33,6 @@ use starknet_types::rpc::state::ThinStateDiff;
 use starknet_types::rpc::transaction_receipt::{
     DeployTransactionReceipt, L1HandlerTransactionReceipt, TransactionReceipt,
 };
-use starknet_types::rpc::transactions::broadcasted_declare_transaction_v1::BroadcastedDeclareTransactionV1;
-use starknet_types::rpc::transactions::broadcasted_declare_transaction_v2::BroadcastedDeclareTransactionV2;
-use starknet_types::rpc::transactions::broadcasted_declare_transaction_v3::BroadcastedDeclareTransactionV3;
 use starknet_types::rpc::transactions::broadcasted_deploy_account_transaction_v1::BroadcastedDeployAccountTransactionV1;
 use starknet_types::rpc::transactions::broadcasted_deploy_account_transaction_v3::BroadcastedDeployAccountTransactionV3;
 use starknet_types::rpc::transactions::broadcasted_invoke_transaction_v1::BroadcastedInvokeTransactionV1;
@@ -670,33 +667,7 @@ impl Starknet {
         &mut self,
         declare_transaction: BroadcastedDeclareTransaction,
     ) -> DevnetResult<(TransactionHash, ClassHash)> {
-        add_declare_transaction::add_declare_tranaction(self, declare_transaction)
-    }
-
-    pub fn add_declare_transaction_v1(
-        &mut self,
-        declare_transaction: BroadcastedDeclareTransactionV1,
-    ) -> DevnetResult<(TransactionHash, ClassHash)> {
-        add_declare_transaction::add_declare_tranaction(
-            self,
-            starknet_types::rpc::transactions::BroadcastedDeclareTransaction::V1(Box::new(
-                declare_transaction,
-            )),
-        )
-    }
-
-    pub fn add_declare_transaction_v2(
-        &mut self,
-        declare_transaction: BroadcastedDeclareTransactionV2,
-    ) -> DevnetResult<(TransactionHash, ClassHash)> {
-        add_declare_transaction::add_declare_transaction_v2(self, declare_transaction)
-    }
-
-    pub fn add_declare_transaction_v3(
-        &mut self,
-        declare_transaction: BroadcastedDeclareTransactionV3,
-    ) -> DevnetResult<(TransactionHash, ClassHash)> {
-        add_declare_transaction::add_declare_transaction_v3(self, declare_transaction)
+        add_declare_transaction::add_declare_transaction(self, declare_transaction)
     }
 
     /// returning the chain id as object

--- a/crates/starknet-devnet-core/src/starknet/state_update.rs
+++ b/crates/starknet-devnet-core/src/starknet/state_update.rs
@@ -63,7 +63,13 @@ mod tests {
         );
 
         // first execute declare v2 transaction
-        let (txn_hash, _) = starknet.add_declare_transaction_v2(declare_txn).unwrap();
+        let (txn_hash, _) = starknet
+            .add_declare_transaction(
+                starknet_types::rpc::transactions::BroadcastedDeclareTransaction::V2(Box::new(
+                    declare_txn,
+                )),
+            )
+            .unwrap();
         let tx = starknet.transactions.get_by_hash_mut(&txn_hash).unwrap();
         assert_eq!(tx.finality_status, TransactionFinalityStatus::AcceptedOnL2);
         assert_eq!(tx.execution_result.status(), TransactionExecutionStatus::Succeeded);

--- a/crates/starknet-devnet-server/src/api/json_rpc/write_endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/write_endpoints.rs
@@ -28,33 +28,15 @@ impl JsonRpcHandler {
         &self,
         request: BroadcastedDeployAccountTransaction,
     ) -> StrictRpcResult {
-        let (transaction_hash, contract_address) = match request {
-            BroadcastedDeployAccountTransaction::V1(deploy_account_txn_v1) => self
-                .api
-                .starknet
-                .write()
-                .await
-                .add_deploy_account_transaction_v1(deploy_account_txn_v1)
-                .map_err(|err| match err {
+        let (transaction_hash, contract_address) =
+            self.api.starknet.write().await.add_deploy_account_transaction(request).map_err(
+                |err| match err {
                     starknet_core::error::Error::StateError(
                         starknet_core::error::StateError::NoneClassHash(_),
                     ) => ApiError::ClassHashNotFound,
                     unknown_error => ApiError::StarknetDevnetError(unknown_error),
-                })?,
-
-            BroadcastedDeployAccountTransaction::V3(deploy_account_txn_v3) => self
-                .api
-                .starknet
-                .write()
-                .await
-                .add_deploy_account_transaction_v3(deploy_account_txn_v3)
-                .map_err(|err| match err {
-                    starknet_core::error::Error::StateError(
-                        starknet_core::error::StateError::NoneClassHash(_),
-                    ) => ApiError::ClassHashNotFound,
-                    unknown_error => ApiError::StarknetDevnetError(unknown_error),
-                })?,
-        };
+                },
+            )?;
 
         Ok(StarknetResponse::AddDeployAccountTransaction(DeployAccountTransactionOutput {
             transaction_hash,

--- a/crates/starknet-devnet-server/src/api/json_rpc/write_endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/write_endpoints.rs
@@ -15,27 +15,8 @@ impl JsonRpcHandler {
         &self,
         request: BroadcastedDeclareTransaction,
     ) -> StrictRpcResult {
-        let (transaction_hash, class_hash) = match request {
-            BroadcastedDeclareTransaction::V1(broadcasted_declare_txn) => self
-                .api
-                .starknet
-                .write()
-                .await
-                .add_declare_transaction_v1(*broadcasted_declare_txn)?,
-            BroadcastedDeclareTransaction::V2(broadcasted_declare_txn) => self
-                .api
-                .starknet
-                .write()
-                .await
-                .add_declare_transaction_v2(*broadcasted_declare_txn)?,
-
-            BroadcastedDeclareTransaction::V3(broadcasted_declare_txn) => self
-                .api
-                .starknet
-                .write()
-                .await
-                .add_declare_transaction_v3(*broadcasted_declare_txn)?,
-        };
+        let (transaction_hash, class_hash) =
+            self.api.starknet.write().await.add_declare_transaction(request)?;
 
         Ok(StarknetResponse::AddDeclareTransaction(DeclareTransactionOutput {
             transaction_hash,

--- a/crates/starknet-devnet-server/src/api/json_rpc/write_endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/write_endpoints.rs
@@ -48,14 +48,7 @@ impl JsonRpcHandler {
         &self,
         request: BroadcastedInvokeTransaction,
     ) -> StrictRpcResult {
-        let transaction_hash = match request {
-            BroadcastedInvokeTransaction::V1(invoke_txn) => {
-                self.api.starknet.write().await.add_invoke_transaction_v1(invoke_txn)?
-            }
-            BroadcastedInvokeTransaction::V3(invoke_txn) => {
-                self.api.starknet.write().await.add_invoke_transaction_v3(invoke_txn)?
-            }
-        };
+        let transaction_hash = self.api.starknet.write().await.add_invoke_transaction(request)?;
 
         Ok(StarknetResponse::AddInvokeTransaction(InvokeTransactionOutput { transaction_hash }))
     }

--- a/crates/starknet-devnet-types/src/constants.rs
+++ b/crates/starknet-devnet-types/src/constants.rs
@@ -34,3 +34,11 @@ pub(crate) const PREFIX_DEPLOY_ACCOUNT: FieldElement = FieldElement::from_mont([
     18446744073709551615,
     461298303000467581,
 ]);
+
+/// Cairo string for "declare" from starknet-rs
+pub(crate) const PREFIX_DECLARE: FieldElement = FieldElement::from_mont([
+    17542456862011667323,
+    18446744073709551615,
+    18446744073709551615,
+    191557713328401194,
+]);

--- a/crates/starknet-devnet-types/src/constants.rs
+++ b/crates/starknet-devnet-types/src/constants.rs
@@ -18,3 +18,19 @@ pub const QUERY_VERSION_OFFSET: FieldElement = FieldElement::from_mont([
     18446744073709551584,
     576460752142434320,
 ]);
+
+/// Cairo string for "invoke" from starknet-rs
+pub(crate) const PREFIX_INVOKE: FieldElement = FieldElement::from_mont([
+    18443034532770911073,
+    18446744073709551615,
+    18446744073709551615,
+    513398556346534256,
+]);
+
+/// Cairo string for "deploy_account" from starknet-rs
+pub(crate) const PREFIX_DEPLOY_ACCOUNT: FieldElement = FieldElement::from_mont([
+    3350261884043292318,
+    18443211694809419988,
+    18446744073709551615,
+    461298303000467581,
+]);

--- a/crates/starknet-devnet-types/src/constants.rs
+++ b/crates/starknet-devnet-types/src/constants.rs
@@ -1,3 +1,5 @@
+use starknet_rs_ff::FieldElement;
+
 pub const OUTPUT_BUILTIN_NAME: &str = "output_builtin";
 pub const HASH_BUILTIN_NAME: &str = "pedersen_builtin";
 pub const RANGE_CHECK_BUILTIN_NAME: &str = "range_check_builtin";
@@ -8,3 +10,11 @@ pub const KECCAK_BUILTIN_NAME: &str = "keccak_builtin";
 pub const POSEIDON_BUILTIN_NAME: &str = "poseidon_builtin";
 pub const SEGMENT_ARENA_BUILTIN_NAME: &str = "segment_arena_builtin";
 pub const N_STEPS: &str = "n_steps";
+
+// copied from starknet-rs, because it is not exposed as public type
+pub const QUERY_VERSION_OFFSET: FieldElement = FieldElement::from_mont([
+    18446744073700081665,
+    17407,
+    18446744073709551584,
+    576460752142434320,
+]);

--- a/crates/starknet-devnet-types/src/rpc/transactions.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions.rs
@@ -501,7 +501,7 @@ impl BroadcastedDeclareTransaction {
         let (transaction_hash, sn_api_transaction, class_info, version) = match self {
             BroadcastedDeclareTransaction::V1(v1) => {
                 let class_hash = v1.generate_class_hash()?;
-                let transaction_hash = v1.calculate_transaction_hash(&chain_id, &class_hash)?;
+                let transaction_hash = v1.calculate_transaction_hash(chain_id, &class_hash)?;
 
                 let sn_api_declare = starknet_api::transaction::DeclareTransaction::V1(
                     starknet_api::transaction::DeclareTransactionV0V1 {

--- a/crates/starknet-devnet-types/src/rpc/transactions.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions.rs
@@ -439,17 +439,16 @@ impl BroadcastedTransaction {
     pub fn to_blockifier_account_transaction(
         &self,
         chain_id: Felt,
-        only_query: bool,
     ) -> DevnetResult<blockifier::transaction::account_transaction::AccountTransaction> {
         let blockifier_transaction = match self {
             BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V1(invoke_txn)) => {
                 let blockifier_invoke_txn =
-                    invoke_txn.create_blockifier_invoke_transaction(chain_id, only_query)?;
+                    invoke_txn.create_blockifier_invoke_transaction(chain_id)?;
                 AccountTransaction::Invoke(blockifier_invoke_txn)
             }
             BroadcastedTransaction::Invoke(BroadcastedInvokeTransaction::V3(invoke_txn)) => {
                 let blockifier_invoke_txn =
-                    invoke_txn.create_blockifier_invoke_transaction(chain_id, only_query)?;
+                    invoke_txn.create_blockifier_invoke_transaction(chain_id)?;
                 AccountTransaction::Invoke(blockifier_invoke_txn)
             }
             BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V1(declare_v1)) => {
@@ -464,19 +463,17 @@ impl BroadcastedTransaction {
                 AccountTransaction::Declare(declare_v2.create_blockifier_declare(chain_id)?)
             }
             BroadcastedTransaction::Declare(BroadcastedDeclareTransaction::V3(declare_v3)) => {
-                AccountTransaction::Declare(
-                    declare_v3.create_blockifier_declare(chain_id, only_query)?,
-                )
+                AccountTransaction::Declare(declare_v3.create_blockifier_declare(chain_id)?)
             }
             BroadcastedTransaction::DeployAccount(BroadcastedDeployAccountTransaction::V1(
                 deploy_account_v1,
             )) => AccountTransaction::DeployAccount(
-                deploy_account_v1.create_blockifier_deploy_account(chain_id, only_query)?,
+                deploy_account_v1.create_blockifier_deploy_account(chain_id)?,
             ),
             BroadcastedTransaction::DeployAccount(BroadcastedDeployAccountTransaction::V3(
                 deploy_account_v3,
             )) => AccountTransaction::DeployAccount(
-                deploy_account_v3.create_blockifier_deploy_account(chain_id, only_query)?,
+                deploy_account_v3.create_blockifier_deploy_account(chain_id)?,
             ),
         };
 

--- a/crates/starknet-devnet-types/src/rpc/transactions.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -99,6 +100,18 @@ pub enum TransactionType {
     Invoke,
     #[serde(rename(deserialize = "L1_HANDLER", serialize = "L1_HANDLER"))]
     L1Handler,
+}
+
+impl fmt::Display for TransactionType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TransactionType::Declare => write!(f, "Declare transaction"),
+            TransactionType::Deploy => write!(f, "Deploy transaction"),
+            TransactionType::DeployAccount => write!(f, "Deploy account transaction"),
+            TransactionType::Invoke => write!(f, "Invoke transaction"),
+            TransactionType::L1Handler => write!(f, "L1 handler transaction"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -261,6 +274,12 @@ pub struct BroadcastedTransactionCommon {
     pub version: TransactionVersion,
     pub signature: TransactionSignature,
     pub nonce: Nonce,
+}
+
+impl BroadcastedTransactionCommon {
+    pub fn is_max_fee_zero_value(&self) -> bool {
+        self.max_fee.0 == 0
+    }
 }
 
 /// Common fields for all transaction type of version 3
@@ -488,7 +507,25 @@ pub enum BroadcastedDeclareTransaction {
     V3(Box<BroadcastedDeclareTransactionV3>),
 }
 
+impl fmt::Display for BroadcastedDeclareTransaction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let txn_type = TransactionType::Declare;
+        match self {
+            BroadcastedDeclareTransaction::V1(_) => write!(f, "{} V1", txn_type),
+            BroadcastedDeclareTransaction::V2(_) => write!(f, "{} V2", txn_type),
+            BroadcastedDeclareTransaction::V3(_) => write!(f, "{} V3", txn_type),
+        }
+    }
+}
+
 impl BroadcastedDeclareTransaction {
+    pub fn is_max_fee_zero_value(&self) -> bool {
+        match self {
+            BroadcastedDeclareTransaction::V1(v1) => v1.common.is_max_fee_zero_value(),
+            BroadcastedDeclareTransaction::V2(v2) => v2.common.is_max_fee_zero_value(),
+            BroadcastedDeclareTransaction::V3(v3) => v3.common.is_max_fee_zero_value(),
+        }
+    }
     /// Creates a blockifier declare transaction from the current transaction.
     /// The transaction hash is computed using the given chain id.
     ///
@@ -615,7 +652,23 @@ pub enum BroadcastedDeployAccountTransaction {
     V3(BroadcastedDeployAccountTransactionV3),
 }
 
+impl fmt::Display for BroadcastedDeployAccountTransaction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let txn_type = TransactionType::DeployAccount;
+        match self {
+            BroadcastedDeployAccountTransaction::V1(_) => write!(f, "{} V1", txn_type),
+            BroadcastedDeployAccountTransaction::V3(_) => write!(f, "{} V3", txn_type),
+        }
+    }
+}
+
 impl BroadcastedDeployAccountTransaction {
+    pub fn is_max_fee_zero_value(&self) -> bool {
+        match self {
+            BroadcastedDeployAccountTransaction::V1(v1) => v1.common.is_max_fee_zero_value(),
+            BroadcastedDeployAccountTransaction::V3(v3) => v3.common.is_max_fee_zero_value(),
+        }
+    }
     /// Creates a blockifier deploy account transaction from the current transaction.
     /// The transaction hash is computed using the given chain id.
     ///
@@ -734,7 +787,23 @@ pub enum BroadcastedInvokeTransaction {
     V3(BroadcastedInvokeTransactionV3),
 }
 
+impl fmt::Display for BroadcastedInvokeTransaction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let txn_type = TransactionType::Invoke;
+        match self {
+            BroadcastedInvokeTransaction::V1(_) => write!(f, "{} V1", txn_type),
+            BroadcastedInvokeTransaction::V3(_) => write!(f, "{} V3", txn_type),
+        }
+    }
+}
+
 impl BroadcastedInvokeTransaction {
+    pub fn is_max_fee_zero_value(&self) -> bool {
+        match self {
+            BroadcastedInvokeTransaction::V1(v1) => v1.common.is_max_fee_zero_value(),
+            BroadcastedInvokeTransaction::V3(v3) => v3.common.is_max_fee_zero_value(),
+        }
+    }
     /// Creates a blockifier invoke transaction from the current transaction.
     /// The transaction hash is computed using the given chain id.
     ///

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v1.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v1.rs
@@ -13,6 +13,7 @@ pub(crate) const PREFIX_DECLARE: FieldElement = FieldElement::from_mont([
     191557713328401194,
 ]);
 
+use crate::constants::QUERY_VERSION_OFFSET;
 use crate::contract_address::ContractAddress;
 use crate::contract_class::{Cairo0ContractClass, ContractClass};
 use crate::error::DevnetResult;
@@ -72,11 +73,19 @@ impl BroadcastedDeclareTransactionV1 {
         let class_info: ClassInfo =
             ContractClass::Cairo0(self.contract_class.clone()).try_into()?;
 
-        Ok(DeclareTransaction::new(
-            sn_api_declare,
-            starknet_api::transaction::TransactionHash(transaction_hash.into()),
-            class_info,
-        )?)
+        if FieldElement::from(self.common.version) > QUERY_VERSION_OFFSET {
+            Ok(DeclareTransaction::new_for_query(
+                sn_api_declare,
+                starknet_api::transaction::TransactionHash(transaction_hash.into()),
+                class_info,
+            )?)
+        } else {
+            Ok(DeclareTransaction::new(
+                sn_api_declare,
+                starknet_api::transaction::TransactionHash(transaction_hash.into()),
+                class_info,
+            )?)
+        }
     }
 
     pub fn generate_class_hash(&self) -> DevnetResult<Felt> {

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v1.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v1.rs
@@ -5,21 +5,11 @@ use starknet_api::transaction::Fee;
 use starknet_rs_core::crypto::compute_hash_on_elements;
 use starknet_rs_ff::FieldElement;
 
-/// Cairo string for "declare" from starknet-rs
-pub(crate) const PREFIX_DECLARE: FieldElement = FieldElement::from_mont([
-    17542456862011667323,
-    18446744073709551615,
-    18446744073709551615,
-    191557713328401194,
-]);
-
-use crate::constants::QUERY_VERSION_OFFSET;
+use crate::constants::{PREFIX_DECLARE, QUERY_VERSION_OFFSET};
 use crate::contract_address::ContractAddress;
 use crate::contract_class::{Cairo0ContractClass, ContractClass};
 use crate::error::DevnetResult;
-use crate::felt::{
-    ClassHash, Felt, Nonce, TransactionHash, TransactionSignature, TransactionVersion,
-};
+use crate::felt::{ClassHash, Felt, Nonce, TransactionSignature, TransactionVersion};
 use crate::rpc::transactions::BroadcastedTransactionCommon;
 use crate::traits::HashProducer;
 
@@ -50,41 +40,6 @@ impl BroadcastedDeclareTransactionV1 {
                 version,
                 signature: signature.clone(),
             },
-        }
-    }
-
-    pub fn create_blockifier_declare(
-        &self,
-        class_hash: ClassHash,
-        transaction_hash: TransactionHash,
-    ) -> DevnetResult<DeclareTransaction> {
-        let sn_api_declare = starknet_api::transaction::DeclareTransaction::V1(
-            starknet_api::transaction::DeclareTransactionV0V1 {
-                class_hash: class_hash.into(),
-                sender_address: self.sender_address.try_into()?,
-                nonce: starknet_api::core::Nonce(self.common.nonce.into()),
-                max_fee: self.common.max_fee,
-                signature: starknet_api::transaction::TransactionSignature(
-                    self.common.signature.iter().map(|&felt| felt.into()).collect(),
-                ),
-            },
-        );
-
-        let class_info: ClassInfo =
-            ContractClass::Cairo0(self.contract_class.clone()).try_into()?;
-
-        if FieldElement::from(self.common.version) > QUERY_VERSION_OFFSET {
-            Ok(DeclareTransaction::new_for_query(
-                sn_api_declare,
-                starknet_api::transaction::TransactionHash(transaction_hash.into()),
-                class_info,
-            )?)
-        } else {
-            Ok(DeclareTransaction::new(
-                sn_api_declare,
-                starknet_api::transaction::TransactionHash(transaction_hash.into()),
-                class_info,
-            )?)
         }
     }
 
@@ -121,6 +76,7 @@ mod tests {
     use crate::contract_class::Cairo0Json;
     use crate::felt::Felt;
     use crate::rpc::transactions::broadcasted_declare_transaction_v1::BroadcastedDeclareTransactionV1;
+    use crate::rpc::transactions::{BroadcastedDeclareTransaction, BroadcastedTransaction};
     use crate::traits::{HashProducer, ToHexString};
 
     #[derive(Deserialize)]
@@ -167,13 +123,10 @@ mod tests {
             feeder_gateway_transaction.version,
         );
 
-        let class_hash = broadcasted_tx.generate_class_hash().unwrap();
-        let transaction_hash = broadcasted_tx
-            .calculate_transaction_hash(&ChainId::goerli_legacy_id(), &class_hash)
-            .unwrap();
-
         let blockifier_declare_transaction =
-            broadcasted_tx.create_blockifier_declare(class_hash, transaction_hash).unwrap();
+            BroadcastedDeclareTransaction::V1(Box::new(broadcasted_tx))
+                .create_blockifier_declare(&ChainId::goerli_legacy_id())
+                .unwrap();
 
         assert_eq!(
             feeder_gateway_transaction.transaction_hash,

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v1.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v1.rs
@@ -1,13 +1,13 @@
-use blockifier::execution::contract_class::ClassInfo;
-use blockifier::transaction::transactions::DeclareTransaction;
+
+
 use serde::{Deserialize, Serialize};
 use starknet_api::transaction::Fee;
 use starknet_rs_core::crypto::compute_hash_on_elements;
 use starknet_rs_ff::FieldElement;
 
-use crate::constants::{PREFIX_DECLARE, QUERY_VERSION_OFFSET};
+use crate::constants::{PREFIX_DECLARE};
 use crate::contract_address::ContractAddress;
-use crate::contract_class::{Cairo0ContractClass, ContractClass};
+use crate::contract_class::{Cairo0ContractClass};
 use crate::error::DevnetResult;
 use crate::felt::{ClassHash, Felt, Nonce, TransactionSignature, TransactionVersion};
 use crate::rpc::transactions::BroadcastedTransactionCommon;
@@ -76,7 +76,7 @@ mod tests {
     use crate::contract_class::Cairo0Json;
     use crate::felt::Felt;
     use crate::rpc::transactions::broadcasted_declare_transaction_v1::BroadcastedDeclareTransactionV1;
-    use crate::rpc::transactions::{BroadcastedDeclareTransaction, BroadcastedTransaction};
+    use crate::rpc::transactions::{BroadcastedDeclareTransaction};
     use crate::traits::{HashProducer, ToHexString};
 
     #[derive(Deserialize)]

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v1.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v1.rs
@@ -1,13 +1,11 @@
-
-
 use serde::{Deserialize, Serialize};
 use starknet_api::transaction::Fee;
 use starknet_rs_core::crypto::compute_hash_on_elements;
 use starknet_rs_ff::FieldElement;
 
-use crate::constants::{PREFIX_DECLARE};
+use crate::constants::PREFIX_DECLARE;
 use crate::contract_address::ContractAddress;
-use crate::contract_class::{Cairo0ContractClass};
+use crate::contract_class::Cairo0ContractClass;
 use crate::error::DevnetResult;
 use crate::felt::{ClassHash, Felt, Nonce, TransactionSignature, TransactionVersion};
 use crate::rpc::transactions::BroadcastedTransactionCommon;
@@ -76,7 +74,7 @@ mod tests {
     use crate::contract_class::Cairo0Json;
     use crate::felt::Felt;
     use crate::rpc::transactions::broadcasted_declare_transaction_v1::BroadcastedDeclareTransactionV1;
-    use crate::rpc::transactions::{BroadcastedDeclareTransaction};
+    use crate::rpc::transactions::BroadcastedDeclareTransaction;
     use crate::traits::{HashProducer, ToHexString};
 
     #[derive(Deserialize)]

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v2.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v2.rs
@@ -6,6 +6,7 @@ use starknet_rs_core::crypto::compute_hash_on_elements;
 use starknet_rs_ff::FieldElement;
 
 use super::broadcasted_declare_transaction_v1::PREFIX_DECLARE;
+use crate::constants::QUERY_VERSION_OFFSET;
 use crate::contract_address::ContractAddress;
 use crate::contract_class::{compute_sierra_class_hash, ContractClass};
 use crate::error::DevnetResult;
@@ -76,11 +77,19 @@ impl BroadcastedDeclareTransactionV2 {
         ])
         .into();
 
-        Ok(DeclareTransaction::new(
-            sn_api_declare,
-            starknet_api::transaction::TransactionHash(txn_hash.into()),
-            ContractClass::Cairo1(self.contract_class.clone()).try_into()?,
-        )?)
+        if FieldElement::from(self.common.version) > QUERY_VERSION_OFFSET {
+            Ok(DeclareTransaction::new_for_query(
+                sn_api_declare,
+                starknet_api::transaction::TransactionHash(txn_hash.into()),
+                ContractClass::Cairo1(self.contract_class.clone()).try_into()?,
+            )?)
+        } else {
+            Ok(DeclareTransaction::new(
+                sn_api_declare,
+                starknet_api::transaction::TransactionHash(txn_hash.into()),
+                ContractClass::Cairo1(self.contract_class.clone()).try_into()?,
+            )?)
+        }
     }
 }
 

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v2.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v2.rs
@@ -1,14 +1,8 @@
-
 use cairo_lang_starknet_classes::contract_class::ContractClass as SierraContractClass;
 use serde::{Deserialize, Serialize};
 use starknet_api::transaction::Fee;
 
-
-
-
 use crate::contract_address::ContractAddress;
-
-
 use crate::felt::{CompiledClassHash, Nonce, TransactionSignature, TransactionVersion};
 use crate::rpc::transactions::BroadcastedTransactionCommon;
 use crate::serde_helpers::rpc_sierra_contract_class_to_sierra_contract_class::deserialize_to_sierra_contract_class;

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v2.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v2.rs
@@ -5,8 +5,7 @@ use starknet_api::transaction::Fee;
 use starknet_rs_core::crypto::compute_hash_on_elements;
 use starknet_rs_ff::FieldElement;
 
-use super::broadcasted_declare_transaction_v1::PREFIX_DECLARE;
-use crate::constants::QUERY_VERSION_OFFSET;
+use crate::constants::{PREFIX_DECLARE, QUERY_VERSION_OFFSET};
 use crate::contract_address::ContractAddress;
 use crate::contract_class::{compute_sierra_class_hash, ContractClass};
 use crate::error::DevnetResult;
@@ -47,50 +46,6 @@ impl BroadcastedDeclareTransactionV2 {
             },
         }
     }
-
-    pub fn create_blockifier_declare(&self, chain_id: Felt) -> DevnetResult<DeclareTransaction> {
-        let sierra_class_hash: Felt = compute_sierra_class_hash(&self.contract_class)?;
-
-        let sn_api_declare = starknet_api::transaction::DeclareTransaction::V2(
-            starknet_api::transaction::DeclareTransactionV2 {
-                max_fee: self.common.max_fee,
-                signature: starknet_api::transaction::TransactionSignature(
-                    self.common.signature.iter().map(|&felt| felt.into()).collect(),
-                ),
-                nonce: starknet_api::core::Nonce(self.common.nonce.into()),
-                class_hash: sierra_class_hash.into(),
-                compiled_class_hash: self.compiled_class_hash.into(),
-                sender_address: self.sender_address.try_into()?,
-            },
-        );
-
-        let txn_hash: Felt = compute_hash_on_elements(&[
-            PREFIX_DECLARE,
-            self.common.version.into(),
-            self.sender_address.into(),
-            FieldElement::ZERO, // entry_point_selector
-            compute_hash_on_elements(&[sierra_class_hash.into()]),
-            self.common.max_fee.0.into(),
-            FieldElement::from(chain_id),
-            self.common.nonce.into(),
-            self.compiled_class_hash.into(),
-        ])
-        .into();
-
-        if FieldElement::from(self.common.version) > QUERY_VERSION_OFFSET {
-            Ok(DeclareTransaction::new_for_query(
-                sn_api_declare,
-                starknet_api::transaction::TransactionHash(txn_hash.into()),
-                ContractClass::Cairo1(self.contract_class.clone()).try_into()?,
-            )?)
-        } else {
-            Ok(DeclareTransaction::new(
-                sn_api_declare,
-                starknet_api::transaction::TransactionHash(txn_hash.into()),
-                ContractClass::Cairo1(self.contract_class.clone()).try_into()?,
-            )?)
-        }
-    }
 }
 
 #[cfg(test)]
@@ -103,6 +58,7 @@ mod tests {
     use crate::contract_class::ContractClass;
     use crate::felt::Felt;
     use crate::rpc::transactions::broadcasted_declare_transaction_v2::BroadcastedDeclareTransactionV2;
+    use crate::rpc::transactions::BroadcastedDeclareTransaction;
     use crate::traits::ToHexString;
 
     #[derive(Deserialize)]
@@ -153,9 +109,10 @@ mod tests {
             feeder_gateway_transaction.version,
         );
 
-        let blockifier_declare_transaction = broadcasted_declare_transaction
-            .create_blockifier_declare(ChainId::goerli_legacy_id())
-            .unwrap();
+        let blockifier_declare_transaction =
+            BroadcastedDeclareTransaction::V2(Box::new(broadcasted_declare_transaction))
+                .create_blockifier_declare(&ChainId::goerli_legacy_id())
+                .unwrap();
 
         assert_eq!(
             feeder_gateway_transaction.class_hash,

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v2.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v2.rs
@@ -1,15 +1,15 @@
-use blockifier::transaction::transactions::DeclareTransaction;
+
 use cairo_lang_starknet_classes::contract_class::ContractClass as SierraContractClass;
 use serde::{Deserialize, Serialize};
 use starknet_api::transaction::Fee;
-use starknet_rs_core::crypto::compute_hash_on_elements;
-use starknet_rs_ff::FieldElement;
 
-use crate::constants::{PREFIX_DECLARE, QUERY_VERSION_OFFSET};
+
+
+
 use crate::contract_address::ContractAddress;
-use crate::contract_class::{compute_sierra_class_hash, ContractClass};
-use crate::error::DevnetResult;
-use crate::felt::{CompiledClassHash, Felt, Nonce, TransactionSignature, TransactionVersion};
+
+
+use crate::felt::{CompiledClassHash, Nonce, TransactionSignature, TransactionVersion};
 use crate::rpc::transactions::BroadcastedTransactionCommon;
 use crate::serde_helpers::rpc_sierra_contract_class_to_sierra_contract_class::deserialize_to_sierra_contract_class;
 

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v3.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v3.rs
@@ -1,18 +1,18 @@
-use blockifier::transaction::transactions::DeclareTransaction;
+
 use cairo_lang_starknet_classes::contract_class::ContractClass as SierraContractClass;
 use serde::{Deserialize, Serialize};
-use starknet_api::transaction::DeclareTransactionV3;
+
 use starknet_rs_crypto::poseidon_hash_many;
 use starknet_rs_ff::FieldElement;
 
 use super::BroadcastedTransactionCommonV3;
-use crate::constants::{PREFIX_DECLARE, QUERY_VERSION_OFFSET};
+use crate::constants::{PREFIX_DECLARE};
 use crate::contract_address::ContractAddress;
-use crate::contract_class::{compute_sierra_class_hash, ContractClass};
+
 use crate::error::DevnetResult;
 use crate::felt::{ClassHash, CompiledClassHash, Felt};
 use crate::serde_helpers::rpc_sierra_contract_class_to_sierra_contract_class::deserialize_to_sierra_contract_class;
-use crate::utils::into_vec;
+
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v3.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v3.rs
@@ -1,18 +1,14 @@
-
 use cairo_lang_starknet_classes::contract_class::ContractClass as SierraContractClass;
 use serde::{Deserialize, Serialize};
-
 use starknet_rs_crypto::poseidon_hash_many;
 use starknet_rs_ff::FieldElement;
 
 use super::BroadcastedTransactionCommonV3;
-use crate::constants::{PREFIX_DECLARE};
+use crate::constants::PREFIX_DECLARE;
 use crate::contract_address::ContractAddress;
-
 use crate::error::DevnetResult;
 use crate::felt::{ClassHash, CompiledClassHash, Felt};
 use crate::serde_helpers::rpc_sierra_contract_class_to_sierra_contract_class::deserialize_to_sierra_contract_class;
-
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_deploy_account_transaction_v1.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_deploy_account_transaction_v1.rs
@@ -1,13 +1,5 @@
-
-
 use serde::{Deserialize, Serialize};
-
 use starknet_api::transaction::Fee;
-
-
-
-
-
 
 use crate::felt::{
     Calldata, ClassHash, ContractAddressSalt, Nonce, TransactionSignature, TransactionVersion,
@@ -104,7 +96,7 @@ mod tests {
 
         let blockifier_deploy_account_transaction =
             BroadcastedDeployAccountTransaction::V1(broadcasted_tx)
-                .create_blockifier_deploy_account(chain_id)
+                .create_blockifier_deploy_account(&chain_id)
                 .unwrap();
 
         assert_eq!(

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_deploy_account_transaction_v1.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_deploy_account_transaction_v1.rs
@@ -1,26 +1,18 @@
-use std::sync::Arc;
+
 
 use serde::{Deserialize, Serialize};
-use starknet_api::core::calculate_contract_address;
-use starknet_api::transaction::Fee;
-use starknet_rs_core::crypto::compute_hash_on_elements;
-use starknet_rs_ff::FieldElement;
 
-use crate::constants::QUERY_VERSION_OFFSET;
-use crate::contract_address::ContractAddress;
-use crate::error::DevnetResult;
+use starknet_api::transaction::Fee;
+
+
+
+
+
+
 use crate::felt::{
-    Calldata, ClassHash, ContractAddressSalt, Felt, Nonce, TransactionSignature, TransactionVersion,
+    Calldata, ClassHash, ContractAddressSalt, Nonce, TransactionSignature, TransactionVersion,
 };
 use crate::rpc::transactions::BroadcastedTransactionCommon;
-
-/// Cairo string for "deploy_account" from starknet-rs
-pub(crate) const PREFIX_DEPLOY_ACCOUNT: FieldElement = FieldElement::from_mont([
-    3350261884043292318,
-    18443211694809419988,
-    18446744073709551615,
-    461298303000467581,
-]);
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -54,62 +46,6 @@ impl BroadcastedDeployAccountTransactionV1 {
             },
         }
     }
-
-    pub fn create_blockifier_deploy_account(
-        &self,
-        chain_id: Felt,
-    ) -> DevnetResult<blockifier::transaction::transactions::DeployAccountTransaction> {
-        let contract_address = calculate_contract_address(
-            starknet_api::transaction::ContractAddressSalt(self.contract_address_salt.into()),
-            starknet_api::core::ClassHash(self.class_hash.into()),
-            &starknet_api::transaction::Calldata(Arc::new(
-                self.constructor_calldata.iter().map(|felt| felt.into()).collect(),
-            )),
-            starknet_api::core::ContractAddress::from(0u8),
-        )?;
-
-        let mut calldata_to_hash = vec![self.class_hash, self.contract_address_salt];
-        calldata_to_hash.extend(self.constructor_calldata.iter());
-
-        let calldata_to_hash: Vec<FieldElement> =
-            calldata_to_hash.into_iter().map(FieldElement::from).collect();
-
-        let transaction_hash: Felt = compute_hash_on_elements(&[
-            PREFIX_DEPLOY_ACCOUNT,
-            self.common.version.into(),
-            ContractAddress::from(contract_address).into(),
-            FieldElement::ZERO, // entry_point_selector
-            compute_hash_on_elements(&calldata_to_hash),
-            self.common.max_fee.0.into(),
-            chain_id.into(),
-            self.common.nonce.into(),
-        ])
-        .into();
-
-        let sn_api_transaction = starknet_api::transaction::DeployAccountTransactionV1 {
-            max_fee: self.common.max_fee,
-            signature: starknet_api::transaction::TransactionSignature(
-                self.common.signature.iter().map(|felt| felt.into()).collect(),
-            ),
-            nonce: starknet_api::core::Nonce(self.common.nonce.into()),
-            class_hash: self.class_hash.into(),
-            contract_address_salt: starknet_api::transaction::ContractAddressSalt(
-                self.contract_address_salt.into(),
-            ),
-            constructor_calldata: starknet_api::transaction::Calldata(Arc::new(
-                self.constructor_calldata.iter().map(|felt| felt.into()).collect(),
-            )),
-        };
-
-        let only_query = FieldElement::from(self.common.version) > QUERY_VERSION_OFFSET;
-
-        Ok(blockifier::transaction::transactions::DeployAccountTransaction {
-            tx: starknet_api::transaction::DeployAccountTransaction::V1(sn_api_transaction),
-            tx_hash: starknet_api::transaction::TransactionHash(transaction_hash.into()),
-            contract_address,
-            only_query,
-        })
-    }
 }
 
 #[cfg(test)]
@@ -121,6 +57,7 @@ mod tests {
     use crate::contract_address::ContractAddress;
     use crate::felt::Felt;
     use crate::rpc::transactions::broadcasted_deploy_account_transaction_v1::BroadcastedDeployAccountTransactionV1;
+    use crate::rpc::transactions::BroadcastedDeployAccountTransaction;
     use crate::traits::ToHexString;
 
     #[derive(Deserialize)]
@@ -166,7 +103,9 @@ mod tests {
         let chain_id = ChainId::goerli_legacy_id();
 
         let blockifier_deploy_account_transaction =
-            broadcasted_tx.create_blockifier_deploy_account(chain_id).unwrap();
+            BroadcastedDeployAccountTransaction::V1(broadcasted_tx)
+                .create_blockifier_deploy_account(chain_id)
+                .unwrap();
 
         assert_eq!(
             ContractAddress::new(feeder_gateway_transaction.contract_address).unwrap(),

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_deploy_account_transaction_v3.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_deploy_account_transaction_v3.rs
@@ -2,12 +2,10 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use starknet_api::core::calculate_contract_address;
-
 use starknet_rs_crypto::poseidon_hash_many;
 
-
 use super::BroadcastedTransactionCommonV3;
-use crate::constants::{PREFIX_DEPLOY_ACCOUNT};
+use crate::constants::PREFIX_DEPLOY_ACCOUNT;
 use crate::contract_address::ContractAddress;
 use crate::error::DevnetResult;
 use crate::felt::{Calldata, ClassHash, ContractAddressSalt, Felt};
@@ -26,7 +24,7 @@ pub struct BroadcastedDeployAccountTransactionV3 {
 impl BroadcastedDeployAccountTransactionV3 {
     pub(crate) fn calculate_transaction_hash(
         &self,
-        chain_id: Felt,
+        chain_id: &Felt,
         contract_address: ContractAddress,
     ) -> DevnetResult<Felt> {
         let common_fields = self.common.common_fields_for_hash(
@@ -144,7 +142,7 @@ mod tests {
             feeder_gateway_transaction.transaction_hash,
             broadcasted_txn
                 .calculate_transaction_hash(
-                    ChainId::goerli_legacy_id(),
+                    &ChainId::goerli_legacy_id(),
                     BroadcastedDeployAccountTransactionV3::calculate_contract_address(
                         &broadcasted_txn.contract_address_salt,
                         &broadcasted_txn.class_hash,

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_deploy_account_transaction_v3.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_deploy_account_transaction_v3.rs
@@ -4,9 +4,11 @@ use serde::{Deserialize, Serialize};
 use starknet_api::core::calculate_contract_address;
 use starknet_api::transaction::DeployAccountTransactionV3;
 use starknet_rs_crypto::poseidon_hash_many;
+use starknet_rs_ff::FieldElement;
 
 use super::broadcasted_deploy_account_transaction_v1::PREFIX_DEPLOY_ACCOUNT;
 use super::BroadcastedTransactionCommonV3;
+use crate::constants::QUERY_VERSION_OFFSET;
 use crate::contract_address::ContractAddress;
 use crate::error::DevnetResult;
 use crate::felt::{Calldata, ClassHash, ContractAddressSalt, Felt};
@@ -69,7 +71,6 @@ impl BroadcastedDeployAccountTransactionV3 {
     pub fn create_blockifier_deploy_account(
         &self,
         chain_id: Felt,
-        only_query: bool,
     ) -> DevnetResult<blockifier::transaction::transactions::DeployAccountTransaction> {
         let contract_address = Self::calculate_contract_address(
             &self.contract_address_salt,
@@ -100,6 +101,8 @@ impl BroadcastedDeployAccountTransactionV3 {
                     &self.constructor_calldata,
                 ))),
             });
+
+        let only_query = FieldElement::from(self.common.version) > QUERY_VERSION_OFFSET;
 
         Ok(blockifier::transaction::transactions::DeployAccountTransaction {
             tx: sn_api_deploy_account,

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_deploy_account_transaction_v3.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_deploy_account_transaction_v3.rs
@@ -2,13 +2,12 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use starknet_api::core::calculate_contract_address;
-use starknet_api::transaction::DeployAccountTransactionV3;
-use starknet_rs_crypto::poseidon_hash_many;
-use starknet_rs_ff::FieldElement;
 
-use super::broadcasted_deploy_account_transaction_v1::PREFIX_DEPLOY_ACCOUNT;
+use starknet_rs_crypto::poseidon_hash_many;
+
+
 use super::BroadcastedTransactionCommonV3;
-use crate::constants::QUERY_VERSION_OFFSET;
+use crate::constants::{PREFIX_DEPLOY_ACCOUNT};
 use crate::contract_address::ContractAddress;
 use crate::error::DevnetResult;
 use crate::felt::{Calldata, ClassHash, ContractAddressSalt, Felt};
@@ -25,7 +24,7 @@ pub struct BroadcastedDeployAccountTransactionV3 {
 }
 
 impl BroadcastedDeployAccountTransactionV3 {
-    fn calculate_transaction_hash(
+    pub(crate) fn calculate_transaction_hash(
         &self,
         chain_id: Felt,
         contract_address: ContractAddress,
@@ -51,7 +50,7 @@ impl BroadcastedDeployAccountTransactionV3 {
         Ok(txn_hash.into())
     }
 
-    fn calculate_contract_address(
+    pub(crate) fn calculate_contract_address(
         contract_address_salt: &Felt,
         class_hash: &ClassHash,
         constructor_calldata: &Calldata,
@@ -66,50 +65,6 @@ impl BroadcastedDeployAccountTransactionV3 {
         )?;
 
         Ok(ContractAddress::from(contract_address))
-    }
-
-    pub fn create_blockifier_deploy_account(
-        &self,
-        chain_id: Felt,
-    ) -> DevnetResult<blockifier::transaction::transactions::DeployAccountTransaction> {
-        let contract_address = Self::calculate_contract_address(
-            &self.contract_address_salt,
-            &self.class_hash,
-            &self.constructor_calldata,
-        )?;
-
-        let transaction_hash = self.calculate_transaction_hash(chain_id, contract_address)?;
-
-        let sn_api_deploy_account =
-            starknet_api::transaction::DeployAccountTransaction::V3(DeployAccountTransactionV3 {
-                resource_bounds: (&self.common.resource_bounds).into(),
-                tip: self.common.tip,
-                signature: starknet_api::transaction::TransactionSignature(into_vec(
-                    &self.common.signature,
-                )),
-                nonce: starknet_api::core::Nonce(self.common.nonce.into()),
-                class_hash: starknet_api::core::ClassHash(self.class_hash.into()),
-                nonce_data_availability_mode: self.common.nonce_data_availability_mode,
-                fee_data_availability_mode: self.common.fee_data_availability_mode,
-                paymaster_data: starknet_api::transaction::PaymasterData(into_vec(
-                    &self.common.paymaster_data,
-                )),
-                contract_address_salt: starknet_api::transaction::ContractAddressSalt(
-                    self.contract_address_salt.into(),
-                ),
-                constructor_calldata: starknet_api::transaction::Calldata(Arc::new(into_vec(
-                    &self.constructor_calldata,
-                ))),
-            });
-
-        let only_query = FieldElement::from(self.common.version) > QUERY_VERSION_OFFSET;
-
-        Ok(blockifier::transaction::transactions::DeployAccountTransaction {
-            tx: sn_api_deploy_account,
-            tx_hash: starknet_api::transaction::TransactionHash(transaction_hash.into()),
-            contract_address: contract_address.try_into()?,
-            only_query,
-        })
     }
 }
 

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_invoke_transaction_v1.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_invoke_transaction_v1.rs
@@ -1,18 +1,9 @@
 use serde::{Deserialize, Serialize};
 use starknet_api::transaction::Fee;
-use starknet_rs_ff::FieldElement;
 
 use crate::contract_address::ContractAddress;
 use crate::felt::{Calldata, Nonce, TransactionSignature, TransactionVersion};
 use crate::rpc::transactions::BroadcastedTransactionCommon;
-
-/// Cairo string for "invoke" from starknet-rs
-pub(crate) const PREFIX_INVOKE: FieldElement = FieldElement::from_mont([
-    18443034532770911073,
-    18446744073709551615,
-    18446744073709551615,
-    513398556346534256,
-]);
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_invoke_transaction_v1.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_invoke_transaction_v1.rs
@@ -89,7 +89,7 @@ mod tests {
 
         let chain_id = ChainId::goerli_legacy_id();
         let blockifier_transaction = BroadcastedInvokeTransaction::V1(transaction)
-            .create_blockifier_invoke_transaction(chain_id)
+            .create_blockifier_invoke_transaction(&chain_id)
             .unwrap();
 
         assert_eq!(

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_invoke_transaction_v1.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_invoke_transaction_v1.rs
@@ -1,13 +1,7 @@
-use std::sync::Arc;
-
-use blockifier::transaction::transactions::InvokeTransaction;
 use serde::{Deserialize, Serialize};
-use starknet_api::hash::StarkFelt;
 use starknet_api::transaction::Fee;
-use starknet_rs_core::crypto::compute_hash_on_elements;
 use starknet_rs_ff::FieldElement;
 
-use super::BroadcastedTransaction;
 use crate::contract_address::ContractAddress;
 use crate::felt::{Calldata, Nonce, TransactionSignature, TransactionVersion};
 use crate::rpc::transactions::BroadcastedTransactionCommon;

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_invoke_transaction_v3.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_invoke_transaction_v3.rs
@@ -8,6 +8,7 @@ use starknet_rs_ff::FieldElement;
 
 use super::broadcasted_invoke_transaction_v1::PREFIX_INVOKE;
 use super::BroadcastedTransactionCommonV3;
+use crate::constants::QUERY_VERSION_OFFSET;
 use crate::contract_address::ContractAddress;
 use crate::error::DevnetResult;
 use crate::felt::{Calldata, Felt};
@@ -61,11 +62,9 @@ impl BroadcastedInvokeTransactionV3 {
     ///
     /// # Arguments
     /// `chain_id` - the chain id to use for the transaction hash computation
-    /// `only_query` - whether the transaction is a query or not
     pub fn create_blockifier_invoke_transaction(
         &self,
         chain_id: Felt,
-        only_query: bool,
     ) -> DevnetResult<InvokeTransaction> {
         let txn_hash = self.calculate_transaction_hash(chain_id)?;
 
@@ -89,6 +88,8 @@ impl BroadcastedInvokeTransactionV3 {
                 self.account_deployment_data.iter().map(|f| f.into()).collect(),
             ),
         };
+
+        let only_query = FieldElement::from(self.common.version) > QUERY_VERSION_OFFSET;
 
         Ok(InvokeTransaction {
             tx: starknet_api::transaction::InvokeTransaction::V3(sn_api_transaction),

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_invoke_transaction_v3.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_invoke_transaction_v3.rs
@@ -1,18 +1,12 @@
-use std::sync::Arc;
-
-use blockifier::transaction::transactions::InvokeTransaction;
 use serde::{Deserialize, Serialize};
-use starknet_api::hash::StarkFelt;
 use starknet_rs_crypto::poseidon_hash_many;
 use starknet_rs_ff::FieldElement;
 
 use super::broadcasted_invoke_transaction_v1::PREFIX_INVOKE;
 use super::BroadcastedTransactionCommonV3;
-use crate::constants::QUERY_VERSION_OFFSET;
 use crate::contract_address::ContractAddress;
 use crate::error::DevnetResult;
 use crate::felt::{Calldata, Felt};
-use crate::utils::into_vec;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -30,7 +24,7 @@ impl BroadcastedInvokeTransactionV3 {
     ///
     /// # Arguments
     /// `chain_id` - the chain id to use for the transaction hash computation
-    fn calculate_transaction_hash(&self, chain_id: Felt) -> DevnetResult<Felt> {
+    pub(crate) fn calculate_transaction_hash(&self, chain_id: Felt) -> DevnetResult<Felt> {
         let common_fields = self.common.common_fields_for_hash(
             PREFIX_INVOKE,
             chain_id.into(),
@@ -55,47 +49,6 @@ impl BroadcastedInvokeTransactionV3 {
         let txn_hash = poseidon_hash_many(fields_to_hash.as_slice());
 
         Ok(txn_hash.into())
-    }
-
-    /// Creates a blockifier invoke transaction from the current transaction.
-    /// The transaction hash is computed using the given chain id.
-    ///
-    /// # Arguments
-    /// `chain_id` - the chain id to use for the transaction hash computation
-    pub fn create_blockifier_invoke_transaction(
-        &self,
-        chain_id: Felt,
-    ) -> DevnetResult<InvokeTransaction> {
-        let txn_hash = self.calculate_transaction_hash(chain_id)?;
-
-        let sn_api_transaction = starknet_api::transaction::InvokeTransactionV3 {
-            resource_bounds: (&self.common.resource_bounds).into(),
-            tip: self.common.tip,
-            signature: starknet_api::transaction::TransactionSignature(into_vec(
-                &self.common.signature,
-            )),
-            nonce: starknet_api::core::Nonce(self.common.nonce.into()),
-            sender_address: self.sender_address.try_into()?,
-            calldata: starknet_api::transaction::Calldata(Arc::new(
-                self.calldata.iter().map(StarkFelt::from).collect::<Vec<StarkFelt>>(),
-            )),
-            nonce_data_availability_mode: self.common.nonce_data_availability_mode,
-            fee_data_availability_mode: self.common.fee_data_availability_mode,
-            paymaster_data: starknet_api::transaction::PaymasterData(
-                self.common.paymaster_data.iter().map(|f| f.into()).collect(),
-            ),
-            account_deployment_data: starknet_api::transaction::AccountDeploymentData(
-                self.account_deployment_data.iter().map(|f| f.into()).collect(),
-            ),
-        };
-
-        let only_query = FieldElement::from(self.common.version) > QUERY_VERSION_OFFSET;
-
-        Ok(InvokeTransaction {
-            tx: starknet_api::transaction::InvokeTransaction::V3(sn_api_transaction),
-            tx_hash: starknet_api::transaction::TransactionHash(txn_hash.into()),
-            only_query,
-        })
     }
 }
 

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_invoke_transaction_v3.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_invoke_transaction_v3.rs
@@ -24,7 +24,7 @@ impl BroadcastedInvokeTransactionV3 {
     ///
     /// # Arguments
     /// `chain_id` - the chain id to use for the transaction hash computation
-    pub(crate) fn calculate_transaction_hash(&self, chain_id: Felt) -> DevnetResult<Felt> {
+    pub(crate) fn calculate_transaction_hash(&self, chain_id: &Felt) -> DevnetResult<Felt> {
         let common_fields = self.common.common_fields_for_hash(
             PREFIX_INVOKE,
             chain_id.into(),
@@ -126,7 +126,7 @@ mod tests {
 
         assert_eq!(
             feeder_gateway_transaction.transaction_hash,
-            broadcasted_txn.calculate_transaction_hash(ChainId::goerli_legacy_id()).unwrap()
+            broadcasted_txn.calculate_transaction_hash(&ChainId::goerli_legacy_id()).unwrap()
         );
     }
 }

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_invoke_transaction_v3.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_invoke_transaction_v3.rs
@@ -2,8 +2,8 @@ use serde::{Deserialize, Serialize};
 use starknet_rs_crypto::poseidon_hash_many;
 use starknet_rs_ff::FieldElement;
 
-use super::broadcasted_invoke_transaction_v1::PREFIX_INVOKE;
 use super::BroadcastedTransactionCommonV3;
+use crate::constants::PREFIX_INVOKE;
 use crate::contract_address::ContractAddress;
 use crate::error::DevnetResult;
 use crate::felt::{Calldata, Felt};

--- a/crates/starknet-devnet/tests/common/background_anvil.rs
+++ b/crates/starknet-devnet/tests/common/background_anvil.rs
@@ -1,6 +1,6 @@
 use std::process::{Child, Command};
 use std::sync::Arc;
-use std::{thread, time};
+use std::{time};
 
 use ethers::prelude::*;
 use ethers::providers::{Http, Provider};

--- a/crates/starknet-devnet/tests/common/background_anvil.rs
+++ b/crates/starknet-devnet/tests/common/background_anvil.rs
@@ -1,6 +1,6 @@
 use std::process::{Child, Command};
 use std::sync::Arc;
-use std::{time};
+use std::time;
 
 use ethers::prelude::*;
 use ethers::providers::{Http, Provider};

--- a/crates/starknet-devnet/tests/common/background_anvil.rs
+++ b/crates/starknet-devnet/tests/common/background_anvil.rs
@@ -62,7 +62,7 @@ impl BackgroundAnvil {
             }
 
             retries += 1;
-            thread::sleep(time::Duration::from_millis(500));
+            tokio::time::sleep(time::Duration::from_millis(500)).await;
         }
 
         Err(TestError::AnvilNotStartable)

--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fmt::LowerHex;
 use std::net::TcpListener;
 use std::process::{Child, Command, Stdio};
-use std::{thread, time};
+use std::{time};
 
 use hyper::client::HttpConnector;
 use hyper::http::request;

--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fmt::LowerHex;
 use std::net::TcpListener;
 use std::process::{Child, Command, Stdio};
-use std::{time};
+use std::time;
 
 use hyper::client::HttpConnector;
 use hyper::http::request;

--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -145,7 +145,7 @@ impl BackgroundDevnet {
             // otherwise there is an error, probably a ConnectError if Devnet is not yet up
             // so we retry after some sleep
             retries += 1;
-            thread::sleep(time::Duration::from_millis(500));
+            tokio::time::sleep(time::Duration::from_millis(500)).await;
         }
 
         Err(TestError::DevnetNotStartable)

--- a/crates/starknet-devnet/tests/common/utils.rs
+++ b/crates/starknet-devnet/tests/common/utils.rs
@@ -148,7 +148,7 @@ pub fn get_unix_timestamp_as_seconds() -> u64 {
 
 pub async fn send_ctrl_c_signal_and_wait(process: &Child) {
     send_ctrl_c_signal(process).await;
-    std::thread::sleep(std::time::Duration::from_secs(1));
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 }
 
 async fn send_ctrl_c_signal(process: &Child) {

--- a/crates/starknet-devnet/tests/test_advancing_time.rs
+++ b/crates/starknet-devnet/tests/test_advancing_time.rs
@@ -3,7 +3,7 @@ pub mod common;
 mod advancing_time_tests {
 
     use std::sync::Arc;
-    use std::{time};
+    use std::time;
 
     use hyper::Body;
     use serde_json::json;

--- a/crates/starknet-devnet/tests/test_advancing_time.rs
+++ b/crates/starknet-devnet/tests/test_advancing_time.rs
@@ -153,7 +153,7 @@ mod advancing_time_tests {
         assert_ge_with_buffer(current_timestamp, now + increase_time);
 
         // wait 1 second, mine block
-        thread::sleep(time::Duration::from_secs(1));
+        tokio::time::sleep(time::Duration::from_secs(1)).await;
         devnet.create_block().await.unwrap();
 
         // check if timestamp is greater
@@ -171,7 +171,7 @@ mod advancing_time_tests {
         let timestamp_contract_address = setup_timestamp_contract(&devnet).await;
 
         // wait 1 second
-        thread::sleep(time::Duration::from_secs(1));
+        tokio::time::sleep(time::Duration::from_secs(1)).await;
 
         // check constructor set of timestamp
         let call_storage_timestamp = FunctionCall {
@@ -190,7 +190,7 @@ mod advancing_time_tests {
         assert_gt_with_buffer(storage_timestamp, now);
 
         // wait 1 second and mine block
-        thread::sleep(time::Duration::from_secs(1));
+        tokio::time::sleep(time::Duration::from_secs(1)).await;
         devnet.create_block().await.unwrap();
 
         // check if current timestamp > storage timestamp and now
@@ -249,7 +249,7 @@ mod advancing_time_tests {
         assert_ge_with_buffer(set_time_block.timestamp, past_time);
 
         // wait 1 second
-        thread::sleep(time::Duration::from_secs(1));
+        tokio::time::sleep(time::Duration::from_secs(1)).await;
 
         // create block and check if block_timestamp > past_time, check if inside buffer limit
         devnet.create_block().await.unwrap();
@@ -257,7 +257,7 @@ mod advancing_time_tests {
         assert_gt_with_buffer(empty_block.timestamp, past_time);
 
         // wait 1 second
-        thread::sleep(time::Duration::from_secs(1));
+        tokio::time::sleep(time::Duration::from_secs(1)).await;
 
         // check if after mint timestamp > last block, check if inside buffer limit
         devnet.mint(DUMMY_ADDRESS, DUMMY_AMOUNT).await;
@@ -279,7 +279,7 @@ mod advancing_time_tests {
         assert_ge_with_buffer(set_time_block.timestamp, future_time);
 
         // wait 1 second
-        thread::sleep(time::Duration::from_secs(1));
+        tokio::time::sleep(time::Duration::from_secs(1)).await;
 
         // create block and check if block_timestamp > future_time, check if inside buffer limit
         devnet.create_block().await.unwrap();
@@ -287,7 +287,7 @@ mod advancing_time_tests {
         assert_gt_with_buffer(empty_block.timestamp, future_time);
 
         // wait 1 second
-        thread::sleep(time::Duration::from_secs(1));
+        tokio::time::sleep(time::Duration::from_secs(1)).await;
 
         // check if after mint timestamp > last empty block, check if inside buffer limit
         devnet.mint(DUMMY_ADDRESS, DUMMY_AMOUNT).await;
@@ -341,7 +341,7 @@ mod advancing_time_tests {
         );
 
         // wait 1 second
-        thread::sleep(time::Duration::from_secs(1));
+        tokio::time::sleep(time::Duration::from_secs(1)).await;
 
         // create block and check again if block_timestamp > last block, check if
         // inside buffer limit
@@ -350,7 +350,7 @@ mod advancing_time_tests {
         assert_gt_with_buffer(empty_block.timestamp, second_increase_time_block.timestamp);
 
         // wait 1 second
-        thread::sleep(time::Duration::from_secs(1));
+        tokio::time::sleep(time::Duration::from_secs(1)).await;
 
         // check if after mint timestamp > last block, check if inside buffer limit
         devnet.mint(DUMMY_ADDRESS, DUMMY_AMOUNT).await;
@@ -465,7 +465,7 @@ mod advancing_time_tests {
         assert_ge_with_buffer(set_time_block.timestamp, now);
 
         // wait 1 second
-        thread::sleep(time::Duration::from_secs(1));
+        tokio::time::sleep(time::Duration::from_secs(1)).await;
 
         // create a new empty block and check again if block timestamp > set_time_block, check if
         // inside buffer limit
@@ -486,7 +486,7 @@ mod advancing_time_tests {
         );
 
         // wait 1 second
-        thread::sleep(time::Duration::from_secs(1));
+        tokio::time::sleep(time::Duration::from_secs(1)).await;
 
         // check if the last block timestamp is > previous block, check if inside buffer limit
         devnet.create_block().await.unwrap();
@@ -536,7 +536,7 @@ mod advancing_time_tests {
         assert!(resp_body_set_time["block_hash"].is_null());
 
         // wait 1 second
-        thread::sleep(time::Duration::from_secs(1));
+        tokio::time::sleep(time::Duration::from_secs(1)).await;
 
         // create block and assert
         devnet.create_block().await.unwrap();

--- a/crates/starknet-devnet/tests/test_advancing_time.rs
+++ b/crates/starknet-devnet/tests/test_advancing_time.rs
@@ -3,7 +3,7 @@ pub mod common;
 mod advancing_time_tests {
 
     use std::sync::Arc;
-    use std::{thread, time};
+    use std::{time};
 
     use hyper::Body;
     use serde_json::json;

--- a/crates/starknet-devnet/tests/test_dump_and_load.rs
+++ b/crates/starknet-devnet/tests/test_dump_and_load.rs
@@ -419,7 +419,7 @@ mod dump_and_load_tests {
         devnet_dump.post_json("/set_time".into(), set_time_body).await.unwrap();
 
         // wait 1 second
-        thread::sleep(time::Duration::from_secs(1));
+        tokio::time::sleep(time::Duration::from_secs(1)).await;
 
         devnet_dump.create_block().await.unwrap();
         devnet_dump.get_latest_block_with_tx_hashes().await.unwrap();

--- a/crates/starknet-devnet/tests/test_dump_and_load.rs
+++ b/crates/starknet-devnet/tests/test_dump_and_load.rs
@@ -2,7 +2,7 @@ pub mod common;
 
 mod dump_and_load_tests {
     use std::path::Path;
-    use std::{time};
+    use std::time;
 
     use hyper::Body;
     use serde_json::json;

--- a/crates/starknet-devnet/tests/test_dump_and_load.rs
+++ b/crates/starknet-devnet/tests/test_dump_and_load.rs
@@ -2,7 +2,7 @@ pub mod common;
 
 mod dump_and_load_tests {
     use std::path::Path;
-    use std::{thread, time};
+    use std::{time};
 
     use hyper::Body;
     use serde_json::json;

--- a/crates/starknet-devnet/tests/test_estimate_fee.rs
+++ b/crates/starknet-devnet/tests/test_estimate_fee.rs
@@ -4,9 +4,7 @@ mod estimate_fee_tests {
     use std::sync::Arc;
 
     use serde_json::json;
-    use starknet_core::constants::{
-        CAIRO_0_ACCOUNT_CONTRACT_HASH, QUERY_VERSION_BASE, UDC_CONTRACT_ADDRESS,
-    };
+    use starknet_core::constants::{CAIRO_0_ACCOUNT_CONTRACT_HASH, UDC_CONTRACT_ADDRESS};
     use starknet_core::utils::exported_test_utils::dummy_cairo_0_contract_class;
     use starknet_rs_accounts::{
         Account, AccountError, AccountFactory, AccountFactoryError, Call, ConnectedAccount,
@@ -23,6 +21,7 @@ mod estimate_fee_tests {
         cairo_short_string_to_felt, get_selector_from_name, get_udc_deployed_address, UdcUniqueness,
     };
     use starknet_rs_providers::{Provider, ProviderError};
+    use starknet_types::constants::QUERY_VERSION_OFFSET;
 
     use crate::common::background_devnet::BackgroundDevnet;
     use crate::common::constants::{
@@ -473,7 +472,7 @@ mod estimate_fee_tests {
             .await
             .expect("Cannot deploy");
 
-        let expected_version = QUERY_VERSION_BASE + FieldElement::ONE;
+        let expected_version = QUERY_VERSION_OFFSET + FieldElement::ONE;
         let calls = vec![Call {
             to: contract_address,
             selector: get_selector_from_name("assert_version").unwrap(),


### PR DESCRIPTION
## Usage related changes

closes #349 

## Development related changes

Refactor add_transaction methods. By combining handling cases of transaction versions
Replaced thread::sleep with Tokio::time::sleep in async methods
Added check for returning error when a query_only transaction is send in write endpoints

## Checklist:

- [ ] Checked the relevant parts of [development docs](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#development)
- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
- [ ] Performed code self-review
- [ ] Rebased to the latest commit of the target branch (or merged it into my branch)
- [ ] Updated the docs if needed, including the [TODO section](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#todo-to-reach-feature-parity-with-the-pythonic-devnet)
- [ ] Linked the issues which this PR resolves
- [ ] Updated the tests if needed; all passing ([execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#test-execution))
