### PR TITLE
Fix of value_name for dump_on

### DIFF
--- a/crates/starknet-devnet/src/cli.rs
+++ b/crates/starknet-devnet/src/cli.rs
@@ -104,7 +104,7 @@ pub(crate) struct Args {
     chain_id: ChainId,
 
     #[arg(long = "dump-on")]
-    #[arg(value_name = "DUMP_ON")]
+    #[arg(value_name = "EVENT")]
     #[arg(help = "Specify when to dump the state of Devnet;")]
     #[arg(requires = "dump_path")]
     dump_on: Option<DumpOn>,

--- a/crates/starknet-devnet/src/cli.rs
+++ b/crates/starknet-devnet/src/cli.rs
@@ -104,7 +104,7 @@ pub(crate) struct Args {
     chain_id: ChainId,
 
     #[arg(long = "dump-on")]
-    #[arg(value_name = "WHEN")]
+    #[arg(value_name = "DUMP_ON")]
     #[arg(help = "Specify when to dump the state of Devnet;")]
     #[arg(requires = "dump_path")]
     dump_on: Option<DumpOn>,


### PR DESCRIPTION
## Usage related changes

- Fix of value_name for dump_on

## Checklist:

- [x] Checked the relevant parts of [development docs](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#development)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
- [x] Updated the docs if needed, including the [TODO section](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#todo-to-reach-feature-parity-with-the-pythonic-devnet)
- [x] Linked the issues which this PR resolves
- [x] Updated the tests if needed; all passing ([execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#test-execution))
