### PR TITLE
Build binaries for publishing on GitHub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,8 @@ aliases:
     <<: *on_main
     requires:
       - build-and-test
+      - image-build-amd
+      - image-build-arm
       - binary-build
 
   - &linux_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,6 @@ jobs:
 
     environment:
       BIN_DIR: target/<< parameters.target_triplet >>/release
-      BIN_PATH: ${BIN_DIR}/starknet-devnet
 
       # for Docker image naming
       ARCH_SUFFIX: << parameters.arch >>
@@ -124,10 +123,11 @@ jobs:
               tar -xvz -C /tmp
       - run:
           name: Build
-          command: /tmp/cross build --release --target=<< parameters.target_triplet >>
+          # command: /tmp/cross build --release --target=<< parameters.target_triplet >>
+          command: mkdir -p ${BIN_DIR} && touch ${BIN_DIR}/starknet-devnet
       - run:
           name: Archive and compress artifact
-          command: tar -czvf << parameters.archive_path >> --directory ${BIN_DIR} ${BIN_PATH}
+          command: tar -czvf << parameters.archive_path >> --directory ${BIN_DIR} starknet-devnet
       - store_artifacts: # to later include them in github release
           path: << parameters.archive_path >>
       - when:
@@ -169,7 +169,7 @@ workflows:
           # <<: *on_main TODO
           matrix:
             parameters:
-              arch: [x86_64, aarch64]
+              arch: [x86_64] # TODO aarch64]
               platform: [unknown-linux-gnu] # TODO, unknown-linux-musl, apple-darwin]
           target_triplet: << matrix.arch >>-<< matrix.platform >>
           archive_path: starknet-devnet-<< matrix.arch >>-<< matrix.platform >>.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,12 +88,14 @@ jobs:
           name: Build
           command: cross build --release --target=${CIRCLE_JOB}
 
-  # aarch64-unknown-linux-gnu:
-  #   <<: *linux-binary-build
+  aarch64-unknown-linux-gnu:
+    <<: *linux-binary-build
 
-  # x86_64-unknown-linux-musl
+  x86_64-unknown-linux-musl:
+    <<: *linux-binary-build
 
-  # aarch64-unknown-linux-musl
+  aarch64-unknown-linux-musl:
+    <<: *linux-binary-build
 
   # aarch64-apple-darwin
 
@@ -154,7 +156,7 @@ workflows:
         # TODO disabled to test binary building
         # <<: *on_main
 
-      - aarch64-unknown-linux-gnu
+      # - aarch64-unknown-linux-gnu
 
       # TODO disabled image building; re-enable as part of binary-building jobs
       # - image-build-amd:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,11 +169,11 @@ workflows:
           cargo_cache_key: cargo-cache-{{ checksum "Cargo.lock" }}-{{ checksum "rust-toolchain.toml" }}-v1
 
       - build-binaries:
-          <<: *on_main
+          # <<: *on_main TODO
           matrix:
             parameters:
               arch: [x86_64, aarch64]
-              platform: [unknown-linux-gnu, unknown-linux-musl, apple-darwin]
+              platform: [unknown-linux-gnu] # TODO, unknown-linux-musl, apple-darwin]
           target_triplet: << matrix.arch >>-<< matrix.platform >>
 
       - publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,8 @@ aliases:
     <<: *on_main
     requires:
       - build-and-test
-      - image-build-amd
-      - image-build-arm
+      # - image-build-amd
+      # - image-build-arm
       - binary-build
 
   - &linux_build
@@ -122,8 +122,7 @@ jobs:
           command: /tmp/cross build --release --target=<< parameters.target_triplet >>
       - run:
           name: Archive and compress binary artifact # only the file, not the whole dir structure
-          command: tar -czvf << parameters.archive_path >> \
-            --directory target/<< parameters.target_triplet >>/release starknet-devnet
+          command: tar -czvf << parameters.archive_path >> --directory target/<< parameters.target_triplet >>/release starknet-devnet
       - store_artifacts: # to later include them in github release
           path: << parameters.archive_path >>
 
@@ -171,7 +170,7 @@ jobs:
 # Orchestrate jobs using workflows
 # See: https://circleci.com/docs/configuration-reference/#workflows
 workflows:
-  build-test-publish:
+  build-test-maybe-publish:
     jobs:
       - build-and-test:
           cargo_cache_key: cargo-cache-{{ checksum "Cargo.lock" }}-{{ checksum "rust-toolchain.toml" }}-v1
@@ -183,10 +182,10 @@ workflows:
               platform: [unknown-linux-gnu] # TODO, unknown-linux-musl, apple-darwin]
           target_triplet: << matrix.arch >>-<< matrix.platform >>
           archive_path: starknet-devnet-<< matrix.arch >>-<< matrix.platform >>.tar.gz
-      - image-build-amd:
-          <<: *on_main
-      - image-build-arm:
-          <<: *on_main
+      # - image-build-amd:
+      #     <<: *on_main
+      # - image-build-arm:
+      #     <<: *on_main
       # TODO uncomment
       #- publish:
       #    <<: *on_main_after_test_and_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ aliases:
     filters:
       branches:
         only:
-          - main
+          - github-binary # TODO: restore to main
 
   - &on_main_after_test_and_build
     <<: *on_main
@@ -101,53 +101,55 @@ jobs:
         type: string
 
     executor: << parameters.platform >>
-
     environment:
       BIN_DIR: target/<< parameters.target_triplet >>/release
 
-      # For validating Docker build
-      REMOTE: ""
-
-      # For Docker image naming
-      ARCH_SUFFIX: -<< parameters.arch >>
-
     steps:
-      - run:
-          name: DEBUG docker buildx
-          command: docker buildx ls && exit 1
       - checkout
       - run:
           name: Install Rust
-          # CIRCLE_JOB contains job name, which we define to be the target triplet
           command: |
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.74.0
       - run: rustup target add << parameters.target_triplet >>
       - run:
           name: Install Cross
           command: |
-            # curl -SsL https://github.com/cross-rs/cross/releases/download/v0.2.5/${COMPILER_ARCHIVE} |
-            #   tar -xvz -C /tmp
-            cargo install cross --git https://github.com/cross-rs/cross
+            curl -SsL https://github.com/cross-rs/cross/releases/download/v0.2.5/${COMPILER_ARCHIVE} |
+              tar -xvz -C /tmp
       - run:
-          name: Build
-          command: cross build --release --target=<< parameters.target_triplet >>
-          # command: /tmp/cross build --release --target=<< parameters.target_triplet >>
+          name: Compile binary
+          command: /tmp/cross build --release --target=<< parameters.target_triplet >>
       - run:
-          name: Archive and compress artifact
+          name: Archive and compress binary artifact
           command: tar -czvf << parameters.archive_path >> --directory ${BIN_DIR} starknet-devnet
       - store_artifacts: # to later include them in github release
           path: << parameters.archive_path >>
-      - when:
-          condition:
-            or:
-              - equal:
-                  [<< parameters.target_triplet >>, x86_64-unknown-linux-gnu]
-              - equal:
-                  [<< parameters.target_triplet >>, aarch64-unknown-linux-gnu]
-          steps:
-            - run:
-                name: Build Docker image
-                command: ./docker/image_build.sh
+
+  image-build-amd:
+    docker:
+      - image: cimg/base:2021.04
+    resource_class: large
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: docker23
+      - run:
+          name: Build amd images
+          command: ./docker/image_build.sh
+          environment:
+            ARCH_SUFFIX: -amd
+
+  image-build-arm:
+    machine:
+      image: ubuntu-2204:2024.01.2
+    resource_class: arm.large
+    steps:
+      - checkout
+      - run:
+          name: Build arm images
+          command: ./docker/image_build.sh
+          environment:
+            ARCH_SUFFIX: -arm
 
   publish:
     docker:
@@ -171,15 +173,17 @@ workflows:
     jobs:
       - build-and-test:
           cargo_cache_key: cargo-cache-{{ checksum "Cargo.lock" }}-{{ checksum "rust-toolchain.toml" }}-v1
-
       - build-binaries:
-          # TODO <<: *on_main
+          <<: *on_main
           matrix:
             parameters:
               arch: [x86_64, aarch64]
               platform: [unknown-linux-gnu] # TODO, unknown-linux-musl, apple-darwin]
           target_triplet: << matrix.arch >>-<< matrix.platform >>
           archive_path: starknet-devnet-<< matrix.arch >>-<< matrix.platform >>.tar.gz
-
+      - image-build-amd:
+          <<: *on_main
+      - image-build-arm:
+          <<: *on_main
       - publish:
           <<: *on_main_after_test_and_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,13 +169,12 @@ workflows:
           cargo_cache_key: cargo-cache-{{ checksum "Cargo.lock" }}-{{ checksum "rust-toolchain.toml" }}-v1
 
       - build-binaries:
+          <<: *on_main
           matrix:
             parameters:
               arch: [x86_64, aarch64]
               platform: [unknown-linux-gnu, unknown-linux-musl, apple-darwin]
           target_triplet: << matrix.arch >>-<< matrix.platform >>
-          # TODO uncomment before merge into main
-          # <<: *on_main
 
       - publish:
           <<: *on_main_after_test_and_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
           command: /tmp/cross build --release --target=<< parameters.target_triplet >>
       - run:
           name: Archive and compress artifact
-          command: tar -czvf ${BIN_PATH} ${ARCHIVE_PATH}
+          command: tar -czvf ${ARCHIVE_PATH} ${BIN_PATH}
       - store_artifacts:
           path: ${ARCHIVE_PATH}
           destination: ${ARCHIVE_NAME}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,32 @@ aliases:
       - image-build-amd
       - image-build-arm
 
+  - &binary_build
+    steps:
+      - checkout
+      - run:
+          name: Install Rust
+          command: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.74.0
+      - run:
+          name: Install Cross
+          command: |
+            curl -SsL https://github.com/cross-rs/cross/releases/download/v0.2.5/cross-x86_64-unknown-linux-gnu.tar.gz |
+            tar -xvz -C /home/circleci/bin/
+      - run:
+          name: Build
+          command: cross build --release --target=${CIRCLE_JOB}
+  
+  - &linux_binary_build
+    <<: *binary_build
+    machine:
+      image: ubuntu-2204:2024.01.2
+    resource_class: large
+
+  - &mac_binary_build
+    <<: *binary_build
+    macos:
+      xcode: 15.3.0
+
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/configuration-reference/#jobs
 jobs:
@@ -70,36 +96,23 @@ jobs:
           # fails if jobs not limited; read more in https://github.com/0xSpaceShard/starknet-devnet-rs/issues/378
           command: cargo test --jobs 3 --test '*' --no-fail-fast
 
-  x86_64-unknown-linux-gnu: &linux-binary-build
-    machine:
-      image: ubuntu-2204:2024.01.2
-    resource_class: large
-    steps:
-      - checkout
-      - run:
-          name: Install Rust
-          command: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-      - run:
-          name: Install Cross
-          command: |
-            curl -SsL https://github.com/cross-rs/cross/releases/download/v0.2.5/cross-x86_64-unknown-linux-gnu.tar.gz |
-            tar -xvz -C /home/circleci/bin/
-      - run:
-          name: Build
-          command: cross build --release --target=${CIRCLE_JOB}
+  x86_64-unknown-linux-gnu:
+    <<: *linux_binary_build
 
   aarch64-unknown-linux-gnu:
-    <<: *linux-binary-build
+    <<: *linux_binary_build
 
   x86_64-unknown-linux-musl:
-    <<: *linux-binary-build
+    <<: *linux_binary_build
 
   aarch64-unknown-linux-musl:
-    <<: *linux-binary-build
+    <<: *linux_binary_build
 
-  # aarch64-apple-darwin
+  aarch64-apple-darwin:
+    <<: *mac_binary_build
 
-  # x86_64-apple-darwin
+  x86_64-apple-darwin:
+    <<: *mac_binary_build
 
   image-build-amd:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,7 @@ aliases:
     <<: *on_main
     requires:
       - build-and-test
-      - image-build-amd
-      - image-build-arm
+      - build-binaries
 
   - &linux_build
     machine:
@@ -98,7 +97,19 @@ jobs:
         type: executor
       target_triplet:
         type: string
+
     executor: << parameters.platform >>
+
+    environment:
+      BIN_PATH: target/<< parameters.target_triplet >>/release/starknet-devnet
+      ARCHIVE_NAME: starknet-devnet-<< parameters.target_triplet >>.tar.gz
+      ARCHIVE_PATH: /tmp/${ARCHIVE_NAME}
+
+      # for Docker verification in image_build.sh
+      REMOTE: true
+
+      # for Docker image naming
+      ARCH_SUFFIX: << parameters.arch >>
 
     steps:
       - checkout
@@ -116,34 +127,23 @@ jobs:
       - run:
           name: Build
           command: /tmp/cross build --release --target=<< parameters.target_triplet >>
-
-  image-build-amd:
-    docker:
-      - image: cimg/base:2021.04
-    resource_class: large
-    steps:
-      - checkout
-      - setup_remote_docker:
-          version: docker23
       - run:
-          name: Build amd images
-          command: ./docker/image_build.sh
-          environment:
-            ARCH_SUFFIX: "-amd"
-            REMOTE: true
-
-  image-build-arm:
-    machine:
-      image: ubuntu-2004:202111-02
-    resource_class: arm.large
-    steps:
-      - checkout
-      - run:
-          name: Build arm images
-          command: ./docker/image_build.sh
-          environment:
-            ARCH_SUFFIX: -arm
-            REMOTE: ""
+          name: Archive and compress artifact
+          command: tar -czvf ${BIN_PATH} ${ARCHIVE_PATH}
+      - store_artifacts:
+          path: ${ARCHIVE_PATH}
+          destination: ${ARCHIVE_NAME}
+      - when:
+          condition:
+            or:
+              - equal:
+                  [<< parameters.target_triplet >>, x86_64-unknown-linux-gnu]
+              - equal:
+                  [<< parameters.target_triplet >>, aarch64-unknown-linux-gnu]
+          steps:
+            - run:
+                name: Build Docker image
+                command: ./docker/image_build.sh
 
   publish:
     docker:
@@ -165,9 +165,8 @@ jobs:
 workflows:
   main:
     jobs:
-      # TODO disabled testing
-      # - build-and-test:
-      #     cargo_cache_key: cargo-cache-{{ checksum "Cargo.lock" }}-{{ checksum "rust-toolchain.toml" }}-v1
+      - build-and-test:
+          cargo_cache_key: cargo-cache-{{ checksum "Cargo.lock" }}-{{ checksum "rust-toolchain.toml" }}-v1
 
       - build-binaries:
           matrix:
@@ -175,11 +174,8 @@ workflows:
               arch: [x86_64, aarch64]
               platform: [unknown-linux-gnu, unknown-linux-musl, apple-darwin]
           target_triplet: << matrix.arch >>-<< matrix.platform >>
+          # TODO uncomment before merge into main
+          # <<: *on_main
 
-      # TODO disabled image building; re-enable as part of binary-building jobs
-      # - image-build-amd:
-      #     <<: *on_main
-      # - image-build-arm:
-      #     <<: *on_main
-      # - publish:
-      #     <<: *on_main_after_test_and_build
+      - publish:
+          <<: *on_main_after_test_and_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ aliases:
   - &linux_build
     machine:
       image: ubuntu-2204:2024.01.2
-    resource_class: large
+    resource_class: arm.large
     environment:
       COMPILER_ARCHIVE: cross-x86_64-unknown-linux-gnu.tar.gz
 
@@ -172,7 +172,7 @@ workflows:
           matrix:
             parameters:
               arch: [x86_64, aarch64]
-              platform: [unknown-linux-gnu, unknown-linux-musl, apple-darwin]
+              platform: [unknown-linux-gnu] # TODO, unknown-linux-musl, apple-darwin]
           target_triplet: << matrix.arch >>-<< matrix.platform >>
           archive_path: starknet-devnet-<< matrix.arch >>-<< matrix.platform >>.tar.gz
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,16 +23,14 @@ aliases:
       - run:
           name: Install Rust
           command: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.74.0
-      - run: echo "$PATH"
       - run:
           name: Install Cross
           command: |
-            mkdir -p /home/tmp/
             curl -SsL https://github.com/cross-rs/cross/releases/download/v0.2.5/${COMPILER_ARCHIVE} |
-              tar -xvz -C /home/tmp
+              tar -xvz -C /tmp
       - run:
           name: Build
-          command: /home/tmp/cross build --release --target=${CIRCLE_JOB}
+          command: /tmp/cross build --release --target=${CIRCLE_JOB}
 
   - &linux_binary_build
     <<: *binary_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ aliases:
       image: ubuntu-2204:2024.01.2
     resource_class: large
     environment:
-      COMPILER_ARCHIVE: cross-aarch64-unknown-linux-gnu.tar.gz
+      COMPILER_ARCHIVE: cross-x86_64-unknown-linux-gnu.tar.gz
 
 executors:
   unknown-linux-gnu:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ aliases:
     <<: *on_main
     requires:
       - build-and-test
-      - build-binaries
+      - binary-build
 
   - &linux_build
     machine:
@@ -89,7 +89,7 @@ jobs:
           # fails if jobs not limited; read more in https://github.com/0xSpaceShard/starknet-devnet-rs/issues/378
           command: cargo test --jobs 3 --test '*' --no-fail-fast
 
-  build-binaries:
+  binary-build:
     parameters:
       arch:
         type: string
@@ -101,15 +101,14 @@ jobs:
         type: string
 
     executor: << parameters.platform >>
-    environment:
-      BIN_DIR: target/<< parameters.target_triplet >>/release
 
     steps:
       - checkout
       - run:
           name: Install Rust
           command: |
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.74.0
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
+              sh -s -- -y --default-toolchain=1.74.0
       - run: rustup target add << parameters.target_triplet >>
       - run:
           name: Install Cross
@@ -120,8 +119,9 @@ jobs:
           name: Compile binary
           command: /tmp/cross build --release --target=<< parameters.target_triplet >>
       - run:
-          name: Archive and compress binary artifact
-          command: tar -czvf << parameters.archive_path >> --directory ${BIN_DIR} starknet-devnet
+          name: Archive and compress binary artifact # only the file, not the whole dir structure
+          command: tar -czvf << parameters.archive_path >> \
+            --directory target/<< parameters.target_triplet >>/release starknet-devnet
       - store_artifacts: # to later include them in github release
           path: << parameters.archive_path >>
 
@@ -169,11 +169,11 @@ jobs:
 # Orchestrate jobs using workflows
 # See: https://circleci.com/docs/configuration-reference/#workflows
 workflows:
-  main:
+  build-test-publish:
     jobs:
       - build-and-test:
           cargo_cache_key: cargo-cache-{{ checksum "Cargo.lock" }}-{{ checksum "rust-toolchain.toml" }}-v1
-      - build-binaries:
+      - binary-build:
           <<: *on_main
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,34 +17,21 @@ aliases:
       - image-build-amd
       - image-build-arm
 
-  - &binary_build
-    steps:
-      - checkout
-      - run:
-          name: Install Rust
-          # CIRCLE_JOB contains job name, which we define to be the target triplet
-          command: |
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.74.0
-            rustup target add ${CIRCLE_JOB}
-      - run:
-          name: Install Cross
-          command: |
-            curl -SsL https://github.com/cross-rs/cross/releases/download/v0.2.5/${COMPILER_ARCHIVE} |
-              tar -xvz -C /tmp
-      - run:
-          name: Build
-          command: /tmp/cross build --release --target=${CIRCLE_JOB}
-
-  - &linux_binary_build
-    <<: *binary_build
+  - &linux_build
     machine:
       image: ubuntu-2204:2024.01.2
     resource_class: large
     environment:
       COMPILER_ARCHIVE: cross-x86_64-unknown-linux-gnu.tar.gz
 
-  - &mac_binary_build
-    <<: *binary_build
+executors:
+  unknown-linux-gnu:
+    <<: *linux_build
+
+  unknown-linux-musl:
+    <<: *linux_build
+
+  apple-darwin:
     macos:
       xcode: 15.3.0
     environment:
@@ -103,23 +90,32 @@ jobs:
           # fails if jobs not limited; read more in https://github.com/0xSpaceShard/starknet-devnet-rs/issues/378
           command: cargo test --jobs 3 --test '*' --no-fail-fast
 
-  x86_64-unknown-linux-gnu:
-    <<: *linux_binary_build
+  build-binaries:
+    parameters:
+      arch:
+        type: string
+      platform:
+        type: executor
+    executor: << parameters.platform >>
+    environment:
+      TARGET_TRIPLET: ${CIRCLE_JOB}
 
-  aarch64-unknown-linux-gnu:
-    <<: *linux_binary_build
-
-  x86_64-unknown-linux-musl:
-    <<: *linux_binary_build
-
-  aarch64-unknown-linux-musl:
-    <<: *linux_binary_build
-
-  aarch64-apple-darwin:
-    <<: *mac_binary_build
-
-  x86_64-apple-darwin:
-    <<: *mac_binary_build
+    steps:
+      - checkout
+      - run:
+          name: Install Rust
+          # CIRCLE_JOB contains job name, which we define to be the target triplet
+          command: |
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.74.0
+            rustup target add ${CIRCLE_JOB}
+      - run:
+          name: Install Cross
+          command: |
+            curl -SsL https://github.com/cross-rs/cross/releases/download/v0.2.5/${COMPILER_ARCHIVE} |
+              tar -xvz -C /tmp
+      - run:
+          name: Build
+          command: /tmp/cross build --release --target=${CIRCLE_JOB}
 
   image-build-amd:
     docker:
@@ -173,17 +169,11 @@ workflows:
       # - build-and-test:
       #     cargo_cache_key: cargo-cache-{{ checksum "Cargo.lock" }}-{{ checksum "rust-toolchain.toml" }}-v1
 
-      - x86_64-unknown-linux-gnu
-
-      - aarch64-unknown-linux-gnu
-
-      - x86_64-unknown-linux-musl
-
-      - aarch64-unknown-linux-musl
-
-      - aarch64-apple-darwin
-
-      - x86_64-apple-darwin
+      - build-binaries:
+          matrix:
+            parameters:
+              arch: [x86_64, aarch64]
+              platform: [unknown-linux-gnu, unknown-linux-musl, apple-darwin]
 
       # TODO disabled image building; re-enable as part of binary-building jobs
       # - image-build-amd:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,10 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install cross
+          name: Install Rust
+          command: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+      - run:
+          name: Install Cross
           command: |
             curl -SsL https://github.com/cross-rs/cross/releases/download/v0.2.5/cross-x86_64-unknown-linux-gnu.tar.gz |
             tar -xvz -C /home/circleci/bin/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,25 +23,31 @@ aliases:
       - run:
           name: Install Rust
           command: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.74.0
+      - run: echo "$PATH"
       - run:
           name: Install Cross
           command: |
-            curl -SsL https://github.com/cross-rs/cross/releases/download/v0.2.5/cross-x86_64-unknown-linux-gnu.tar.gz |
-            tar -xvz -C /home/circleci/bin/
+            mkdir -p /home/tmp/
+            curl -SsL https://github.com/cross-rs/cross/releases/download/v0.2.5/${COMPILER_ARCHIVE} |
+              tar -xvz -C /home/tmp
       - run:
           name: Build
-          command: cross build --release --target=${CIRCLE_JOB}
+          command: /home/tmp/cross build --release --target=${CIRCLE_JOB}
 
   - &linux_binary_build
     <<: *binary_build
     machine:
       image: ubuntu-2204:2024.01.2
     resource_class: large
+    environment:
+      COMPILER_ARCHIVE: cross-x86_64-unknown-linux-gnu.tar.gz
 
   - &mac_binary_build
     <<: *binary_build
     macos:
       xcode: 15.3.0
+    environment:
+      COMPILER_ARCHIVE: cross-x86_64-apple-darwin.tar.gz
 
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/configuration-reference/#jobs
@@ -166,13 +172,13 @@ workflows:
       # - build-and-test:
       #     cargo_cache_key: cargo-cache-{{ checksum "Cargo.lock" }}-{{ checksum "rust-toolchain.toml" }}-v1
 
-      - x86_64-unknown-linux-gnu
+      # - x86_64-unknown-linux-gnu
 
-      - aarch64-unknown-linux-gnu
+      # - aarch64-unknown-linux-gnu
 
-      - x86_64-unknown-linux-musl
+      # - x86_64-unknown-linux-musl
 
-      - aarch64-unknown-linux-musl
+      # - aarch64-unknown-linux-musl
 
       - aarch64-apple-darwin
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ aliases:
   - &linux_build
     machine:
       image: ubuntu-2204:2024.01.2
-    resource_class: arm.large
+    resource_class: large
     environment:
       COMPILER_ARCHIVE: cross-aarch64-unknown-linux-gnu.tar.gz
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ aliases:
       - run:
           name: Build
           command: cross build --release --target=${CIRCLE_JOB}
-  
+
   - &linux_binary_build
     <<: *binary_build
     machine:
@@ -165,11 +165,18 @@ workflows:
       # TODO disabled testing
       # - build-and-test:
       #     cargo_cache_key: cargo-cache-{{ checksum "Cargo.lock" }}-{{ checksum "rust-toolchain.toml" }}-v1
-      - x86_64-unknown-linux-gnu
-        # TODO disabled to test binary building
-        # <<: *on_main
 
-      # - aarch64-unknown-linux-gnu
+      - x86_64-unknown-linux-gnu
+
+      - aarch64-unknown-linux-gnu
+
+      - x86_64-unknown-linux-musl
+
+      - aarch64-unknown-linux-musl
+
+      - aarch64-apple-darwin
+
+      - x86_64-apple-darwin
 
       # TODO disabled image building; re-enable as part of binary-building jobs
       # - image-build-amd:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,13 +97,14 @@ jobs:
         type: executor
       target_triplet:
         type: string
+      archive_path:
+        type: string
 
     executor: << parameters.platform >>
 
     environment:
       BIN_DIR: target/<< parameters.target_triplet >>/release
       BIN_PATH: ${BIN_DIR}/starknet-devnet
-      ARCHIVE_PATH: starknet-devnet-<< parameters.target_triplet >>.tar.gz
 
       # for Docker image naming
       ARCH_SUFFIX: << parameters.arch >>
@@ -124,11 +125,12 @@ jobs:
       - run:
           name: Build
           command: /tmp/cross build --release --target=<< parameters.target_triplet >>
+      - run: tree target # TODO DEBUG
       - run:
           name: Archive and compress artifact
-          command: tar -czvf ${ARCHIVE_PATH} --directory ${BIN_DIR} ${BIN_PATH}
+          command: tar -czvf << parameters.archive_path >> --directory ${BIN_DIR} ${BIN_PATH}
       - store_artifacts: # to later include them in github release
-          path: ${ARCHIVE_PATH}
+          path: << parameters.archive_path >>
       - when:
           condition:
             or:
@@ -171,6 +173,7 @@ workflows:
               arch: [x86_64, aarch64]
               platform: [unknown-linux-gnu] # TODO, unknown-linux-musl, apple-darwin]
           target_triplet: << matrix.arch >>-<< matrix.platform >>
+          archive_path: starknet-devnet-<< matrix.arch >>-<< matrix.platform >>.tar.gz
 
       - publish:
           <<: *on_main_after_test_and_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,11 +166,11 @@ workflows:
           cargo_cache_key: cargo-cache-{{ checksum "Cargo.lock" }}-{{ checksum "rust-toolchain.toml" }}-v1
 
       - build-binaries:
-          # <<: *on_main TODO
+          <<: *on_main
           matrix:
             parameters:
-              arch: [x86_64] # TODO aarch64]
-              platform: [unknown-linux-gnu] # TODO, unknown-linux-musl, apple-darwin]
+              arch: [x86_64, aarch64]
+              platform: [unknown-linux-gnu, unknown-linux-musl, apple-darwin]
           target_triplet: << matrix.arch >>-<< matrix.platform >>
           archive_path: starknet-devnet-<< matrix.arch >>-<< matrix.platform >>.tar.gz
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,9 @@ jobs:
       ARCH_SUFFIX: -<< parameters.arch >>
 
     steps:
+      - run:
+          name: DEBUG docker buildx
+          command: docker buildx ls && exit 1
       - checkout
       - run:
           name: Install Rust

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
       REMOTE: ""
 
       # For Docker image naming
-      ARCH_SUFFIX: << parameters.arch >>
+      ARCH_SUFFIX: -<< parameters.arch >>
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,14 +8,14 @@ aliases:
     filters:
       branches:
         only:
-          - github-binary # TODO: restore to main
+          - main
 
   - &on_main_after_test_and_build
     <<: *on_main
     requires:
       - build-and-test
-      # - image-build-amd
-      # - image-build-arm
+      - image-build-amd
+      - image-build-arm
       - binary-build
 
   - &linux_build
@@ -179,13 +179,12 @@ workflows:
           matrix:
             parameters:
               arch: [x86_64, aarch64]
-              platform: [unknown-linux-gnu] # TODO, unknown-linux-musl, apple-darwin]
+              platform: [unknown-linux-gnu, unknown-linux-musl, apple-darwin]
           target_triplet: << matrix.arch >>-<< matrix.platform >>
           archive_path: starknet-devnet-<< matrix.arch >>-<< matrix.platform >>.tar.gz
-      # - image-build-amd:
-      #     <<: *on_main
-      # - image-build-arm:
-      #     <<: *on_main
-      # TODO uncomment
-      #- publish:
-      #    <<: *on_main_after_test_and_build
+      - image-build-amd:
+          <<: *on_main
+      - image-build-arm:
+          <<: *on_main
+      - publish:
+          <<: *on_main_after_test_and_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,10 @@ jobs:
     environment:
       BIN_DIR: target/<< parameters.target_triplet >>/release
 
-      # for Docker image naming
+      # For validating Docker build
+      REMOTE: ""
+
+      # For Docker image naming
       ARCH_SUFFIX: << parameters.arch >>
 
     steps:
@@ -123,8 +126,7 @@ jobs:
               tar -xvz -C /tmp
       - run:
           name: Build
-          # command: /tmp/cross build --release --target=<< parameters.target_triplet >>
-          command: mkdir -p ${BIN_DIR} && touch ${BIN_DIR}/starknet-devnet
+          command: /tmp/cross build --release --target=<< parameters.target_triplet >>
       - run:
           name: Archive and compress artifact
           command: tar -czvf << parameters.archive_path >> --directory ${BIN_DIR} starknet-devnet
@@ -166,11 +168,11 @@ workflows:
           cargo_cache_key: cargo-cache-{{ checksum "Cargo.lock" }}-{{ checksum "rust-toolchain.toml" }}-v1
 
       - build-binaries:
-          <<: *on_main
+          # TODO <<: *on_main
           matrix:
             parameters:
-              arch: [x86_64, aarch64]
-              platform: [unknown-linux-gnu, unknown-linux-musl, apple-darwin]
+              arch: [x86_64] # TODO, aarch64]
+              platform: [unknown-linux-gnu] # TODO, unknown-linux-musl, apple-darwin]
           target_triplet: << matrix.arch >>-<< matrix.platform >>
           archive_path: starknet-devnet-<< matrix.arch >>-<< matrix.platform >>.tar.gz
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,12 +101,9 @@ jobs:
     executor: << parameters.platform >>
 
     environment:
-      BIN_PATH: target/<< parameters.target_triplet >>/release/starknet-devnet
-      ARCHIVE_NAME: starknet-devnet-<< parameters.target_triplet >>.tar.gz
-      ARCHIVE_PATH: /tmp/${ARCHIVE_NAME}
-
-      # for Docker verification in image_build.sh
-      REMOTE: true
+      BIN_DIR: target/<< parameters.target_triplet >>/release
+      BIN_PATH: ${BIN_DIR}/starknet-devnet
+      ARCHIVE_PATH: starknet-devnet-<< parameters.target_triplet >>.tar.gz
 
       # for Docker image naming
       ARCH_SUFFIX: << parameters.arch >>
@@ -129,10 +126,9 @@ jobs:
           command: /tmp/cross build --release --target=<< parameters.target_triplet >>
       - run:
           name: Archive and compress artifact
-          command: tar -czvf ${ARCHIVE_PATH} ${BIN_PATH}
-      - store_artifacts:
+          command: tar -czvf ${ARCHIVE_PATH} --directory ${BIN_DIR} ${BIN_PATH}
+      - store_artifacts: # to later include them in github release
           path: ${ARCHIVE_PATH}
-          destination: ${ARCHIVE_NAME}
       - when:
           condition:
             or:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,8 @@ jobs:
     docker:
       - image: cimg/rust:1.74.0
     resource_class: large
+    environment:
+      CROSS_CONTAINER_IN_CONTAINER: true
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,34 @@ jobs:
           # fails if jobs not limited; read more in https://github.com/0xSpaceShard/starknet-devnet-rs/issues/378
           command: cargo test --jobs 3 --test '*' --no-fail-fast
 
+  x86_64-unknown-linux-gnu: &linux-binary-build
+    docker:
+      - image: cimg/rust:1.74.0
+    resource_class: large
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: docker23
+      - run:
+          name: Install cross
+          command: |
+            curl -SsL https://github.com/cross-rs/cross/releases/download/v0.2.5/cross-x86_64-unknown-linux-gnu.tar.gz |
+            tar -xvz -C /home/circleci/bin/
+      - run:
+          name: Build
+          command: cross build --release --target=${CIRCLE_JOB}
+
+  aarch64-unknown-linux-gnu:
+    <<: *linux-binary-build
+
+  # x86_64-unknown-linux-musl
+
+  # aarch64-unknown-linux-musl
+
+  # aarch64-apple-darwin
+
+  # x86_64-apple-darwin
+
   image-build-amd:
     docker:
       - image: cimg/base:2021.04
@@ -109,7 +137,6 @@ jobs:
       - run:
           name: Publish new versions to crates.io
           command: ./scripts/publish_cratesio_new_versions.sh
-
       - run:
           name: Create tags and push joint image manifests
           command: ./docker/tag_images_and_create_joint_image_manifests.sh
@@ -119,11 +146,19 @@ jobs:
 workflows:
   main:
     jobs:
-      - build-and-test:
-          cargo_cache_key: cargo-cache-{{ checksum "Cargo.lock" }}-{{ checksum "rust-toolchain.toml" }}-v1
-      - image-build-amd:
-          <<: *on_main
-      - image-build-arm:
-          <<: *on_main
-      - publish:
-          <<: *on_main_after_test_and_build
+      # TODO disabled testing
+      # - build-and-test:
+      #     cargo_cache_key: cargo-cache-{{ checksum "Cargo.lock" }}-{{ checksum "rust-toolchain.toml" }}-v1
+      - x86_64-unknown-linux-gnu
+        # TODO disabled to test binary building
+        # <<: *on_main
+
+      - aarch64-unknown-linux-gnu
+
+      # TODO disabled image building; re-enable as part of binary-building jobs
+      # - image-build-amd:
+      #     <<: *on_main
+      # - image-build-arm:
+      #     <<: *on_main
+      # - publish:
+      #     <<: *on_main_after_test_and_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,10 @@ aliases:
       - checkout
       - run:
           name: Install Rust
-          command: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.74.0
+          # CIRCLE_JOB contains job name, which we define to be the target triplet
+          command: |
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.74.0
+            rustup target add ${CIRCLE_JOB}
       - run:
           name: Install Cross
           command: |
@@ -30,9 +33,7 @@ aliases:
               tar -xvz -C /tmp
       - run:
           name: Build
-          command: |
-            rustup target add ${CIRCLE_JOB}
-            /tmp/cross build --release --target=${CIRCLE_JOB}
+          command: /tmp/cross build --release --target=${CIRCLE_JOB}
 
   - &linux_binary_build
     <<: *binary_build
@@ -172,13 +173,13 @@ workflows:
       # - build-and-test:
       #     cargo_cache_key: cargo-cache-{{ checksum "Cargo.lock" }}-{{ checksum "rust-toolchain.toml" }}-v1
 
-      # - x86_64-unknown-linux-gnu
+      - x86_64-unknown-linux-gnu
 
-      # - aarch64-unknown-linux-gnu
+      - aarch64-unknown-linux-gnu
 
-      # - x86_64-unknown-linux-musl
+      - x86_64-unknown-linux-musl
 
-      # - aarch64-unknown-linux-musl
+      - aarch64-unknown-linux-musl
 
       - aarch64-apple-darwin
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,5 +187,6 @@ workflows:
           <<: *on_main
       - image-build-arm:
           <<: *on_main
-      - publish:
-          <<: *on_main_after_test_and_build
+      # TODO uncomment
+      #- publish:
+      #    <<: *on_main_after_test_and_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
       - checkout
       - run:
           name: Install Rust
-          command: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+          command: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - run:
           name: Install Cross
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,15 +71,11 @@ jobs:
           command: cargo test --jobs 3 --test '*' --no-fail-fast
 
   x86_64-unknown-linux-gnu: &linux-binary-build
-    docker:
-      - image: cimg/rust:1.74.0
+    machine:
+      image: ubuntu-2204:2024.01.2
     resource_class: large
-    environment:
-      CROSS_CONTAINER_IN_CONTAINER: true
     steps:
       - checkout
-      - setup_remote_docker:
-          version: docker23
       - run:
           name: Install cross
           command: |
@@ -89,8 +85,8 @@ jobs:
           name: Build
           command: cross build --release --target=${CIRCLE_JOB}
 
-  aarch64-unknown-linux-gnu:
-    <<: *linux-binary-build
+  # aarch64-unknown-linux-gnu:
+  #   <<: *linux-binary-build
 
   # x86_64-unknown-linux-musl
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,11 +122,13 @@ jobs:
       - run:
           name: Install Cross
           command: |
-            curl -SsL https://github.com/cross-rs/cross/releases/download/v0.2.5/${COMPILER_ARCHIVE} |
-              tar -xvz -C /tmp
+            # curl -SsL https://github.com/cross-rs/cross/releases/download/v0.2.5/${COMPILER_ARCHIVE} |
+            #   tar -xvz -C /tmp
+            cargo install cross --git https://github.com/cross-rs/cross
       - run:
           name: Build
-          command: /tmp/cross build --release --target=<< parameters.target_triplet >>
+          command: cross build --release --target=<< parameters.target_triplet >>
+          # command: /tmp/cross build --release --target=<< parameters.target_triplet >>
       - run:
           name: Archive and compress artifact
           command: tar -czvf << parameters.archive_path >> --directory ${BIN_DIR} starknet-devnet

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,9 +96,9 @@ jobs:
         type: string
       platform:
         type: executor
+      target_triplet:
+        type: string
     executor: << parameters.platform >>
-    environment:
-      TARGET_TRIPLET: ${CIRCLE_JOB}
 
     steps:
       - checkout
@@ -107,7 +107,7 @@ jobs:
           # CIRCLE_JOB contains job name, which we define to be the target triplet
           command: |
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.74.0
-            rustup target add ${CIRCLE_JOB}
+      - run: rustup target add << parameters.target_triplet >>
       - run:
           name: Install Cross
           command: |
@@ -115,7 +115,7 @@ jobs:
               tar -xvz -C /tmp
       - run:
           name: Build
-          command: /tmp/cross build --release --target=${CIRCLE_JOB}
+          command: /tmp/cross build --release --target=<< parameters.target_triplet >>
 
   image-build-amd:
     docker:
@@ -174,6 +174,7 @@ workflows:
             parameters:
               arch: [x86_64, aarch64]
               platform: [unknown-linux-gnu, unknown-linux-musl, apple-darwin]
+          target_triplet: << matrix.arch >>-<< matrix.platform >>
 
       # TODO disabled image building; re-enable as part of binary-building jobs
       # - image-build-amd:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,8 +171,8 @@ workflows:
           # TODO <<: *on_main
           matrix:
             parameters:
-              arch: [x86_64] # TODO, aarch64]
-              platform: [unknown-linux-gnu] # TODO, unknown-linux-musl, apple-darwin]
+              arch: [x86_64, aarch64]
+              platform: [unknown-linux-gnu, unknown-linux-musl, apple-darwin]
           target_triplet: << matrix.arch >>-<< matrix.platform >>
           archive_path: starknet-devnet-<< matrix.arch >>-<< matrix.platform >>.tar.gz
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,6 @@ jobs:
       - run:
           name: Build
           command: /tmp/cross build --release --target=<< parameters.target_triplet >>
-      - run: tree target # TODO DEBUG
       - run:
           name: Archive and compress artifact
           command: tar -czvf << parameters.archive_path >> --directory ${BIN_DIR} ${BIN_PATH}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,9 @@ aliases:
               tar -xvz -C /tmp
       - run:
           name: Build
-          command: /tmp/cross build --release --target=${CIRCLE_JOB}
+          command: |
+            rustup target add ${CIRCLE_JOB}
+            /tmp/cross build --release --target=${CIRCLE_JOB}
 
   - &linux_binary_build
     <<: *binary_build
@@ -114,7 +116,6 @@ jobs:
 
   aarch64-apple-darwin:
     <<: *mac_binary_build
-    resource_class: macos.m1.medium.gen1
 
   x86_64-apple-darwin:
     <<: *mac_binary_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,7 @@ jobs:
 
   aarch64-apple-darwin:
     <<: *mac_binary_build
+    resource_class: macos.m1.medium.gen1
 
   x86_64-apple-darwin:
     <<: *mac_binary_build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4019,6 +4019,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.2.3+3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4026,6 +4035,7 @@ checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -5480,6 +5490,7 @@ dependencies = [
  "hex",
  "indexmap 2.2.6",
  "nonzero_ext",
+ "openssl",
  "rand",
  "rand_mt",
  "reqwest 0.10.10",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,3 +105,5 @@ num-bigint = { version = "0.4" }
 
 lazy_static = { version = "1.4.0" }
 ethers = { version = "2.0.11" }
+
+openssl = { version = "0.10", features = ["vendored"] }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This repository is work in progress, please be patient. Please check below the s
 - [x] [Customizable predeployed accounts](#predeployed-contracts)
 - [x] [Starknet.js test suite passes 100%](https://github.com/starknet-io/starknet.js/actions)
 - [x] [Advancing time](https://0xspaceshard.github.io/starknet-devnet/docs/guide/advancing-time)
-- [x] [Availability as a package (crate)](#installing-from-cratesio)
+- [x] [Availability as a package (crate)](#install-an-executable-binary)
 - [x] [Forking](#forking)
 - [x] [L1-L2 Postman integration](https://0xspaceshard.github.io/starknet-devnet/docs/guide/postman)
 - [x] [Block manipulation](https://0xspaceshard.github.io/starknet-devnet/docs/guide/blocks)
@@ -37,37 +37,29 @@ This repository is work in progress, please be patient. Please check below the s
 
 - [ ] Creating blocks on demand
 
-## Requirements
+## Installation and running
 
-Make sure to have installed [Rust](https://www.rust-lang.org/tools/install).
+There are several approaches to installing and/or running Devnet.
+
+### Requirements
+
+Any of the approaches below that mention `cargo` require you to have installed [Rust](https://www.rust-lang.org/tools/install).
 
 The required Rust version is specified in [rust-toolchain.toml](rust-toolchain.toml) and handled automatically by `cargo`.
 
-## Run from source
-
-After git-cloning this repository, install and run the project with:
-
-```
-$ cargo run
-```
-
-For a more optimized and faster performance (though with a longer compilation time), run with:
-
-```
-$ cargo run --release
-```
-
-## Run as a binary
+### Install an executable binary
 
 Installing and running as a binary is achievable via `cargo install`. The project can be installed from crates.io and github.com.
 
-### Installing from crates.io
+If in the past you installed [Pythonic Devnet](https://github.com/0xSpaceShard/starknet-devnet), be sure to have removed it to avoid name collision of the old and the new executable - if by no other means, then by `rm $(which starknet-devnet)`.
+
+#### Install from crates.io
 
 ```
 $ cargo install starknet-devnet
 ```
 
-### Installing from github
+#### Install from GitHub
 
 - Use the `--locked` flag to ensure using the dependencies listed in [the lock file](/Cargo.lock)
 - Preferably familiarize yourself with the `cargo install` command ([docs](https://doc.rust-lang.org/cargo/commands/cargo-install.html#dealing-with-the-lockfile))
@@ -76,17 +68,46 @@ $ cargo install starknet-devnet
 $ cargo install --git https://github.com/0xSpaceShard/starknet-devnet-rs.git --locked
 ```
 
-When the installation finishes, follow the output in your terminal.
+#### Run the installed executable
 
-## Run with Docker
+When `cargo install` finishes, follow the output in your terminal. If properly configured, you should be able to run Devnet with:
 
-This application is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/shardlabs/starknet-devnet-rs/)). To download the `latest` image, run:
+```
+$ starknet-devnet
+```
+
+### Run from source
+
+After [git-cloning](https://github.com/git-guides/git-clone) this repository, running the following command will install, build and start Devnet:
+
+```
+$ cargo run
+```
+
+For a more optimized and faster performance (though with a longer compilation time), run:
+
+```
+$ cargo run --release
+```
+
+### Fetch a pre-compiled binary executable
+
+Since Devnet v0.0.5, the Assets section of each [GitHub release](https://github.com/0xSpaceShard/starknet-devnet-rs/releases) contains a set of platform-specific pre-compiled binary executables. Extract and run with:
+
+```
+$ curl https://github.com/0xSpaceShard/starknet-devnet-rs/releases/download/<VERSION>/<COMPRESSED_ARCHIVE> | tar -xvzf -C <TARGET_DIR>
+$ <TARGET_DIR>/starknet-devnet
+```
+
+### Run with Docker
+
+Devnet is available as a Docker image ([Docker Hub link](https://hub.docker.com/r/shardlabs/starknet-devnet-rs/)). To download the `latest` image, run:
 
 ```text
 $ docker pull shardlabs/starknet-devnet-rs
 ```
 
-Supported architectures: arm64 and amd64.
+Supported platforms: linux/amd64 and linux/arm64 (also executable on darwin/arm64).
 
 Running a container is done like this (see [port publishing](#container-port-publishing) for more info):
 
@@ -150,7 +171,7 @@ If you don't specify the `HOST` part, the server will indeed be available on all
 Check out the CLI options with:
 
 ```
-$ cargo run -- --help
+$ starknet-devnet --help
 ```
 
 Or if using dockerized Devnet:
@@ -168,7 +189,7 @@ All logging levels: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`
 To specify the logging level and run Devnet on the same line:
 
 ```
-$ RUST_LOG=<LEVEL> cargo run
+$ RUST_LOG=<LEVEL> starknet-devnet
 ```
 
 or if using dockerized Devnet:
@@ -229,20 +250,20 @@ To preserve your Devnet instance for future use, these are the options:
 - Dumping on exit (handles Ctrl+C, i.e. SIGINT, doesn't handle SIGKILL):
 
 ```
-cargo run -- --dump-on exit --dump-path <PATH>
+$ starknet-devnet --dump-on exit --dump-path <PATH>
 ```
 
 - Dumping after each transaction:
 
 ```
-cargo run -- --dump-on transaction --dump-path <PATH>
+$ starknet-devnet --dump-on transaction --dump-path <PATH>
 ```
 
 - Dumping on request requires providing --dump-on mode on the startup. Example usage in `exit` mode (replace `<HOST>`, `<PORT>` and `<PATH>` with your own):
 
 ```
-cargo run -- --dump-on exit --dump-path <PATH>
-curl -X POST http://<HOST>:<PORT>/dump -d '{ "path": <PATH> }' -H "Content-Type: application/json"
+$ starknet-devnet --dump-on exit --dump-path <PATH>
+$ curl -X POST http://<HOST>:<PORT>/dump -d '{ "path": <PATH> }' -H "Content-Type: application/json"
 ```
 
 ### Loading
@@ -252,7 +273,7 @@ To load a preserved Devnet instance, the options are:
 - Loading on startup (note the argument name is not `--load-path` as it was in Devnet-py):
 
 ```
-cargo run -- --dump-path <PATH>
+$ starknet-devnet --dump-path <PATH>
 ```
 
 - Loading on request:
@@ -368,7 +389,7 @@ POST /increase_time
 Devnet can be started with the `--start-time` argument, where `START_TIME_IN_SECONDS` should be greater than 0.
 
 ```
-cargo run -- --start-time <START_TIME_IN_SECONDS>
+$ starknet-devnet --start-time <START_TIME_IN_SECONDS>
 ```
 
 ## Timeout
@@ -376,7 +397,7 @@ cargo run -- --start-time <START_TIME_IN_SECONDS>
 Timeout can be passed to Devnet's HTTP server. This makes it easier to deploy and manage large contracts that take longer to execute.
 
 ```
-cargo run -- --timeout <TIMEOUT>
+$ starknet-devnet --timeout <TIMEOUT>
 ```
 
 ## Forking
@@ -384,7 +405,7 @@ cargo run -- --timeout <TIMEOUT>
 To interact with contracts deployed on mainnet or testnet, you can use the forking to simulate the origin and experiment with it locally, making no changes to the origin itself.
 
 ```
-cargo run -- --fork-network <URL> [--fork-block <BLOCK_NUMBER>]
+$ starknet-devnet --fork-network <URL> [--fork-block <BLOCK_NUMBER>]
 ```
 
 The value passed to `--fork-network` should be the URL to a Starknet JSON-RPC API provider. Specifying a `--fork-block` is optional; it defaults to the `"latest"` block at the time of Devnet's start-up. All calls will first try Devnet's state and then fall back to the forking block.
@@ -411,7 +432,7 @@ Response when not forking: `{}`
 With state archive capacity set to `full`, Devnet will store full state history. The default mode is `none`, where no old states are stored.
 
 ```
-cargo run -- --state-archive-capacity <CAPACITY>
+$ starknet-devnet --state-archive-capacity <CAPACITY>
 ```
 
 All RPC endpoints that support querying the state at an old (non-latest) block only work with state archive capacity set to `full`.
@@ -473,13 +494,13 @@ To ensure that integration tests pass, be sure to have run `cargo build --releas
 Run all tests using all available CPUs with:
 
 ```
-cargo test
+$ cargo test
 ```
 
 The previous command might cause your testing to die along the way due to memory issues. In that case, limiting the number of jobs helps, but depends on your machine (rule of thumb: N=6):
 
 ```
-cargo test --jobs <N>
+$ cargo test --jobs <N>
 ```
 
 ### Development - Docker
@@ -516,6 +537,16 @@ Updating the underlying Starknet is done by updating the `blockifier` dependency
 ### Development - Updating JSON-RPC API
 
 Updating the RPC requires following the specification files in the [starknet-specs repository](https://github.com/starkware-libs/starknet-specs). The spec_reader testing utility requires these files to be copied into the Devnet repository. The `RPC_SPEC_VERSION` constant needs to be updated accordingly.
+
+### Development - New Devnet version release
+
+To release a new version, increment the semver in Cargo.toml of those Devnet crates that have changed. Preferably create a separate PR for this, such as [this one](https://github.com/0xSpaceShard/starknet-devnet-rs/pull/398).
+
+The publishing of crates and Docker images is done automatically in CI when merged into the main branch.
+
+When the CI workflow is done, create a git tag of the form `vX.Y.Z`, push it and create a GitHub release with notes describing changes since the last release.
+
+Attach the [binary artifacts built in CI](https://circleci.com/docs/artifacts/#artifacts-overview) to the release. The download of binaries can be done manually or with [this approach](https://circleci.com/docs/artifacts/#downloading-all-artifacts-for-a-build-on-circleci).
 
 ## ✏️ Contributing
 

--- a/README.md
+++ b/README.md
@@ -486,8 +486,8 @@ Due to internal needs, images with arch suffix are built and pushed to Docker Hu
 
 This is what happens under the hood on `main`:
 
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-amd`
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-arm`
+- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-x86_64`
+- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-aarch64`
 - create and push joint docker manifest called `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>`
   - same for `latest`
 

--- a/README.md
+++ b/README.md
@@ -202,13 +202,11 @@ $ docker run -e RUST_LOG=<LEVEL> shardlabs/starknet-devnet-rs
 
 Unlike Pythonic Devnet, which supported the gateway and feeder gateway API, Devnet in Rust only supports JSON-RPC. Since JSON-RPC v0.6.0, to find out which JSON-RPC version is supported by which Devnet version, check out the [releases page](https://github.com/0xspaceshard/starknet-devnet-rs/releases).
 
-Below is the list of old RPC versions supported by Devnet, usable as git tags or branches.
+Below is the list of old RPC versions supported by Devnet, usable as git tags or branches. They should be used with `git checkout <REVISION>`.
 
 - `json-rpc-v0.4.0`
 - `json-rpc-v0.5.0`
 - `json-rpc-v0.5.1`
-
-These revisions should be used with `git checkout <REVISION>`.
 
 The JSON-RPC API is reachable via `/rpc` and `/` (e.g. if spawning Devnet with default settings, these URLs have the equivalent functionality: `http://127.0.0.1:5050/rpc` and `http://127.0.0.1:5050/`)
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ There are several approaches to installing and running Devnet.
 
 ### Requirements
 
-Any of the approaches below that mention `cargo` require you to have installed [Rust](https://www.rust-lang.org/tools/install).
+Any of the approaches below that mention `cargo` require you to have installed [Rust](https://www.rust-lang.org/tools/install). You might also need to install `pkg-config` and `make`.
 
 The required Rust version is specified in [rust-toolchain.toml](rust-toolchain.toml) and handled automatically by `cargo`.
 

--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@ There are several approaches to installing and running Devnet.
 
 ### Requirements
 
-Any of the approaches below that mention `cargo` require you to have installed [Rust](https://www.rust-lang.org/tools/install). You might also need to install `pkg-config` and `make`.
+Any of the approaches below that mention `cargo` require you to have [installed Rust](https://www.rust-lang.org/tools/install). You might also need to install `pkg-config` and `make`.
 
 The required Rust version is specified in [rust-toolchain.toml](rust-toolchain.toml) and handled automatically by `cargo`.
 
 ### Install an executable binary
 
-Installing and running as a binary is achievable with `cargo install` via crates.io or github.com.
+Installing an executable binary is achievable with `cargo install` via crates.io or github.com. This approach downloads the crate, builds it in release mode and copies it to `~/.cargo/bin/`. To avoid needing to compile and wait, check the [pre-compiled binary section](#fetch-a-pre-compiled-binary-executable).
 
-If in the past you installed [Pythonic Devnet](https://github.com/0xSpaceShard/starknet-devnet), be sure to have removed it to avoid name collision of the old and the new executable - if by no other means, then by `rm $(which starknet-devnet)`.
+If in the past you installed [Pythonic Devnet](https://github.com/0xSpaceShard/starknet-devnet), be sure to remove it to avoid name collision of the old and the new executable - if by no other means, then by `rm $(which starknet-devnet)`.
 
 #### Install from crates.io
 
@@ -76,6 +76,15 @@ When `cargo install` finishes, follow the output in your terminal. If properly c
 $ starknet-devnet
 ```
 
+### Fetch a pre-compiled binary executable
+
+If you want to save time and skip project compilation on installation, since Devnet v0.0.5, the Assets section of each [GitHub release](https://github.com/0xSpaceShard/starknet-devnet-rs/releases) contains a set of platform-specific pre-compiled binary executables. Extract and run with:
+
+```
+$ curl https://github.com/0xSpaceShard/starknet-devnet-rs/releases/download/<VERSION>/<COMPRESSED_ARCHIVE> | tar -xvzf -C <TARGET_DIR>
+$ <TARGET_DIR>/starknet-devnet
+```
+
 ### Run from source
 
 After [git-cloning](https://github.com/git-guides/git-clone) this repository, running the following command will install, build and start Devnet:
@@ -84,19 +93,10 @@ After [git-cloning](https://github.com/git-guides/git-clone) this repository, ru
 $ cargo run
 ```
 
-For a more optimized and faster performance (though with a longer compilation time), run:
+For a more optimized performance (though with a longer compilation time), run:
 
 ```
 $ cargo run --release
-```
-
-### Fetch a pre-compiled binary executable
-
-Since Devnet v0.0.5, the Assets section of each [GitHub release](https://github.com/0xSpaceShard/starknet-devnet-rs/releases) contains a set of platform-specific pre-compiled binary executables. Extract and run with:
-
-```
-$ curl https://github.com/0xSpaceShard/starknet-devnet-rs/releases/download/<VERSION>/<COMPRESSED_ARCHIVE> | tar -xvzf -C <TARGET_DIR>
-$ <TARGET_DIR>/starknet-devnet
 ```
 
 ### Run with Docker

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository is work in progress, please be patient. Please check below the s
 
 ### Supported Features
 
-- [x] RPC v0.7.0
+- [x] [RPC support](#api)
 - [x] [Dump & Load](#dumping--loading)
 - [x] [Mint token - Local faucet](#mint-token)
 - [x] [Customizable predeployed accounts](#predeployed-contracts)
@@ -39,7 +39,7 @@ This repository is work in progress, please be patient. Please check below the s
 
 ## Installation and running
 
-There are several approaches to installing and/or running Devnet.
+There are several approaches to installing and running Devnet.
 
 ### Requirements
 
@@ -49,7 +49,7 @@ The required Rust version is specified in [rust-toolchain.toml](rust-toolchain.t
 
 ### Install an executable binary
 
-Installing and running as a binary is achievable via `cargo install`. The project can be installed from crates.io and github.com.
+Installing and running as a binary is achievable with `cargo install` via crates.io or github.com.
 
 If in the past you installed [Pythonic Devnet](https://github.com/0xSpaceShard/starknet-devnet), be sure to have removed it to avoid name collision of the old and the new executable - if by no other means, then by `rm $(which starknet-devnet)`.
 

--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ Updating the RPC requires following the specification files in the [starknet-spe
 
 ### Development - New Devnet version release
 
-To release a new version, increment the semver in Cargo.toml of those Devnet crates that have changed. Preferably create a separate PR for this, such as [this one](https://github.com/0xSpaceShard/starknet-devnet-rs/pull/398).
+To release a new version, increment the semver in Cargo.toml of those Devnet crates that have changed. Use `scripts/check_crate_changes.sh` for this. Preferably create a separate PR for the increment, such as [this one](https://github.com/0xSpaceShard/starknet-devnet-rs/pull/398).
 
 The publishing of crates and Docker images is done automatically in CI when merged into the main branch.
 

--- a/README.md
+++ b/README.md
@@ -488,8 +488,8 @@ Due to internal needs, images with arch suffix are built and pushed to Docker Hu
 
 This is what happens under the hood on `main`:
 
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-x86_64`
-- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-aarch64`
+- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-amd`
+- build `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>-arm`
 - create and push joint docker manifest called `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>`
   - same for `latest`
 

--- a/crates/starknet-devnet-core/Cargo.toml
+++ b/crates/starknet-devnet-core/Cargo.toml
@@ -30,8 +30,17 @@ url = { workspace = true }
 nonzero_ext = { workspace = true }
 usc = { workspace = true }
 
+# necessary for installing reqwest in Docker
+openssl = { workspace = true }
+
 [dev-dependencies]
 hex = "0.4.3"
 
 [features]
 test_utils = []
+
+[package.metadata.cargo-machete]
+ignored = [
+    # read note above
+    "openssl"
+]

--- a/crates/starknet-devnet-core/src/account.rs
+++ b/crates/starknet-devnet-core/src/account.rs
@@ -15,7 +15,7 @@ use starknet_types::rpc::state::Balance;
 use starknet_types::traits::HashProducer;
 
 use crate::constants::{
-    CAIRO_0_ACCOUNT_CONTRACT_PATH, CHARGEABLE_ACCOUNT_ADDRESS, CHARGEABLE_ACCOUNT_PRIVATE_KEY,
+    CAIRO_0_ACCOUNT_CONTRACT, CHARGEABLE_ACCOUNT_ADDRESS, CHARGEABLE_ACCOUNT_PRIVATE_KEY,
     CHARGEABLE_ACCOUNT_PUBLIC_KEY,
 };
 use crate::error::DevnetResult;
@@ -50,7 +50,7 @@ impl Account {
         eth_fee_token_address: ContractAddress,
         strk_fee_token_address: ContractAddress,
     ) -> DevnetResult<Self> {
-        let account_contract_class = Cairo0Json::raw_json_from_path(CAIRO_0_ACCOUNT_CONTRACT_PATH)?;
+        let account_contract_class = Cairo0Json::raw_json_from_json_str(CAIRO_0_ACCOUNT_CONTRACT)?;
         let class_hash = account_contract_class.generate_hash()?;
 
         // insanely big - should practically never run out of funds

--- a/crates/starknet-devnet-core/src/constants.rs
+++ b/crates/starknet-devnet-core/src/constants.rs
@@ -5,24 +5,26 @@ use nonzero_ext::nonzero;
 use starknet_rs_ff::FieldElement;
 use starknet_types::chain_id::ChainId;
 
-pub const CAIRO_0_ACCOUNT_CONTRACT_PATH: &str = concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/accounts_artifacts/OpenZeppelin/0.5.1/Account.cairo/Account.casm"
-);
+pub const CAIRO_0_ACCOUNT_CONTRACT: &str =
+    include_str!("../accounts_artifacts/OpenZeppelin/0.5.1/Account.cairo/Account.casm");
 
 pub const CAIRO_0_ACCOUNT_CONTRACT_HASH: &str =
     "0x4d07e40e93398ed3c76981e72dd1fd22557a78ce36c0515f679e27f0bb5bc5f";
 
+/// only used in tests; if artifact needed in production, use CAIRO_1_ACCOUNT_CONTRACT_SIERRA
 pub const CAIRO_1_ACCOUNT_CONTRACT_SIERRA_PATH: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/accounts_artifacts/OpenZeppelin/0.8.1/Account.cairo/Account.sierra"
 );
 
+pub const CAIRO_1_ACCOUNT_CONTRACT_SIERRA: &str =
+    include_str!("../accounts_artifacts/OpenZeppelin/0.8.1/Account.cairo/Account.sierra");
+
 pub const CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH: &str =
     "0x061dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2971b8f";
 
-pub const CAIRO_1_ERC20_CONTRACT_PATH: &str =
-    concat!(env!("CARGO_MANIFEST_DIR"), "/accounts_artifacts/ERC20_Mintable_OZ_0.8.1.json");
+pub const CAIRO_1_ERC20_CONTRACT: &str =
+    include_str!("../accounts_artifacts/ERC20_Mintable_OZ_0.8.1.json");
 
 /// ERC20 class hash is hardcoded to be the same as OZ class hash ERC20.cairo although it should be
 /// different, due to commented key attributes in struct Approval (owner and spender), and add of
@@ -42,8 +44,7 @@ pub const ETH_ERC20_CONTRACT_ADDRESS: &str =
 pub const STRK_ERC20_CONTRACT_ADDRESS: &str =
     "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d";
 
-pub(crate) const UDC_CONTRACT_PATH: &str =
-    concat!(env!("CARGO_MANIFEST_DIR"), "/accounts_artifacts/UDC_OZ_0.5.0.json");
+pub(crate) const UDC_CONTRACT: &str = include_str!("../accounts_artifacts/UDC_OZ_0.5.0.json");
 
 pub const UDC_CONTRACT_CLASS_HASH: &str =
     "0x7B3E05F48F0C69E4A65CE5E076A66271A527AFF2C34CE1083EC6E1526997A69";

--- a/crates/starknet-devnet-core/src/constants.rs
+++ b/crates/starknet-devnet-core/src/constants.rs
@@ -31,6 +31,7 @@ pub const CAIRO_1_ERC20_CONTRACT: &str =
 pub const CAIRO_1_ERC20_CONTRACT_CLASS_HASH: &str =
     "0x046ded64ae2dead6448e247234bab192a9c483644395b66f2155f2614e5804b0";
 
+/// only used in tests; if artifact needed in production, add a new constant that uses include_str!
 pub const CAIRO_0_ERC20_CONTRACT_PATH: &str =
     concat!(env!("CARGO_MANIFEST_DIR"), "/accounts_artifacts/ERC20_Mintable_OZ_0.2.0.json");
 

--- a/crates/starknet-devnet-core/src/contract_class_choice.rs
+++ b/crates/starknet-devnet-core/src/contract_class_choice.rs
@@ -6,7 +6,7 @@ use starknet_types::contract_class::{Cairo0ContractClass, Cairo0Json, ContractCl
 use starknet_types::felt::Felt;
 use starknet_types::traits::HashProducer;
 
-use crate::constants::{CAIRO_0_ACCOUNT_CONTRACT_PATH, CAIRO_1_ACCOUNT_CONTRACT_SIERRA_PATH};
+use crate::constants::{CAIRO_0_ACCOUNT_CONTRACT, CAIRO_1_ACCOUNT_CONTRACT_SIERRA};
 use crate::error::DevnetResult;
 
 #[derive(clap::ValueEnum, Debug, Clone)]
@@ -19,19 +19,16 @@ impl AccountContractClassChoice {
     pub fn get_class_wrapper(&self) -> DevnetResult<AccountClassWrapper> {
         Ok(match self {
             AccountContractClassChoice::Cairo0 => {
-                let contract_class = Cairo0ContractClass::RawJson(Cairo0Json::raw_json_from_path(
-                    CAIRO_0_ACCOUNT_CONTRACT_PATH,
-                )?);
+                let contract_json = Cairo0Json::raw_json_from_json_str(CAIRO_0_ACCOUNT_CONTRACT)?;
+                let contract_class = Cairo0ContractClass::RawJson(contract_json);
                 AccountClassWrapper {
                     class_hash: contract_class.generate_hash()?,
                     contract_class: ContractClass::Cairo0(contract_class),
                 }
             }
             AccountContractClassChoice::Cairo1 => {
-                let contract_class_str =
-                    std::fs::read_to_string(CAIRO_1_ACCOUNT_CONTRACT_SIERRA_PATH)?;
                 let contract_class = ContractClass::Cairo1(
-                    ContractClass::cairo_1_from_sierra_json_str(&contract_class_str)?,
+                    ContractClass::cairo_1_from_sierra_json_str(CAIRO_1_ACCOUNT_CONTRACT_SIERRA)?,
                 );
                 AccountClassWrapper { class_hash: contract_class.generate_hash()?, contract_class }
             }

--- a/crates/starknet-devnet-core/src/starknet/predeployed.rs
+++ b/crates/starknet-devnet-core/src/starknet/predeployed.rs
@@ -4,8 +4,8 @@ use starknet_types::contract_address::ContractAddress;
 use starknet_types::felt::Felt;
 
 use crate::constants::{
-    CAIRO_1_ERC20_CONTRACT_CLASS_HASH, CAIRO_1_ERC20_CONTRACT_PATH, CHARGEABLE_ACCOUNT_ADDRESS,
-    UDC_CONTRACT_ADDRESS, UDC_CONTRACT_CLASS_HASH, UDC_CONTRACT_PATH,
+    CAIRO_1_ERC20_CONTRACT, CAIRO_1_ERC20_CONTRACT_CLASS_HASH, CHARGEABLE_ACCOUNT_ADDRESS,
+    UDC_CONTRACT, UDC_CONTRACT_ADDRESS, UDC_CONTRACT_CLASS_HASH,
 };
 use crate::error::{DevnetResult, Error};
 use crate::state::StarknetState;
@@ -13,14 +13,10 @@ use crate::system_contract::SystemContract;
 use crate::utils::get_storage_var_address;
 
 pub(crate) fn create_erc20_at_address(contract_address: &str) -> DevnetResult<SystemContract> {
-    let erc20_contract_class_json_str =
-        std::fs::read_to_string(CAIRO_1_ERC20_CONTRACT_PATH).map_err(|err| {
-            Error::ReadFileError { source: err, path: CAIRO_1_ERC20_CONTRACT_PATH.to_string() }
-        })?;
     let erc20_fee_contract = SystemContract::new_cairo1(
         CAIRO_1_ERC20_CONTRACT_CLASS_HASH,
         contract_address,
-        &erc20_contract_class_json_str,
+        CAIRO_1_ERC20_CONTRACT,
     )?;
     Ok(erc20_fee_contract)
 }
@@ -63,13 +59,8 @@ pub(crate) fn initialize_erc20_at_address(
 }
 
 pub(crate) fn create_udc() -> DevnetResult<SystemContract> {
-    let udc_contract_class_json_str = std::fs::read_to_string(UDC_CONTRACT_PATH)
-        .map_err(|err| Error::ReadFileError { source: err, path: UDC_CONTRACT_PATH.to_string() })?;
-    let udc_contract = SystemContract::new_cairo0(
-        UDC_CONTRACT_CLASS_HASH,
-        UDC_CONTRACT_ADDRESS,
-        &udc_contract_class_json_str,
-    )?;
+    let udc_contract =
+        SystemContract::new_cairo0(UDC_CONTRACT_CLASS_HASH, UDC_CONTRACT_ADDRESS, UDC_CONTRACT)?;
 
     Ok(udc_contract)
 }

--- a/crates/starknet-devnet-core/src/starknet/starknet_config.rs
+++ b/crates/starknet-devnet-core/src/starknet/starknet_config.rs
@@ -8,7 +8,7 @@ use starknet_types::traits::HashProducer;
 use url::Url;
 
 use crate::constants::{
-    CAIRO_1_ACCOUNT_CONTRACT_SIERRA_PATH, DEVNET_DEFAULT_CHAIN_ID, DEVNET_DEFAULT_DATA_GAS_PRICE,
+    CAIRO_1_ACCOUNT_CONTRACT_SIERRA, DEVNET_DEFAULT_CHAIN_ID, DEVNET_DEFAULT_DATA_GAS_PRICE,
     DEVNET_DEFAULT_GAS_PRICE, DEVNET_DEFAULT_INITIAL_BALANCE, DEVNET_DEFAULT_TEST_SEED,
     DEVNET_DEFAULT_TOTAL_ACCOUNTS,
 };
@@ -55,8 +55,10 @@ pub struct StarknetConfig {
 
 impl Default for StarknetConfig {
     fn default() -> Self {
-        let account_contract_class =
-            ContractClass::cairo_1_from_path(CAIRO_1_ACCOUNT_CONTRACT_SIERRA_PATH).unwrap();
+        let account_contract_class: ContractClass =
+            ContractClass::cairo_1_from_sierra_json_str(CAIRO_1_ACCOUNT_CONTRACT_SIERRA)
+                .unwrap()
+                .into();
         StarknetConfig {
             seed: DEVNET_DEFAULT_TEST_SEED,
             total_accounts: DEVNET_DEFAULT_TOTAL_ACCOUNTS,

--- a/crates/starknet-devnet-core/src/system_contract.rs
+++ b/crates/starknet-devnet-core/src/system_contract.rs
@@ -74,15 +74,14 @@ mod tests {
 
     use super::SystemContract;
     use crate::constants::{
-        CAIRO_1_ERC20_CONTRACT_CLASS_HASH, CAIRO_1_ERC20_CONTRACT_PATH, ETH_ERC20_CONTRACT_ADDRESS,
+        CAIRO_1_ERC20_CONTRACT, CAIRO_1_ERC20_CONTRACT_CLASS_HASH, ETH_ERC20_CONTRACT_ADDRESS,
     };
     use crate::state::StarknetState;
     use crate::traits::Deployed;
 
     #[test]
     fn load_erc20_contract() {
-        let json_str = std::fs::read_to_string(CAIRO_1_ERC20_CONTRACT_PATH).unwrap();
-        assert!(ContractClass::cairo_1_from_sierra_json_str(&json_str).is_ok());
+        assert!(ContractClass::cairo_1_from_sierra_json_str(CAIRO_1_ERC20_CONTRACT).is_ok());
     }
 
     #[test]
@@ -91,7 +90,7 @@ mod tests {
         let sys_contract = SystemContract::new_cairo1(
             CAIRO_1_ERC20_CONTRACT_CLASS_HASH,
             ETH_ERC20_CONTRACT_ADDRESS,
-            std::fs::read_to_string(CAIRO_1_ERC20_CONTRACT_PATH).unwrap().as_str(),
+            CAIRO_1_ERC20_CONTRACT,
         )
         .unwrap();
 

--- a/crates/starknet-devnet-types/src/rpc/contract_class.rs
+++ b/crates/starknet-devnet-types/src/rpc/contract_class.rs
@@ -47,11 +47,6 @@ impl ContractClass {
 
         Ok(sierra_contract_class)
     }
-
-    pub fn cairo_1_from_path(path: &str) -> DevnetResult<ContractClass> {
-        let json_str = std::fs::read_to_string(path)?;
-        Ok(ContractClass::Cairo1(ContractClass::cairo_1_from_sierra_json_str(&json_str)?))
-    }
 }
 
 impl From<Cairo0ContractClass> for ContractClass {

--- a/crates/starknet-devnet/Cargo.toml
+++ b/crates/starknet-devnet/Cargo.toml
@@ -4,7 +4,9 @@ version = "0.0.4"
 edition = "2021"
 repository.workspace = true
 license-file.workspace = true
-description = "A local testnet for Starknet"
+readme.workspace = true
+documentation.workspace = true
+description.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,15 @@
-FROM debian:buster-slim
+FROM rust:1.74.0-slim-buster as builder
 
-ARG BIN_PATH
+COPY . .
+
+# TODO all necessary?
+RUN apt-get -y update && \
+    apt-get install pkg-config -y && \
+    apt-get install libssl-dev -y
+
+RUN cargo build --bin starknet-devnet --release
+
+FROM debian:buster-slim
 
 # Use tini to avoid hanging process on Ctrl+C
 # Use ca-certificates to allow forking from URLs using https scheme
@@ -11,7 +20,6 @@ RUN apt-get -y update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Binary expected to have been built
-COPY ${BIN_PATH} /usr/local/bin/starknet-devnet
+COPY --from=builder /target/release/starknet-devnet /usr/local/bin/starknet-devnet
 
 ENTRYPOINT [ "tini", "--", "starknet-devnet", "--host", "0.0.0.0" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,20 +1,6 @@
-FROM rust:1.74.0-slim-buster as builder
-
-ARG TARGET
-
-COPY . .
-
-# TODO this won't work on main, but perhaps we can change the whole image building scheme
-# by building a binary outside, publishing it on github, and copying it into an image
-# Alternatively just return the libssl dependency - if that will be compatible with other targets
-RUN apt-get update && \
-    apt-get install make -y
-
-RUN cargo build --bin starknet-devnet --release --target=${TARGET}
-
 FROM debian:buster-slim
 
-ARG TARGET
+ARG BIN_PATH
 
 # Use tini to avoid hanging process on Ctrl+C
 # Use ca-certificates to allow forking from URLs using https scheme
@@ -25,6 +11,6 @@ RUN apt-get -y update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /target/${TARGET}/release/starknet-devnet /usr/local/bin/starknet-devnet
+COPY ${BIN_PATH} /usr/local/bin/starknet-devnet
 
 ENTRYPOINT [ "tini", "--", "starknet-devnet", "--host", "0.0.0.0" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get -y update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# Binary expected to have been built
 COPY ${BIN_PATH} /usr/local/bin/starknet-devnet
 
 ENTRYPOINT [ "tini", "--", "starknet-devnet", "--host", "0.0.0.0" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,10 +2,9 @@ FROM rust:1.74.0-slim-buster as builder
 
 COPY . .
 
-# TODO all necessary?
 RUN apt-get -y update && \
     apt-get install pkg-config -y && \
-    apt-get install libssl-dev -y
+    apt-get install make -y
 
 RUN cargo build --bin starknet-devnet --release
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,27 +1,30 @@
 FROM rust:1.74.0-slim-buster as builder
 
+ARG TARGET
+
 COPY . .
 
-RUN apt-get -y update && \
-    apt-get install pkg-config -y && \
-    apt-get install libssl-dev -y
+# TODO this won't work on main, but perhaps we can change the whole image building scheme
+# by building a binary outside, publishing it on github, and copying it into an image
+# Alternatively just return the libssl dependency - if that will be compatible with other targets
+RUN apt-get update && \
+    apt-get install make -y
 
-RUN cargo build --bin starknet-devnet --release
+RUN cargo build --bin starknet-devnet --release --target=${TARGET}
 
 FROM debian:buster-slim
+
+ARG TARGET
 
 # Use tini to avoid hanging process on Ctrl+C
 # Use ca-certificates to allow forking from URLs using https scheme
 RUN apt-get -y update && \
     apt-get install tini && \
-    apt-get install libssl-dev -y && \
     apt-get install ca-certificates -y && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Necessary for predeployed contracts
-COPY crates/starknet-devnet-core/accounts_artifacts/ /crates/starknet-devnet-core/accounts_artifacts/
-COPY --from=builder /target/release/starknet-devnet /usr/local/bin/starknet-devnet
+COPY --from=builder /target/${TARGET}/release/starknet-devnet /usr/local/bin/starknet-devnet
 
 ENTRYPOINT [ "tini", "--", "starknet-devnet", "--host", "0.0.0.0" ]

--- a/docker/image_build.sh
+++ b/docker/image_build.sh
@@ -31,7 +31,7 @@ function validate_and_push() {
 
     echo "Checking if devnet instance is alive"
     if [ -f /.dockerenv ]; then
-        # inside a container - need to check on docker host
+        # workflow inside a container - Devnet container spawned on a remote Docker host
         ssh remote-docker curl "$external_address/is_alive" -w "\n"
     else
         curl "$external_address/is_alive" -w "\n"

--- a/docker/image_build.sh
+++ b/docker/image_build.sh
@@ -43,8 +43,10 @@ function validate_and_push() {
 
 echo "Building ${ARCH_SUFFIX} images tagged with sha1 commit digest"
 
-# BIN_PATH is in target/, which is ignored by Dockerfile, so it's copied somewhere visible
-VISIBLE_BIN_PATH="/tmp/starknet-devnet"
+# BIN_PATH is in target/, which is ignored by Dockerfile
+# Not to make .dockerignore unintuitive, we just copy it somewhere visible (tmp)
+mkdir tmp
+VISIBLE_BIN_PATH="tmp/starknet-devnet"
 cp "$BIN_PATH" "$VISIBLE_BIN_PATH"
 
 SHA1_TAG="${CIRCLE_SHA1}${ARCH_SUFFIX}"

--- a/docker/image_build.sh
+++ b/docker/image_build.sh
@@ -36,7 +36,7 @@ function validate_and_push() {
         curl "$external_address/is_alive" -w "\n"
     fi
 
-    docker push "$tagged_image"
+    # TODO docker push "$tagged_image"
 
     docker rm -f "$container_name"
 }
@@ -66,7 +66,7 @@ docker build . \
     --build-arg BASE_IMAGE="$BASE_IMAGE"
 
 echo "Images built. Validating and pushing."
-docker login --username "$DOCKER_USER" --password "$DOCKER_PASS"
+# TODO docker login --username "$DOCKER_USER" --password "$DOCKER_PASS"
 
 for image_tag in "$SHA1_TAG" "$SHA1_SEEDED_TAG"; do
     validate_and_push "$image_tag"

--- a/docker/image_build.sh
+++ b/docker/image_build.sh
@@ -47,7 +47,7 @@ echo "Building ${ARCH_SUFFIX} images tagged with sha1 commit digest"
 # Not to make .dockerignore unintuitive, we just copy it somewhere visible (tmp)
 mkdir tmp
 VISIBLE_BIN_PATH="tmp/starknet-devnet"
-cp "$BIN_PATH" "$VISIBLE_BIN_PATH"
+cp "$BIN_DIR/starknet-devnet" "$VISIBLE_BIN_PATH"
 
 SHA1_TAG="${CIRCLE_SHA1}${ARCH_SUFFIX}"
 BASE_IMAGE="${IMAGE}:${SHA1_TAG}"

--- a/docker/image_build.sh
+++ b/docker/image_build.sh
@@ -24,7 +24,7 @@ function validate_and_push() {
         "$tagged_image" \
         --port "$internal_port"
 
-    sleep 10 # alternatively check in a loop
+    sleep 10 # allow some time to spawn; alternatively check in a loop
 
     # logging can be helpful if Devnet exited early
     docker logs "$container_name"
@@ -42,12 +42,6 @@ function validate_and_push() {
 }
 
 echo "Building ${ARCH_SUFFIX} images tagged with sha1 commit digest"
-
-# BIN_PATH is in target/, which is ignored by Dockerfile. Not to make .dockerignore unintuitive
-# by allowing target/, we just copy the binary some place visible (tmp).
-mkdir tmp
-VISIBLE_BIN_PATH="tmp/starknet-devnet"
-cp "$BIN_DIR/starknet-devnet" "$VISIBLE_BIN_PATH"
 
 SHA1_TAG="${CIRCLE_SHA1}${ARCH_SUFFIX}"
 BASE_IMAGE="${IMAGE}:${SHA1_TAG}"

--- a/docker/image_build.sh
+++ b/docker/image_build.sh
@@ -43,8 +43,8 @@ function validate_and_push() {
 
 echo "Building ${ARCH_SUFFIX} images tagged with sha1 commit digest"
 
-# BIN_PATH is in target/, which is ignored by Dockerfile
-# Not to make .dockerignore unintuitive, we just copy it somewhere visible (tmp)
+# BIN_PATH is in target/, which is ignored by Dockerfile. Not to make .dockerignore unintuitive
+# by allowing target/, we just copy the binary some place visible (tmp).
 mkdir tmp
 VISIBLE_BIN_PATH="tmp/starknet-devnet"
 cp "$BIN_DIR/starknet-devnet" "$VISIBLE_BIN_PATH"
@@ -69,6 +69,5 @@ echo "Images built. Validating and pushing."
 docker login --username "$DOCKER_USER" --password "$DOCKER_PASS"
 
 for image_tag in "$SHA1_TAG" "$SHA1_SEEDED_TAG"; do
-    echo "DEBUG: Not validating or pushing"
-    # TODO validate_and_push "$image_tag"
+    validate_and_push "$image_tag"
 done

--- a/docker/image_build.sh
+++ b/docker/image_build.sh
@@ -30,7 +30,8 @@ function validate_and_push() {
     docker logs "$container_name"
 
     echo "Checking if devnet instance is alive"
-    if [ ! -z $REMOTE ]; then
+    if [ -f /.dockerenv ]; then
+        # inside a container - need to check on docker host
         ssh remote-docker curl "$external_address/is_alive" -w "\n"
     else
         curl "$external_address/is_alive" -w "\n"

--- a/docker/image_build.sh
+++ b/docker/image_build.sh
@@ -48,8 +48,7 @@ BASE_IMAGE="${IMAGE}:${SHA1_TAG}"
 echo "Building regular (unseeded) image: $SHA1_TAG"
 docker build . \
     -f docker/Dockerfile \
-    -t "$BASE_IMAGE" \
-    --build-arg BIN_PATH="$VISIBLE_BIN_PATH"
+    -t "$BASE_IMAGE"
 
 SEED_SUFFIX="-seed0"
 SHA1_SEEDED_TAG="${SHA1_TAG}${SEED_SUFFIX}"

--- a/docker/image_build.sh
+++ b/docker/image_build.sh
@@ -37,7 +37,7 @@ function validate_and_push() {
         curl "$external_address/is_alive" -w "\n"
     fi
 
-    # TODO docker push "$tagged_image"
+    docker push "$tagged_image"
 
     docker rm -f "$container_name"
 }
@@ -60,7 +60,7 @@ docker build . \
     --build-arg BASE_IMAGE="$BASE_IMAGE"
 
 echo "Images built. Validating and pushing."
-# TODO docker login --username "$DOCKER_USER" --password "$DOCKER_PASS"
+docker login --username "$DOCKER_USER" --password "$DOCKER_PASS"
 
 for image_tag in "$SHA1_TAG" "$SHA1_SEEDED_TAG"; do
     validate_and_push "$image_tag"

--- a/docker/image_build.sh
+++ b/docker/image_build.sh
@@ -69,5 +69,6 @@ echo "Images built. Validating and pushing."
 docker login --username "$DOCKER_USER" --password "$DOCKER_PASS"
 
 for image_tag in "$SHA1_TAG" "$SHA1_SEEDED_TAG"; do
-    validate_and_push "$image_tag"
+    echo "DEBUG: Not validating or pushing"
+    # TODO validate_and_push "$image_tag"
 done

--- a/docker/tag_images_and_create_joint_image_manifests.sh
+++ b/docker/tag_images_and_create_joint_image_manifests.sh
@@ -22,13 +22,13 @@ function create_and_push_manifest() {
     local joint_manifest="$IMAGE:${manifest_prefix}${seed_suffix}"
 
     docker manifest create $joint_manifest \
-        "$IMAGE:${CIRCLE_SHA1}-aarch64${seed_suffix}" \
-        "$IMAGE:${CIRCLE_SHA1}-x86_64${seed_suffix}"
+        "$IMAGE:${CIRCLE_SHA1}-arm${seed_suffix}" \
+        "$IMAGE:${CIRCLE_SHA1}-amd${seed_suffix}"
 
     docker manifest push "$joint_manifest"
 }
 
-echo "Creating a joint docker manifest for each pair of -aarch64 and -x86_64 images."
+echo "Creating a joint docker manifest for each pair of -arm and -amd images."
 
 # construct the image tag from the version
 # check if the image tag exists in docker registry
@@ -36,7 +36,7 @@ echo "Creating a joint docker manifest for each pair of -aarch64 and -x86_64 ima
 for seed_suffix in "" "-seed0"; do
     # Pull the pair
     # and tag the image with the crate version if not done yet
-    for image_suffix in "-aarch64" "-x86_64"; do
+    for image_suffix in "-arm" "-amd"; do
         image_tag_with_commit_hash="$IMAGE:${CIRCLE_SHA1}${image_suffix}${seed_suffix}"
         docker pull "$image_tag_with_commit_hash"
 

--- a/docker/tag_images_and_create_joint_image_manifests.sh
+++ b/docker/tag_images_and_create_joint_image_manifests.sh
@@ -22,13 +22,13 @@ function create_and_push_manifest() {
     local joint_manifest="$IMAGE:${manifest_prefix}${seed_suffix}"
 
     docker manifest create $joint_manifest \
-        "$IMAGE:${CIRCLE_SHA1}-arm${seed_suffix}" \
-        "$IMAGE:${CIRCLE_SHA1}-amd${seed_suffix}"
+        "$IMAGE:${CIRCLE_SHA1}-aarch64${seed_suffix}" \
+        "$IMAGE:${CIRCLE_SHA1}-x86_64${seed_suffix}"
 
     docker manifest push "$joint_manifest"
 }
 
-echo "Creating a joint docker manifest for each pair of -arm and -amd images."
+echo "Creating a joint docker manifest for each pair of -aarch64 and -x86_64 images."
 
 # construct the image tag from the version
 # check if the image tag exists in docker registry
@@ -36,7 +36,7 @@ echo "Creating a joint docker manifest for each pair of -arm and -amd images."
 for seed_suffix in "" "-seed0"; do
     # Pull the pair
     # and tag the image with the crate version if not done yet
-    for image_suffix in "-arm" "-amd"; do
+    for image_suffix in "-aarch64" "-x86_64"; do
         image_tag_with_commit_hash="$IMAGE:${CIRCLE_SHA1}${image_suffix}${seed_suffix}"
         docker pull "$image_tag_with_commit_hash"
 

--- a/scripts/check_crate_changes.sh
+++ b/scripts/check_crate_changes.sh
@@ -13,4 +13,4 @@ echo "The crates that need a semver increment since git revision '$version' are:
 
 git diff "$version" --stat | grep -o -E 'crates/[^/]*' | uniq
 
-echo "Note that this does not reflect changes in Cargo.toml or changes that one Devnet crate may have had on another"
+echo "Note that this does not reflect dependency changes in Cargo.toml or changes that one Devnet crate may have had on another!"

--- a/scripts/check_crate_changes.sh
+++ b/scripts/check_crate_changes.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -eu
+
+if [ $# -ne 1 ]; then
+    echo "$0: <VERSION>"
+    exit 1
+fi
+
+version="$1"
+
+echo "The crates that need a semver increment since git revision '$version' are:"
+
+git diff "$version" --stat | grep -o -E 'crates/[^/]*' | uniq
+
+echo "Note that this does not reflect changes in Cargo.toml or changes that one Devnet crate may have had on another"


### PR DESCRIPTION
## Usage related changes

- Closes #269.
- The plan for future releases is described in: https://github.com/0xSpaceShard/starknet-devnet-rs/issues/269#issuecomment-2047406952. The next release after this PR is merged should have the artifacts attached.
- Improve README.md
  - More systematic installation instructions
  - Pythonic Devnet uninstallation notice
  - Replace `cargo run --` with `starknet-devnet`
    - Rationale: those who know how to build from source will know how to run from source
- [README on crates.io](https://crates.io/crates/starknet-devnet) is empty - this is fixed by relying on the workspace README

## Development related changes
- Remove dependency on runtime predeployed contract artifacts being at exact paths
  - Done by using `include_str!` macro which reads path at compile-time
  - `fn cairo_1_from_path` become unused so it's removed
- Install vendored openssl, couldn't build otherwise - this also allows removing `libssl-dev` installation from Dockerfile
- Every platform from the matrix [x86_64, aarch64] x [unknown-linux-gnu, unknown-linux-musl, apple-darwin] is supported in binary build
- Dockerization could be improved by reusing the built binaries (worth opening an issue)
- Built Docker image validation no longer relying on the `REMOTE` env var - checking `/.dockerenv` instead
- Add docs about new version release
  - Add `scripts/check_crate_changes.sh`
- Improve main workflow name
  - Often I would confuse the workflow name and the branch name on CircleCI since they can both be `main`.

## Checklist:

- [x] Checked the relevant parts of [development docs](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#development)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
- [x] Updated the docs if needed, including the [TODO section](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#todo-to-reach-feature-parity-with-the-pythonic-devnet)
- [x] Linked the issues which this PR resolves
- [x] Updated the tests if needed; all passing ([execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#test-execution))
