### PR TITLE
Fix predeployed account constructor simulation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,5 +15,5 @@
 - [ ] Performed code self-review
 - [ ] Rebased to the latest commit of the target branch (or merged it into my branch)
 - [ ] Updated the docs if needed, including the [TODO section](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#todo-to-reach-feature-parity-with-the-pythonic-devnet)
-- [ ] Linked the issues which this PR resolves
+- [ ] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) which this PR resolves
 - [ ] Updated the tests if needed; all passing ([execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#test-execution))

--- a/README.md
+++ b/README.md
@@ -528,6 +528,8 @@ Devnet exposes the following endpoints:
 
 Tests in devnet require an erc20 contract with the `Mintable` feature, keep in mind that before the compilation process of [cairo-contracts](https://github.com/OpenZeppelin/cairo-contracts/) you need to mark the `Mintable` check box in this [wizard](https://wizard.openzeppelin.com/cairo) and copy this implementation to `/src/presets/erc20.cairo`.
 
+If smart contract constructor logic has changed, Devnet's predeployment logic needs to be changed, e.g. `simulate_constructor` in `crates/starknet-devnet-core/src/account.rs`.
+
 ### Development - Updating Starknet
 
 Updating the underlying Starknet is done by updating the `blockifier` dependency. It also requires updating the `STARKNET_VERSION` constant.

--- a/crates/starknet-devnet-core/src/account.rs
+++ b/crates/starknet-devnet-core/src/account.rs
@@ -16,7 +16,7 @@ use starknet_types::traits::HashProducer;
 
 use crate::constants::{
     CAIRO_0_ACCOUNT_CONTRACT, CHARGEABLE_ACCOUNT_ADDRESS, CHARGEABLE_ACCOUNT_PRIVATE_KEY,
-    CHARGEABLE_ACCOUNT_PUBLIC_KEY,
+    CHARGEABLE_ACCOUNT_PUBLIC_KEY, ISRC6_ID_HEX,
 };
 use crate::error::DevnetResult;
 use crate::state::state_readers::DictState;
@@ -110,16 +110,29 @@ impl Deployed for Account {
 
         state.predeploy_contract(self.account_address, self.class_hash)?;
 
-        // set public key directly in the most underlying state
+        // set balance directly in the most underlying state
+        self.set_initial_balance(&mut state.state.state)?;
+
+        // simulate constructor logic (register interfaces and set public key), as done in
+        // https://github.com/OpenZeppelin/cairo-contracts/blob/89a450a88628ec3b86273f261b2d8d1ca9b1522b/src/account/account.cairo#L207-L211
+        let core_address = self.account_address.try_into()?;
+
+        let interface_storage_var = get_storage_var_address(
+            "SRC5_supported_interfaces",
+            &[Felt::from_prefixed_hex_str(ISRC6_ID_HEX)?],
+        )?;
+        state.state.state.set_storage_at(
+            core_address,
+            interface_storage_var.try_into()?,
+            StarkFelt::ONE,
+        )?;
+
         let public_key_storage_var = get_storage_var_address("Account_public_key", &[])?;
         state.state.state.set_storage_at(
-            self.account_address.try_into()?,
+            core_address,
             public_key_storage_var.try_into()?,
             self.public_key.into(),
         )?;
-
-        // set balance directly in the most underlying state
-        self.set_initial_balance(&mut state.state.state)?;
 
         Ok(())
     }

--- a/crates/starknet-devnet-core/src/constants.rs
+++ b/crates/starknet-devnet-core/src/constants.rs
@@ -52,6 +52,9 @@ pub const UDC_CONTRACT_CLASS_HASH: &str =
 pub const UDC_CONTRACT_ADDRESS: &str =
     "0x41A78E741E5AF2FEC34B695679BC6891742439F7AFB8484ECD7766661AD02BF";
 
+/// https://github.com/OpenZeppelin/cairo-contracts/blob/89a450a88628ec3b86273f261b2d8d1ca9b1522b/src/account/interface.cairo#L7
+pub const ISRC6_ID_HEX: &str = "0x2ceccef7f994940b3962a6c67e0ba4fcd37df7d131417c604f91e03caecc1cd";
+
 pub const STARKNET_VERSION: &str = "0.13.1.1";
 
 /// ERC20 contracts storage variables

--- a/crates/starknet-devnet-core/src/state/mod.rs
+++ b/crates/starknet-devnet-core/src/state/mod.rs
@@ -38,6 +38,8 @@ pub trait CustomState {
         class_hash: ClassHash,
         contract_class: ContractClass,
     ) -> DevnetResult<()>;
+
+    /// Link contract address to class hash
     fn predeploy_contract(
         &mut self,
         contract_address: ContractAddress,

--- a/crates/starknet-devnet/tests/test_account_selection.rs
+++ b/crates/starknet-devnet/tests/test_account_selection.rs
@@ -241,7 +241,6 @@ mod test_account_selection {
 
         let resp = devnet.json_rpc_client.call(call, BlockId::Tag(BlockTag::Latest)).await;
         match resp {
-            // TODO currently fails
             Ok(supports) => assert_eq!(supports, vec![FieldElement::ONE]),
             err => panic!("Unexpected resp: {err:?}"),
         };

--- a/crates/starknet-devnet/tests/test_account_selection.rs
+++ b/crates/starknet-devnet/tests/test_account_selection.rs
@@ -16,7 +16,7 @@ mod test_account_selection {
     use starknet_rs_core::types::contract::legacy::LegacyContractClass;
     use starknet_rs_core::types::{
         BlockId, BlockTag, FieldElement, FunctionCall, MaybePendingTransactionReceipt,
-        TransactionReceipt,
+        TransactionFinalityStatus, TransactionReceipt,
     };
     use starknet_rs_core::utils::{
         get_selector_from_name, get_udc_deployed_address, UdcUniqueness,
@@ -113,11 +113,10 @@ mod test_account_selection {
 
         match deploy_account_receipt {
             MaybePendingTransactionReceipt::Receipt(TransactionReceipt::DeployAccount(receipt)) => {
+                assert_eq!(receipt.finality_status, TransactionFinalityStatus::AcceptedOnL2);
                 assert_eq!(receipt.contract_address, new_account_address);
             }
-            _ => {
-                panic!("Invalid receipt {:?}", deploy_account_receipt);
-            }
+            _ => panic!("Invalid receipt {:?}", deploy_account_receipt),
         }
     }
 
@@ -133,11 +132,8 @@ mod test_account_selection {
 
     #[tokio::test]
     async fn can_deploy_new_custom_account() {
-        can_deploy_new_account_test_body(&[
-            "--account-class-custom",
-            CAIRO_1_ACCOUNT_CONTRACT_SIERRA_PATH,
-        ])
-        .await;
+        let args = ["--account-class-custom", CAIRO_1_ACCOUNT_CONTRACT_SIERRA_PATH];
+        can_deploy_new_account_test_body(&args).await;
     }
 
     /// Common body for tests defined below
@@ -220,10 +216,7 @@ mod test_account_selection {
 
     #[tokio::test]
     async fn can_declare_deploy_invoke_using_predeployed_custom() {
-        can_declare_deploy_invoke_using_predeployed_test_body(&[
-            "--account-class-custom",
-            CAIRO_1_ACCOUNT_CONTRACT_SIERRA_PATH,
-        ])
-        .await;
+        let args = ["--account-class-custom", CAIRO_1_ACCOUNT_CONTRACT_SIERRA_PATH];
+        can_declare_deploy_invoke_using_predeployed_test_body(&args).await;
     }
 }


### PR DESCRIPTION
## Usage related changes

- Close #422 

## Development related changes

- Extract constructor simulation logic of predeployed accounts to `simulate_constructor`.
- Deliberately using two constants for `ISRC6_ID_HEX`, one in production, the other in testing.
- Reuse account deployment logic in tests (`deploy_account` utility function).

## Checklist:

- [x] Checked the relevant parts of [development docs](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#development)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
- [x] Updated the docs if needed, including the [TODO section](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#todo-to-reach-feature-parity-with-the-pythonic-devnet)
- [x] Linked the issues which this PR resolves
- [x] Updated the tests if needed; all passing ([execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#test-execution))
