### PR TITLE
Introduce config endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ After [git-cloning](https://github.com/git-guides/git-clone) this repository, ru
 $ cargo run
 ```
 
+Specify optional CLI params like this:
+
+```
+$ cargo run -- [ARGS]
+```
+
 For a more optimized performance (though with a longer compilation time), run:
 
 ```

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ To retrieve the current configuration of Devnet, send a GET request to `/config`
   "state_archive": "none",
   "fork_config": {
     "url": "http://rpc.pathfinder.equilibrium.co/integration-sepolia/rpc/v0_7",
-    "block": 26429
+    "block_number": 26429
   },
   "server_config": {
     "host": "127.0.0.1",

--- a/README.md
+++ b/README.md
@@ -408,24 +408,7 @@ $ starknet-devnet --fork-network <URL> [--fork-block <BLOCK_NUMBER>]
 
 The value passed to `--fork-network` should be the URL to a Starknet JSON-RPC API provider. Specifying a `--fork-block` is optional; it defaults to the `"latest"` block at the time of Devnet's start-up. All calls will first try Devnet's state and then fall back to the forking block.
 
-### Forking status
-
-```
-GET /fork_status
-```
-
-Response when Devnet is a fork of an origin:
-
-```js
-{
-  "url": "https://your.origin.io",
-  "block": 42 // the block from which origin was forked
-}
-```
-
-Response when not forking: `{}`
-
-### Querying old state by specifying block hash or number
+## Querying old state by specifying block hash or number
 
 With state archive capacity set to `full`, Devnet will store full state history. The default mode is `none`, where no old states are stored.
 
@@ -434,6 +417,36 @@ $ starknet-devnet --state-archive-capacity <CAPACITY>
 ```
 
 All RPC endpoints that support querying the state at an old (non-latest) block only work with state archive capacity set to `full`.
+
+## Fetch Devnet configuration
+
+To retrieve the current configuration of Devnet, send a GET request to `/config`. Example response is attached below. It can be interpreted as a JSON mapping of CLI input parameters, both specified and default ones, with some irrelevant parameters omitted. So use `starknet-devnet --help` to better understand the meaning of each value.
+
+```json
+{
+  "seed": 4063802897,
+  "total_accounts": 10,
+  "account_contract_class_hash": "0x61dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2971b8f",
+  "predeployed_accounts_initial_balance": "1000000000000000000000",
+  "start_time": null,
+  "gas_price": 100000000000,
+  "data_gas_price": 100000000000,
+  "chain_id": "SN_SEPOLIA",
+  "dump_on": null,
+  "dump_path": null,
+  "state_archive": "None",
+  "fork_config": {
+    "url": "http://rpc.pathfinder.equilibrium.co/integration-sepolia/rpc/v0_7",
+    "block": 26429
+  },
+  "server_config": {
+    "host": "127.0.0.1",
+    "port": 5050,
+    "timeout": 120,
+    "request_body_size_limit": 2000000
+  }
+}
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ All RPC endpoints that support querying the state at an old (non-latest) block o
 
 ## Fetch Devnet configuration
 
-To retrieve the current configuration of Devnet, send a GET request to `/config`. Example response is attached below. It can be interpreted as a JSON mapping of CLI input parameters, both specified and default ones, with some irrelevant parameters omitted. So use `starknet-devnet --help` to better understand the meaning of each value.
+To retrieve the current configuration of Devnet, send a GET request to `/config`. Example response is attached below. It can be interpreted as a JSON mapping of CLI input parameters, both specified and default ones, with some irrelevant parameters omitted. So use `starknet-devnet --help` to better understand the meaning of each value, though keep in mind that some of the parameters have slightly modified names.
 
 ```json
 {
@@ -432,9 +432,9 @@ To retrieve the current configuration of Devnet, send a GET request to `/config`
   "gas_price": 100000000000,
   "data_gas_price": 100000000000,
   "chain_id": "SN_SEPOLIA",
-  "dump_on": null,
-  "dump_path": null,
-  "state_archive": "None",
+  "dump_on": "exit",
+  "dump_path": "dump_path.json",
+  "state_archive": "none",
   "fork_config": {
     "url": "http://rpc.pathfinder.equilibrium.co/integration-sepolia/rpc/v0_7",
     "block": 26429

--- a/crates/starknet-devnet-core/src/starknet/starknet_config.rs
+++ b/crates/starknet-devnet-core/src/starknet/starknet_config.rs
@@ -1,5 +1,6 @@
 use std::num::NonZeroU128;
 
+use serde::{Serialize, Serializer};
 use starknet_types::chain_id::ChainId;
 use starknet_types::contract_class::ContractClass;
 use starknet_types::felt::Felt;
@@ -13,13 +14,13 @@ use crate::constants::{
     DEVNET_DEFAULT_TOTAL_ACCOUNTS,
 };
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, clap::ValueEnum)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, clap::ValueEnum, Serialize)]
 pub enum DumpOn {
     Exit,
     Transaction,
 }
 
-#[derive(Default, Copy, Clone, Debug, Eq, PartialEq, clap::ValueEnum)]
+#[derive(Default, Copy, Clone, Debug, Eq, PartialEq, clap::ValueEnum, Serialize)]
 pub enum StateArchiveCapacity {
     #[default]
     #[clap(name = "none")]
@@ -28,13 +29,24 @@ pub enum StateArchiveCapacity {
     Full,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct ForkConfig {
+    #[serde(serialize_with = "serialize_config_url")]
     pub url: Option<Url>,
     pub block_number: Option<u64>,
 }
 
-#[derive(Clone, Debug)]
+pub fn serialize_config_url<S>(url: &Option<Url>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match url {
+        Some(url) => serializer.serialize_str(url.as_ref()),
+        None => serializer.serialize_none(),
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
 pub struct StarknetConfig {
     pub seed: u32,
     pub total_accounts: u8,

--- a/crates/starknet-devnet-core/src/starknet/starknet_config.rs
+++ b/crates/starknet-devnet-core/src/starknet/starknet_config.rs
@@ -24,11 +24,10 @@ pub enum DumpOn {
 
 #[derive(Default, Copy, Clone, Debug, Eq, PartialEq, clap::ValueEnum, Serialize)]
 #[serde(rename_all = "snake_case")]
+#[clap(rename_all = "snake_case")]
 pub enum StateArchiveCapacity {
     #[default]
-    #[clap(name = "none")]
     None,
-    #[clap(name = "full")]
     Full,
 }
 

--- a/crates/starknet-devnet-core/src/starknet/starknet_config.rs
+++ b/crates/starknet-devnet-core/src/starknet/starknet_config.rs
@@ -16,12 +16,14 @@ use crate::constants::{
 };
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, clap::ValueEnum, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum DumpOn {
     Exit,
     Transaction,
 }
 
 #[derive(Default, Copy, Clone, Debug, Eq, PartialEq, clap::ValueEnum, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum StateArchiveCapacity {
     #[default]
     #[clap(name = "none")]

--- a/crates/starknet-devnet-core/src/starknet/starknet_config.rs
+++ b/crates/starknet-devnet-core/src/starknet/starknet_config.rs
@@ -46,20 +46,38 @@ where
     }
 }
 
+pub fn serialize_initial_balance<S>(balance: &Balance, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&balance.to_str_radix(10))
+}
+
+pub fn serialize_chain_id<S>(chain_id: &ChainId, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&format!("{chain_id}"))
+}
+
 #[derive(Clone, Debug, Serialize)]
 pub struct StarknetConfig {
     pub seed: u32,
     pub total_accounts: u8,
+    #[serde(skip_serializing)]
     pub account_contract_class: ContractClass,
     pub account_contract_class_hash: Felt,
+    #[serde(serialize_with = "serialize_initial_balance")]
     pub predeployed_accounts_initial_balance: Balance,
     pub start_time: Option<u64>,
     pub gas_price: NonZeroU128,
     pub data_gas_price: NonZeroU128,
+    #[serde(serialize_with = "serialize_chain_id")]
     pub chain_id: ChainId,
     pub dump_on: Option<DumpOn>,
     pub dump_path: Option<String>,
     /// on initialization, re-execute loaded txs (if any)
+    #[serde(skip_serializing)]
     pub re_execute_on_init: bool,
     pub state_archive: StateArchiveCapacity,
     pub fork_config: ForkConfig,

--- a/crates/starknet-devnet-core/src/starknet/starknet_config.rs
+++ b/crates/starknet-devnet-core/src/starknet/starknet_config.rs
@@ -53,16 +53,6 @@ where
     }
 }
 
-pub fn serialize_config_url<S>(url: &Option<Url>, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    match url {
-        Some(url) => serializer.serialize_str(url.as_ref()),
-        None => serializer.serialize_none(),
-    }
-}
-
 pub fn serialize_initial_balance<S>(balance: &Balance, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,

--- a/crates/starknet-devnet-core/src/starknet/starknet_config.rs
+++ b/crates/starknet-devnet-core/src/starknet/starknet_config.rs
@@ -1,6 +1,5 @@
 use std::num::NonZeroU128;
 
-use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
 use starknet_types::chain_id::ChainId;
 use starknet_types::contract_class::ContractClass;
@@ -31,24 +30,19 @@ pub enum StateArchiveCapacity {
     Full,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct ForkConfig {
+    #[serde(serialize_with = "serialize_config_url")]
     pub url: Option<Url>,
     pub block_number: Option<u64>,
 }
 
-pub fn serialize_fork_config<S>(fork_config: &ForkConfig, serializer: S) -> Result<S::Ok, S::Error>
+pub fn serialize_config_url<S>(url: &Option<Url>, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
-    match &fork_config.url {
-        Some(url) => {
-            let mut fork_config_serializer = serializer.serialize_struct("fork_config", 2)?;
-            fork_config_serializer.serialize_field("url", &url.to_string())?;
-            let block_number = fork_config.block_number.unwrap();
-            fork_config_serializer.serialize_field("block", &block_number)?;
-            fork_config_serializer.end()
-        }
+    match url {
+        Some(url) => serializer.serialize_str(url.as_ref()),
         None => serializer.serialize_none(),
     }
 }
@@ -87,7 +81,6 @@ pub struct StarknetConfig {
     #[serde(skip_serializing)]
     pub re_execute_on_init: bool,
     pub state_archive: StateArchiveCapacity,
-    #[serde(serialize_with = "serialize_fork_config")]
     pub fork_config: ForkConfig,
 }
 

--- a/crates/starknet-devnet-server/src/api/http/endpoints/mod.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/mod.rs
@@ -3,7 +3,6 @@ use serde::Serialize;
 use starknet_core::starknet::starknet_config::StarknetConfig;
 
 use super::error::HttpApiError;
-use super::models::ForkStatus;
 use super::{HttpApiHandler, HttpApiResult};
 use crate::ServerConfig;
 
@@ -42,23 +41,10 @@ pub async fn restart(Extension(state): Extension<HttpApiHandler>) -> HttpApiResu
     Ok(())
 }
 
-/// Fork
-/// TODO remove this - redundant if introducing config endpoint
-pub async fn get_fork_status(
-    Extension(state): Extension<HttpApiHandler>,
-) -> HttpApiResult<Json<ForkStatus>> {
-    let fork_config = &state.api.starknet.read().await.config.fork_config;
-    Ok(Json(ForkStatus {
-        url: fork_config.url.as_ref().map(|url| url.to_string()),
-        block: fork_config.block_number,
-    }))
-}
-
 #[derive(Serialize)]
 pub struct DevnetConfig {
     #[serde(flatten)]
     starknet_config: StarknetConfig,
-    #[serde(flatten)]
     server_config: ServerConfig,
 }
 

--- a/crates/starknet-devnet-server/src/api/http/endpoints/mod.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/mod.rs
@@ -1,4 +1,5 @@
 use axum::{Extension, Json};
+use starknet_core::starknet::starknet_config::StarknetConfig;
 
 use super::error::HttpApiError;
 use super::models::ForkStatus;
@@ -40,6 +41,7 @@ pub async fn restart(Extension(state): Extension<HttpApiHandler>) -> HttpApiResu
 }
 
 /// Fork
+/// TODO remove this - redundant if introducing config endpoint
 pub async fn get_fork_status(
     Extension(state): Extension<HttpApiHandler>,
 ) -> HttpApiResult<Json<ForkStatus>> {
@@ -48,4 +50,11 @@ pub async fn get_fork_status(
         url: fork_config.url.as_ref().map(|url| url.to_string()),
         block: fork_config.block_number,
     }))
+}
+
+/// Devnet config
+pub async fn get_devnet_config(
+    Extension(state): Extension<HttpApiHandler>,
+) -> HttpApiResult<Json<StarknetConfig>> {
+    Ok(Json(state.api.starknet.read().await.config.clone()))
 }

--- a/crates/starknet-devnet-server/src/api/http/endpoints/mod.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/mod.rs
@@ -1,9 +1,11 @@
 use axum::{Extension, Json};
+use serde::Serialize;
 use starknet_core::starknet::starknet_config::StarknetConfig;
 
 use super::error::HttpApiError;
 use super::models::ForkStatus;
 use super::{HttpApiHandler, HttpApiResult};
+use crate::ServerConfig;
 
 /// Dumping and loading
 pub mod dump_load;
@@ -52,9 +54,20 @@ pub async fn get_fork_status(
     }))
 }
 
+#[derive(Serialize)]
+pub struct DevnetConfig {
+    #[serde(flatten)]
+    starknet_config: StarknetConfig,
+    #[serde(flatten)]
+    server_config: ServerConfig,
+}
+
 /// Devnet config
 pub async fn get_devnet_config(
     Extension(state): Extension<HttpApiHandler>,
-) -> HttpApiResult<Json<StarknetConfig>> {
-    Ok(Json(state.api.starknet.read().await.config.clone()))
+) -> HttpApiResult<Json<DevnetConfig>> {
+    Ok(Json(DevnetConfig {
+        starknet_config: state.api.starknet.read().await.config.clone(),
+        server_config: state.server_config.clone(),
+    }))
 }

--- a/crates/starknet-devnet-server/src/api/http/mod.rs
+++ b/crates/starknet-devnet-server/src/api/http/mod.rs
@@ -5,6 +5,7 @@ mod models;
 
 use self::error::HttpApiError;
 use super::Api;
+use crate::ServerConfig;
 
 /// Helper type for the result of the http api calls and reducing typing HttpApiError
 type HttpApiResult<T> = Result<T, HttpApiError>;
@@ -13,4 +14,5 @@ type HttpApiResult<T> = Result<T, HttpApiError>;
 #[derive(Clone)]
 pub struct HttpApiHandler {
     pub api: Api,
+    pub server_config: ServerConfig,
 }

--- a/crates/starknet-devnet-server/src/api/json_rpc/models.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/models.rs
@@ -132,9 +132,8 @@ pub struct DeployAccountTransactionOutput {
 }
 
 #[derive(Deserialize, Debug, Clone)]
-#[serde(tag = "type")]
+#[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum BroadcastedInvokeTransactionEnumWrapper {
-    #[serde(rename = "INVOKE")]
     Invoke(BroadcastedInvokeTransaction),
 }
 

--- a/crates/starknet-devnet-server/src/config.rs
+++ b/crates/starknet-devnet-server/src/config.rs
@@ -1,6 +1,8 @@
 use std::net::IpAddr;
 
-#[derive(Debug, Clone)]
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
 pub struct ServerConfig {
     pub host: IpAddr,
     pub port: u16,

--- a/crates/starknet-devnet-server/src/server.rs
+++ b/crates/starknet-devnet-server/src/server.rs
@@ -55,5 +55,6 @@ pub fn serve_http_api_json_rpc(
         .http_api_route("/account_balance", get(http::accounts::get_account_balance))
         .http_api_route("/mint", post(http::mint_token::mint))
         .http_api_route("/fork_status", get(http::get_fork_status))
+        .http_api_route("/config", get(http::get_devnet_config))
         .build(server_config)
 }

--- a/crates/starknet-devnet-server/src/server.rs
+++ b/crates/starknet-devnet-server/src/server.rs
@@ -19,7 +19,7 @@ pub fn serve_http_api_json_rpc(
     starknet_config: &StarknetConfig,
     server_config: &ServerConfig,
 ) -> ServerResult<StarknetDevnetServer> {
-    let http = HttpApiHandler { api: api.clone() };
+    let http = HttpApiHandler { api: api.clone(), server_config: server_config.clone() };
     let origin_caller = if let (Some(url), Some(block_number)) =
         (&starknet_config.fork_config.url, starknet_config.fork_config.block_number)
     {

--- a/crates/starknet-devnet-server/src/server.rs
+++ b/crates/starknet-devnet-server/src/server.rs
@@ -54,7 +54,6 @@ pub fn serve_http_api_json_rpc(
         .http_api_route("/predeployed_accounts", get(http::accounts::get_predeployed_accounts))
         .http_api_route("/account_balance", get(http::accounts::get_account_balance))
         .http_api_route("/mint", post(http::mint_token::mint))
-        .http_api_route("/fork_status", get(http::get_fork_status))
         .http_api_route("/config", get(http::get_devnet_config))
         .build(server_config)
 }

--- a/crates/starknet-devnet-types/src/chain_id.rs
+++ b/crates/starknet-devnet-types/src/chain_id.rs
@@ -1,12 +1,13 @@
 use std::fmt::Display;
 
+use serde::Serialize;
 use starknet_rs_core::chain_id::{MAINNET, SEPOLIA, TESTNET};
 use starknet_rs_core::utils::parse_cairo_short_string;
 use starknet_rs_ff::FieldElement;
 
 use crate::felt::Felt;
 
-#[derive(Clone, Copy, Debug, clap::ValueEnum)]
+#[derive(Clone, Copy, Debug, clap::ValueEnum, Serialize)]
 pub enum ChainId {
     #[clap(name = "MAINNET")]
     Mainnet,

--- a/crates/starknet-devnet-types/src/chain_id.rs
+++ b/crates/starknet-devnet-types/src/chain_id.rs
@@ -1,13 +1,12 @@
 use std::fmt::Display;
 
-use serde::Serialize;
 use starknet_rs_core::chain_id::{MAINNET, SEPOLIA, TESTNET};
 use starknet_rs_core::utils::parse_cairo_short_string;
 use starknet_rs_ff::FieldElement;
 
 use crate::felt::Felt;
 
-#[derive(Clone, Copy, Debug, clap::ValueEnum, Serialize)]
+#[derive(Clone, Copy, Debug, clap::ValueEnum)]
 pub enum ChainId {
     #[clap(name = "MAINNET")]
     Mainnet,

--- a/crates/starknet-devnet-types/src/chain_id.rs
+++ b/crates/starknet-devnet-types/src/chain_id.rs
@@ -7,10 +7,9 @@ use starknet_rs_ff::FieldElement;
 use crate::felt::Felt;
 
 #[derive(Clone, Copy, Debug, clap::ValueEnum)]
+#[clap(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum ChainId {
-    #[clap(name = "MAINNET")]
     Mainnet,
-    #[clap(name = "TESTNET")]
     Testnet,
 }
 

--- a/crates/starknet-devnet-types/src/rpc/transaction_receipt.rs
+++ b/crates/starknet-devnet-types/src/rpc/transaction_receipt.rs
@@ -274,9 +274,7 @@ pub struct FeeAmount {
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "unit")]
 pub enum FeeInUnits {
-    #[serde(rename = "WEI")]
     WEI(FeeAmount),
-    #[serde(rename = "FRI")]
     FRI(FeeAmount),
 }
 

--- a/crates/starknet-devnet-types/src/rpc/transactions.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions.rs
@@ -115,17 +115,12 @@ impl fmt::Display for TransactionType {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "type", deny_unknown_fields)]
+#[serde(tag = "type", deny_unknown_fields, rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum Transaction {
-    #[serde(rename = "DECLARE")]
     Declare(DeclareTransaction),
-    #[serde(rename = "DEPLOY_ACCOUNT")]
     DeployAccount(DeployAccountTransaction),
-    #[serde(rename = "DEPLOY")]
     Deploy(DeployTransaction),
-    #[serde(rename = "INVOKE")]
     Invoke(InvokeTransaction),
-    #[serde(rename = "L1_HANDLER")]
     L1Handler(L1HandlerTransaction),
 }
 
@@ -454,13 +449,10 @@ impl BroadcastedTransactionCommonV3 {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "type")]
+#[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum BroadcastedTransaction {
-    #[serde(rename = "INVOKE")]
     Invoke(BroadcastedInvokeTransaction),
-    #[serde(rename = "DECLARE")]
     Declare(BroadcastedDeclareTransaction),
-    #[serde(rename = "DEPLOY_ACCOUNT")]
     DeployAccount(BroadcastedDeployAccountTransaction),
 }
 
@@ -984,20 +976,17 @@ impl<'de> Deserialize<'de> for BroadcastedInvokeTransaction {
 /// account, and fee will be deducted from the balance before the simulation of the next
 /// transaction). To skip the fee charge, use the SKIP_FEE_CHARGE flag.
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum SimulationFlag {
-    #[serde(rename = "SKIP_VALIDATE")]
     SkipValidate,
-    #[serde(rename = "SKIP_FEE_CHARGE")]
     SkipFeeCharge,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum CallType {
-    #[serde(rename = "LIBRARY_CALL")]
     LibraryCall,
-    #[serde(rename = "CALL")]
     Call,
-    #[serde(rename = "DELEGATE")]
     Delegate,
 }
 
@@ -1019,15 +1008,11 @@ pub struct FunctionInvocation {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type")]
+#[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum TransactionTrace {
-    #[serde(rename = "INVOKE")]
     Invoke(InvokeTransactionTrace),
-    #[serde(rename = "DECLARE")]
     Declare(DeclareTransactionTrace),
-    #[serde(rename = "DEPLOY_ACCOUNT")]
     DeployAccount(DeployAccountTransactionTrace),
-    #[serde(rename = "L1_HANDLER")]
     L1Handler(L1HandlerTransactionTrace),
 }
 

--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -44,6 +44,7 @@ pub struct BackgroundDevnet {
     pub http_client: Client<HttpConnector>,
     pub json_rpc_client: JsonRpcClient<HttpTransport>,
     pub process: Child,
+    pub port: u16,
     pub url: String,
     rpc_url: Url,
 }
@@ -137,6 +138,7 @@ impl BackgroundDevnet {
                     http_client,
                     json_rpc_client,
                     process,
+                    port: free_port,
                     url: devnet_url,
                     rpc_url: devnet_rpc_url,
                 });
@@ -304,6 +306,10 @@ impl BackgroundDevnet {
             Ok(MaybePendingBlockWithTxHashes::Block(b)) => Ok(b),
             other => Err(anyhow::format_err!("Got unexpected block: {other:?}")),
         }
+    }
+
+    pub async fn get_config(&self) -> Result<serde_json::Value, anyhow::Error> {
+        Ok(get_json_body(self.get("/config", None).await?).await)
     }
 }
 

--- a/crates/starknet-devnet/tests/general_integration_tests.rs
+++ b/crates/starknet-devnet/tests/general_integration_tests.rs
@@ -66,12 +66,13 @@ mod general_integration_tests {
             "gas_price": 5,
             "data_gas_price": 6,
             "chain_id": "SN_MAIN",
-            "dump_on": "Exit",
+            "dump_on": "exit",
             "dump_path": dump_file.path,
-            "state_archive": "Full",
+            "state_archive": "full",
             "fork_config": null,
             "server_config": {
                 "host": "0.0.0.0",
+                // expected port added after spawning; determined by port-acquiring logic
                 "timeout": 121,
                 "request_body_size_limit": 1000
             }
@@ -93,14 +94,13 @@ mod general_integration_tests {
             "--chain-id",
             "MAINNET",
             "--dump-on",
-            "exit",
+            &expected_config["dump_on"].as_str().unwrap(),
             "--dump-path",
             &expected_config["dump_path"].as_str().unwrap(),
             "--state-archive-capacity",
-            "full",
+            &expected_config["state_archive"].as_str().unwrap(),
             "--host",
             expected_config["server_config"]["host"].as_str().unwrap(),
-            // not specifying --port as it is determined by port acquiring logic
             "--timeout",
             &serde_json::to_string(&expected_config["server_config"]["timeout"]).unwrap(),
             "--request-body-size-limit",

--- a/crates/starknet-devnet/tests/general_integration_tests.rs
+++ b/crates/starknet-devnet/tests/general_integration_tests.rs
@@ -69,12 +69,15 @@ mod general_integration_tests {
             "dump_on": "exit",
             "dump_path": dump_file.path,
             "state_archive": "full",
-            "fork_config": null,
+            "fork_config": {
+                "url": null,
+                "block_number": null,
+            },
             "server_config": {
                 "host": "0.0.0.0",
                 // expected port added after spawning; determined by port-acquiring logic
                 "timeout": 121,
-                "request_body_size_limit": 1000
+                "request_body_size_limit": 1000,
             }
         });
 

--- a/crates/starknet-devnet/tests/general_integration_tests.rs
+++ b/crates/starknet-devnet/tests/general_integration_tests.rs
@@ -6,7 +6,7 @@ mod general_integration_tests {
     use serde_json::json;
 
     use crate::common::background_devnet::BackgroundDevnet;
-    use crate::common::utils::get_json_body;
+    use crate::common::utils::{get_json_body, UniqueAutoDeletableFile};
 
     #[tokio::test]
     /// Asserts that a background instance can be spawned
@@ -17,12 +17,8 @@ mod general_integration_tests {
     #[tokio::test]
     async fn too_big_request_rejected() {
         let limit = 1_000;
-        let devnet = BackgroundDevnet::spawn_with_additional_args(&[
-            "--request-body-size-limit",
-            &limit.to_string(),
-        ])
-        .await
-        .unwrap();
+        let args = ["--request-body-size-limit", &limit.to_string()];
+        let devnet = BackgroundDevnet::spawn_with_additional_args(&args).await.unwrap();
 
         let too_big_path = "a".repeat(limit);
         match devnet
@@ -39,12 +35,8 @@ mod general_integration_tests {
     #[tokio::test]
     async fn request_size_below_limit() {
         let limit = 100;
-        let devnet = BackgroundDevnet::spawn_with_additional_args(&[
-            "--request-body-size-limit",
-            &limit.to_string(),
-        ])
-        .await
-        .unwrap();
+        let args = ["--request-body-size-limit", &limit.to_string()];
+        let devnet = BackgroundDevnet::spawn_with_additional_args(&args).await.unwrap();
 
         // subtract enough so that the rest of the json body doesn't overflow the limit
         let ok_path = "0".repeat(limit - 20);
@@ -59,5 +51,68 @@ mod general_integration_tests {
             }
             other => panic!("Unexpected response: {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_config() {
+        // random values
+        let dump_file = UniqueAutoDeletableFile::new("dummy");
+        let mut expected_config = json!({
+            "seed": 1,
+            "total_accounts": 2,
+            "account_contract_class_hash": "0x61dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2971b8f",
+            "predeployed_accounts_initial_balance": "3",
+            "start_time": 4,
+            "gas_price": 5,
+            "data_gas_price": 6,
+            "chain_id": "SN_MAIN",
+            "dump_on": "Exit",
+            "dump_path": dump_file.path,
+            "state_archive": "Full",
+            "fork_config": null,
+            "server_config": {
+                "host": "0.0.0.0",
+                "timeout": 121,
+                "request_body_size_limit": 1000
+            }
+        });
+
+        let devnet = BackgroundDevnet::spawn_with_additional_args(&[
+            "--seed",
+            &serde_json::to_string(&expected_config["seed"]).unwrap(),
+            "--accounts",
+            &serde_json::to_string(&expected_config["total_accounts"]).unwrap(),
+            "--initial-balance",
+            expected_config["predeployed_accounts_initial_balance"].as_str().unwrap(),
+            "--start-time",
+            &serde_json::to_string(&expected_config["start_time"]).unwrap(),
+            "--gas-price",
+            &serde_json::to_string(&expected_config["gas_price"]).unwrap(),
+            "--data-gas-price",
+            &serde_json::to_string(&expected_config["data_gas_price"]).unwrap(),
+            "--chain-id",
+            "MAINNET",
+            "--dump-on",
+            "exit",
+            "--dump-path",
+            &expected_config["dump_path"].as_str().unwrap(),
+            "--state-archive-capacity",
+            "full",
+            "--host",
+            expected_config["server_config"]["host"].as_str().unwrap(),
+            // not specifying --port as it is determined by port acquiring logic
+            "--timeout",
+            &serde_json::to_string(&expected_config["server_config"]["timeout"]).unwrap(),
+            "--request-body-size-limit",
+            &serde_json::to_string(&expected_config["server_config"]["request_body_size_limit"])
+                .unwrap(),
+        ])
+        .await
+        .unwrap();
+
+        expected_config["server_config"]["port"] = devnet.port.into();
+
+        let fetched_config = devnet.get_config().await.unwrap();
+        assert_eq!(fetched_config, expected_config);
     }
 }

--- a/crates/starknet-devnet/tests/test_account_selection.rs
+++ b/crates/starknet-devnet/tests/test_account_selection.rs
@@ -48,7 +48,7 @@ mod test_account_selection {
     }
 
     /// Common body for tests defined below
-    async fn correct_artifact_test_body(devnet_args: &[&str], expected_hash: &str) {
+    async fn correct_artifact_test_body(devnet_args: &[&str], expected_hash_hex: &str) {
         let devnet = BackgroundDevnet::spawn_with_additional_args(devnet_args).await.unwrap();
 
         let (_, account_address) = devnet.get_first_predeployed_account().await;
@@ -57,11 +57,12 @@ mod test_account_selection {
             .get_class_hash_at(BlockId::Tag(BlockTag::Latest), account_address)
             .await
             .unwrap();
-        let expected_class_hash = FieldElement::from_hex_be(expected_hash).unwrap();
-        assert_eq!(retrieved_class_hash, expected_class_hash);
+        let expected_hash = FieldElement::from_hex_be(expected_hash_hex).unwrap();
+        assert_eq!(retrieved_class_hash, expected_hash);
 
         let config = devnet.get_config().await.unwrap();
-        assert_eq!(config["account_contract_class_hash"], expected_hash);
+        let config_class_hash_hex = config["account_contract_class_hash"].as_str().unwrap();
+        assert_eq!(FieldElement::from_hex_be(config_class_hash_hex).unwrap(), expected_hash);
     }
 
     #[tokio::test]

--- a/crates/starknet-devnet/tests/test_account_selection.rs
+++ b/crates/starknet-devnet/tests/test_account_selection.rs
@@ -59,6 +59,9 @@ mod test_account_selection {
             .unwrap();
         let expected_class_hash = FieldElement::from_hex_be(expected_hash).unwrap();
         assert_eq!(retrieved_class_hash, expected_class_hash);
+
+        let config = devnet.get_config().await.unwrap();
+        assert_eq!(config["account_contract_class_hash"], expected_hash);
     }
 
     #[tokio::test]

--- a/crates/starknet-devnet/tests/test_fork.rs
+++ b/crates/starknet-devnet/tests/test_fork.rs
@@ -45,18 +45,20 @@ mod fork_tests {
     async fn test_fork_status() {
         let origin_devnet = spawn_forkable_devnet().await.unwrap();
 
-        let origin_status =
-            get_json_body(origin_devnet.get("/fork_status", None).await.unwrap()).await;
-        assert_eq!(origin_status, serde_json::json!({}));
+        let origin_devnet_config =
+            get_json_body(origin_devnet.get("/config", None).await.unwrap()).await;
+        assert_eq!(origin_devnet_config["fork_config"], serde_json::json!(null));
 
         let fork_devnet = origin_devnet.fork().await.unwrap();
 
-        let fork_status = get_json_body(fork_devnet.get("/fork_status", None).await.unwrap()).await;
+        let fork_devnet_config =
+            get_json_body(fork_devnet.get("/config", None).await.unwrap()).await;
+        let fork_devnet_fork_config = &fork_devnet_config["fork_config"];
         assert_eq!(
-            url::Url::from_str(fork_status["url"].as_str().unwrap()).unwrap(),
+            url::Url::from_str(fork_devnet_fork_config["url"].as_str().unwrap()).unwrap(),
             url::Url::from_str(&origin_devnet.url).unwrap()
         );
-        assert_eq!(fork_status["block"].as_i64().unwrap(), 0);
+        assert_eq!(fork_devnet_fork_config["block"].as_i64().unwrap(), 0);
     }
 
     #[tokio::test]

--- a/crates/starknet-devnet/tests/test_fork.rs
+++ b/crates/starknet-devnet/tests/test_fork.rs
@@ -26,7 +26,7 @@ mod fork_tests {
     use crate::common::constants;
     use crate::common::utils::{
         assert_cairo1_classes_equal, assert_tx_successful, declare_deploy,
-        get_block_reader_contract_in_sierra_and_compiled_class_hash, get_json_body,
+        get_block_reader_contract_in_sierra_and_compiled_class_hash,
         get_simple_contract_in_sierra_and_compiled_class_hash, resolve_path,
         send_ctrl_c_signal_and_wait,
     };
@@ -45,14 +45,12 @@ mod fork_tests {
     async fn test_fork_status() {
         let origin_devnet = spawn_forkable_devnet().await.unwrap();
 
-        let origin_devnet_config =
-            get_json_body(origin_devnet.get("/config", None).await.unwrap()).await;
+        let origin_devnet_config = origin_devnet.get_config().await.unwrap();
         assert_eq!(origin_devnet_config["fork_config"], serde_json::json!(null));
 
         let fork_devnet = origin_devnet.fork().await.unwrap();
 
-        let fork_devnet_config =
-            get_json_body(fork_devnet.get("/config", None).await.unwrap()).await;
+        let fork_devnet_config = fork_devnet.get_config().await.unwrap();
         let fork_devnet_fork_config = &fork_devnet_config["fork_config"];
         assert_eq!(
             url::Url::from_str(fork_devnet_fork_config["url"].as_str().unwrap()).unwrap(),

--- a/crates/starknet-devnet/tests/test_fork.rs
+++ b/crates/starknet-devnet/tests/test_fork.rs
@@ -46,7 +46,10 @@ mod fork_tests {
         let origin_devnet = spawn_forkable_devnet().await.unwrap();
 
         let origin_devnet_config = origin_devnet.get_config().await.unwrap();
-        assert_eq!(origin_devnet_config["fork_config"], serde_json::json!(null));
+        assert_eq!(
+            origin_devnet_config["fork_config"],
+            serde_json::json!({ "url": null, "block_number": null })
+        );
 
         let fork_devnet = origin_devnet.fork().await.unwrap();
 
@@ -56,7 +59,7 @@ mod fork_tests {
             url::Url::from_str(fork_devnet_fork_config["url"].as_str().unwrap()).unwrap(),
             url::Url::from_str(&origin_devnet.url).unwrap()
         );
-        assert_eq!(fork_devnet_fork_config["block"].as_i64().unwrap(), 0);
+        assert_eq!(fork_devnet_fork_config["block_number"].as_i64().unwrap(), 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Usage related changes

- Close #428
  - Add endpoint `GET /config` for retrieving the current Devnet configuration. The response can be understood as the mapping of CLI parameters (specified and default ones) in JSON format, with some irrelevant parameters omitted. See `README.md` changes for an example.
- Remove endpoint `GET /fork_status` as its response has become a part of the new endpoint's response.

## Development related changes

- `port` of `BackgroundDevnet` exposed for testing purpose.
- `HttpApiHandler` now including `server_config` property for the purpose of including it in the config response.
- Use `serde(rename_all = ...)` and `clap(rename_all = ...)` where possible.

## Checklist:

- [x] Checked the relevant parts of [development docs](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#development)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
- [x] Updated the docs if needed, including the [TODO section](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#todo-to-reach-feature-parity-with-the-pythonic-devnet)
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) which this PR resolves
- [x] Updated the tests if needed; all passing ([execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#test-execution))
