### PR TITLE
Fix starknet_getClassAt in forked mode

### DIFF
--- a/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
@@ -209,7 +209,9 @@ impl JsonRpcHandler {
             Err(Error::NoBlock) => Err(ApiError::BlockNotFound),
             Err(Error::StateError(StateError::NoneClassHash(_))) => {
                 // NoneClassHash can be returned only when forking, otherwise it means that
-                // address locally is present, but class hash isn't, which is a bug.
+                // contract_address is locally present, but its class hash isn't, which is a bug.
+                // ClassHashNotFound is not expected to be returned by the server, but to be handled
+                // by the forking logic as a signal to forward the request to the origin.
                 Err(ApiError::ClassHashNotFound)
             }
             Err(Error::ContractNotFound | Error::StateError(_)) => Err(ApiError::ContractNotFound),

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -215,10 +215,11 @@ impl JsonRpcHandler {
                 | error::ApiError::TransactionNotFound
                 | error::ApiError::NoStateAtBlock { .. }
                 | error::ApiError::ClassHashNotFound => {
-                    // ClassHashNotFound can be thrown from starknet_getClass or
-                    // starknet_deployAccount, but only starknet_getClass should be retried from
-                    // here; starknet_deployAccount already fetches from origin internally. This is
-                    // handled by (un)setting the `forwardable` flag
+                    // ClassHashNotFound can be thrown from starknet_getClass, starknet_getClassAt
+                    // or starknet_deployAccount, but starknet_deployAccount
+                    // doesn't need to be retried from here as it already attempted fetching from
+                    // the origin internally. This distinction is handled by (un)setting the
+                    // `forwardable` flag
 
                     if forwardable {
                         return forwarder.call(&original_call).await;

--- a/crates/starknet-devnet/tests/test_fork.rs
+++ b/crates/starknet-devnet/tests/test_fork.rs
@@ -249,13 +249,20 @@ mod fork_tests {
             .unwrap();
         assert_eq!(retrieved_class_hash, class_hash);
 
-        let retrieved_class = fork_devnet
+        let expected_sierra = ContractClass::Sierra(contract_class);
+        let retrieved_class_by_hash = fork_devnet
             .json_rpc_client
             .get_class(BlockId::Tag(BlockTag::Latest), class_hash)
             .await
             .unwrap();
-        assert_cairo1_classes_equal(retrieved_class, ContractClass::Sierra(contract_class))
+        assert_cairo1_classes_equal(retrieved_class_by_hash, expected_sierra.clone()).unwrap();
+
+        let retrieved_class_by_address = fork_devnet
+            .json_rpc_client
+            .get_class_at(BlockId::Tag(BlockTag::Latest), contract_address)
+            .await
             .unwrap();
+        assert_cairo1_classes_equal(retrieved_class_by_address, expected_sierra).unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Usage related changes

- Close #413
- Open #424
  - Will handle in a separate PR

## Development related changes

- Expand `test_getting_cairo1_class_from_origin_and_fork` in test_fork.rs to include get_class_at assertion

## Checklist:

- [x] Checked the relevant parts of [development docs](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#development)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
- [x] Updated the docs if needed, including the [TODO section](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#todo-to-reach-feature-parity-with-the-pythonic-devnet)
- [x] Linked the issues which this PR resolves
- [x] Updated the tests if needed; all passing ([execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#test-execution))
