### PR TITLE
Fix binary fetching script

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,7 +546,7 @@ To release a new version, follow these steps:
 
 3. When the CI workflow is done, create a git tag of the form `vX.Y.Z`, push it and create a GitHub release with notes describing changes since the last release.
 
-4. Attach the [binary artifacts built in CI](https://circleci.com/docs/artifacts/#artifacts-overview) to the release. You can use `scripts/fetch_ci_binaries.py`
+4. Attach the [binary artifacts built in CI](https://circleci.com/docs/artifacts/#artifacts-overview) to the release. Use `scripts/fetch_ci_binaries.py` to fetch all artifacts of a CI workflow.
 
 ## ✏️ Contributing
 


### PR DESCRIPTION
## Usage related changes

- None

## Development related changes

- The binary fetching script could so far only download the artifacts of latest main workflow, which is a problem if its commit message contains `[skip ci]`. Now it defaults to the latest successful main workflow, and also supports providing a workflow ID via `scripts/fetch_ci_binaries.py --workflow <ID>`.
- Readme also improved.

## Checklist:

- [x] Checked the relevant parts of [development docs](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#development)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
- [x] Updated the docs if needed, including the [TODO section](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#todo-to-reach-feature-parity-with-the-pythonic-devnet)
- [x] Linked the issues which this PR resolves
- [x] Updated the tests if needed; all passing ([execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#test-execution))
