### PR TITLE
Update Starknet version constant to 0.13.1.1; Update docs on updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,8 +491,6 @@ This is what happens under the hood on `main`:
 - create and push joint docker manifest called `shardlabs/starknet-devnet-rs-<COMMIT_SHA1>`
   - same for `latest`
 
-In the image, `tini` is used to properly handle killing of dockerized Devnet with Ctrl+C
-
 ### Development - L1 / L2 (postman)
 
 To test Starknet messaging, Devnet exposes endpoints prefixed with `postman/` which are dedicated to the messaging feature.
@@ -505,9 +503,17 @@ Devnet exposes the following endpoints:
 - `/postman/send_message_to_l2`: sends and executes a message on L2 (L1 node **not** required).
 - `/postman/consume_message_from_l2`: consumes a message on L1 node from the L2 (requires L1 node to be running).
 
-### Development - Update of OpenZeppelin contracts
+### Development - Updating OpenZeppelin contracts
 
 Tests in devnet require an erc20 contract with the `Mintable` feature, keep in mind that before the compilation process of [cairo-contracts](https://github.com/OpenZeppelin/cairo-contracts/) you need to mark the `Mintable` check box in this [wizard](https://wizard.openzeppelin.com/cairo) and copy this implementation to `/src/presets/erc20.cairo`.
+
+### Development - Updating Starknet
+
+Updating the underlying Starknet is done by updating the `blockifier` dependency. It also requires updating the `STARKNET_VERSION` constant.
+
+### Development - Updating JSON-RPC API
+
+Updating the RPC requires following the specification files in the [starknet-specs repository](https://github.com/starkware-libs/starknet-specs). The spec_reader testing utility requires these files to be copied into the Devnet repository. The `RPC_SPEC_VERSION` constant needs to be updated accordingly.
 
 ## ✏️ Contributing
 

--- a/crates/starknet-devnet-core/src/constants.rs
+++ b/crates/starknet-devnet-core/src/constants.rs
@@ -50,7 +50,7 @@ pub const UDC_CONTRACT_CLASS_HASH: &str =
 pub const UDC_CONTRACT_ADDRESS: &str =
     "0x41A78E741E5AF2FEC34B695679BC6891742439F7AFB8484ECD7766661AD02BF";
 
-pub const STARKNET_VERSION: &str = "0.13.1";
+pub const STARKNET_VERSION: &str = "0.13.1.1";
 
 /// ERC20 contracts storage variables
 /// taken from starkcan urls:


### PR DESCRIPTION
## Usage related changes

- Use the correct Starknet version constant (0.13.1.1)

## Development related changes

- Improve dev docs on updating Starknet (blockifier) and RPC
- `tini` notice is removed from Docker docs because it is already mentioned in the Dockerfile (redundancy)

## Checklist:

- [x] Checked the relevant parts of [development docs](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#development)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
- [x] Updated the docs if needed, including the [TODO section](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#todo-to-reach-feature-parity-with-the-pythonic-devnet)
- [x] Linked the issues which this PR resolves
- [x] Updated the tests if needed; all passing ([execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#test-execution))
