### PR TITLE
Update of getBlockWithTxHashes and getStateUpdate

### DIFF
--- a/crates/starknet-devnet-core/src/blocks/mod.rs
+++ b/crates/starknet-devnet-core/src/blocks/mod.rs
@@ -9,8 +9,7 @@ use starknet_rs_core::types::{BlockId, BlockTag};
 use starknet_types::contract_address::ContractAddress;
 use starknet_types::felt::{BlockHash, Felt, TransactionHash};
 use starknet_types::rpc::block::{
-    BaseBlockHeader, BlockHeader as TypesBlockHeader,
-    PendingBlockHeader as TypesPendingBlockHeader, ResourcePrice,
+    BlockHeader as TypesBlockHeader, PendingBlockHeader as TypesPendingBlockHeader, ResourcePrice,
 };
 use starknet_types::traits::HashProducer;
 
@@ -175,7 +174,7 @@ pub struct StarknetBlock {
     pub(crate) status: BlockStatus,
 }
 
-impl From<&StarknetBlock> for BaseBlockHeader {
+impl From<&StarknetBlock> for TypesPendingBlockHeader {
     fn from(value: &StarknetBlock) -> Self {
         Self {
             parent_hash: value.parent_hash(),
@@ -195,19 +194,25 @@ impl From<&StarknetBlock> for BaseBlockHeader {
     }
 }
 
-impl From<&StarknetBlock> for TypesPendingBlockHeader {
-    fn from(value: &StarknetBlock) -> Self {
-        Self { header: BaseBlockHeader::from(value) }
-    }
-}
-
 impl From<&StarknetBlock> for TypesBlockHeader {
     fn from(value: &StarknetBlock) -> Self {
         Self {
             block_hash: value.block_hash(),
+            parent_hash: value.parent_hash(),
             block_number: value.block_number(),
+            sequencer_address: value.sequencer_address(),
             new_root: value.new_root(),
-            header: BaseBlockHeader::from(value),
+            timestamp: value.timestamp(),
+            starknet_version: STARKNET_VERSION.to_string(),
+            l1_gas_price: ResourcePrice {
+                price_in_fri: value.header.l1_gas_price.price_in_fri.0.into(),
+                price_in_wei: value.header.l1_gas_price.price_in_wei.0.into(),
+            },
+            l1_data_gas_price: ResourcePrice {
+                price_in_fri: value.header.l1_data_gas_price.price_in_fri.0.into(),
+                price_in_wei: value.header.l1_data_gas_price.price_in_wei.0.into(),
+            },
+            l1_da_mode: value.header.l1_da_mode,
         }
     }
 }

--- a/crates/starknet-devnet-core/src/blocks/mod.rs
+++ b/crates/starknet-devnet-core/src/blocks/mod.rs
@@ -9,7 +9,8 @@ use starknet_rs_core::types::{BlockId, BlockTag};
 use starknet_types::contract_address::ContractAddress;
 use starknet_types::felt::{BlockHash, Felt, TransactionHash};
 use starknet_types::rpc::block::{
-    BlockHeader as TypesBlockHeader, PendingBlockHeader as TypesPendingBlockHeader, ResourcePrice,
+    BaseBlockHeader, BlockHeader as TypesBlockHeader,
+    PendingBlockHeader as TypesPendingBlockHeader, ResourcePrice,
 };
 use starknet_types::traits::HashProducer;
 
@@ -174,7 +175,7 @@ pub struct StarknetBlock {
     pub(crate) status: BlockStatus,
 }
 
-impl From<&StarknetBlock> for TypesPendingBlockHeader {
+impl From<&StarknetBlock> for BaseBlockHeader {
     fn from(value: &StarknetBlock) -> Self {
         Self {
             parent_hash: value.parent_hash(),
@@ -194,25 +195,19 @@ impl From<&StarknetBlock> for TypesPendingBlockHeader {
     }
 }
 
+impl From<&StarknetBlock> for TypesPendingBlockHeader {
+    fn from(value: &StarknetBlock) -> Self {
+        Self { header: BaseBlockHeader::from(value) }
+    }
+}
+
 impl From<&StarknetBlock> for TypesBlockHeader {
     fn from(value: &StarknetBlock) -> Self {
         Self {
             block_hash: value.block_hash(),
-            parent_hash: value.parent_hash(),
             block_number: value.block_number(),
-            sequencer_address: value.sequencer_address(),
             new_root: value.new_root(),
-            timestamp: value.timestamp(),
-            starknet_version: STARKNET_VERSION.to_string(),
-            l1_gas_price: ResourcePrice {
-                price_in_fri: value.header.l1_gas_price.price_in_fri.0.into(),
-                price_in_wei: value.header.l1_gas_price.price_in_wei.0.into(),
-            },
-            l1_data_gas_price: ResourcePrice {
-                price_in_fri: value.header.l1_data_gas_price.price_in_fri.0.into(),
-                price_in_wei: value.header.l1_data_gas_price.price_in_wei.0.into(),
-            },
-            l1_da_mode: value.header.l1_da_mode,
+            header: BaseBlockHeader::from(value),
         }
     }
 }

--- a/crates/starknet-devnet-core/src/blocks/mod.rs
+++ b/crates/starknet-devnet-core/src/blocks/mod.rs
@@ -8,7 +8,9 @@ use starknet_api::stark_felt;
 use starknet_rs_core::types::{BlockId, BlockTag};
 use starknet_types::contract_address::ContractAddress;
 use starknet_types::felt::{BlockHash, Felt, TransactionHash};
-use starknet_types::rpc::block::{BlockHeader as TypesBlockHeader, ResourcePrice};
+use starknet_types::rpc::block::{
+    BlockHeader as TypesBlockHeader, PendingBlockHeader as TypesPendingBlockHeader, ResourcePrice,
+};
 use starknet_types::traits::HashProducer;
 
 use crate::constants::STARKNET_VERSION;
@@ -170,6 +172,27 @@ pub struct StarknetBlock {
     pub(crate) header: BlockHeader,
     transaction_hashes: Vec<TransactionHash>,
     pub(crate) status: BlockStatus,
+}
+
+impl From<&StarknetBlock> for TypesPendingBlockHeader {
+    fn from(value: &StarknetBlock) -> Self {
+        Self {
+            parent_hash: value.parent_hash(),
+            sequencer_address: value.sequencer_address(),
+            new_root: value.new_root(),
+            timestamp: value.timestamp(),
+            starknet_version: STARKNET_VERSION.to_string(),
+            l1_gas_price: ResourcePrice {
+                price_in_fri: value.header.l1_gas_price.price_in_fri.0.into(),
+                price_in_wei: value.header.l1_gas_price.price_in_wei.0.into(),
+            },
+            l1_data_gas_price: ResourcePrice {
+                price_in_fri: value.header.l1_data_gas_price.price_in_fri.0.into(),
+                price_in_wei: value.header.l1_data_gas_price.price_in_wei.0.into(),
+            },
+            l1_da_mode: value.header.l1_da_mode,
+        }
+    }
 }
 
 impl From<&StarknetBlock> for TypesBlockHeader {

--- a/crates/starknet-devnet-core/src/blocks/mod.rs
+++ b/crates/starknet-devnet-core/src/blocks/mod.rs
@@ -179,7 +179,6 @@ impl From<&StarknetBlock> for TypesPendingBlockHeader {
         Self {
             parent_hash: value.parent_hash(),
             sequencer_address: value.sequencer_address(),
-            new_root: value.new_root(),
             timestamp: value.timestamp(),
             starknet_version: STARKNET_VERSION.to_string(),
             l1_gas_price: ResourcePrice {

--- a/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
@@ -3,7 +3,7 @@ use starknet_rs_core::types::{BlockId as ImportedBlockId, BlockTag, MsgFromL1};
 use starknet_types::contract_address::ContractAddress;
 use starknet_types::felt::{ClassHash, TransactionHash};
 use starknet_types::patricia_key::PatriciaKey;
-use starknet_types::rpc::block::{Block, BlockHeader, BlockId};
+use starknet_types::rpc::block::{Block, BlockHeader, BlockId, PendingBlock, PendingBlockHeader};
 use starknet_types::rpc::state::{PendingStateUpdate, StateUpdate};
 use starknet_types::rpc::transactions::{
     BroadcastedTransaction, EventFilter, EventsChunk, FunctionCall, SimulationFlag,
@@ -24,21 +24,32 @@ impl JsonRpcHandler {
 
     /// starknet_getBlockWithTxHashes
     pub async fn get_block_with_tx_hashes(&self, block_id: BlockId) -> StrictRpcResult {
-        let block =
-            self.api.starknet.read().await.get_block(block_id.as_ref()).map_err(
-                |err| match err {
-                    Error::NoBlock => ApiError::BlockNotFound,
-                    unknown_error => ApiError::StarknetDevnetError(unknown_error),
-                },
-            )?;
+        let starknet = self.api.starknet.read().await;
 
-        Ok(StarknetResponse::Block(Block {
-            status: *block.status(),
-            header: BlockHeader::from(&block),
-            transactions: starknet_types::rpc::transactions::Transactions::Hashes(
-                block.get_transactions().to_owned(),
-            ),
-        }))
+        let block = starknet.get_block(block_id.as_ref()).map_err(|err| match err {
+            Error::NoBlock => ApiError::BlockNotFound,
+            unknown_error => ApiError::StarknetDevnetError(unknown_error),
+        })?;
+
+        // TODO: is this starknet.config.blocks_on_demand needed here?
+        if starknet.config.blocks_on_demand
+            && block_id == ImportedBlockId::Tag(BlockTag::Pending).into()
+        {
+            Ok(StarknetResponse::PendingBlock(PendingBlock {
+                header: PendingBlockHeader::from(&block),
+                transactions: starknet_types::rpc::transactions::Transactions::Hashes(
+                    block.get_transactions().to_owned(),
+                ),
+            }))
+        } else {
+            Ok(StarknetResponse::Block(Block {
+                status: *block.status(),
+                header: BlockHeader::from(&block),
+                transactions: starknet_types::rpc::transactions::Transactions::Hashes(
+                    block.get_transactions().to_owned(),
+                ),
+            }))
+        }
     }
 
     /// starknet_getBlockWithTxs
@@ -81,6 +92,7 @@ impl JsonRpcHandler {
 
         let state_diff = state_update.state_diff.into();
 
+        // TODO: is this starknet.config.blocks_on_demand needed here?
         if starknet.config.blocks_on_demand
             && block_id == ImportedBlockId::Tag(BlockTag::Pending).into()
         {

--- a/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
@@ -31,7 +31,8 @@ impl JsonRpcHandler {
             unknown_error => ApiError::StarknetDevnetError(unknown_error),
         })?;
 
-        // TODO: is this starknet.config.blocks_on_demand needed here?
+        // StarknetBlock needs to be mapped to PendingBlock response only in blocks_on_demand mode
+        // and when block_id is pending
         if starknet.config.blocks_on_demand
             && block_id == ImportedBlockId::Tag(BlockTag::Pending).into()
         {
@@ -92,7 +93,8 @@ impl JsonRpcHandler {
 
         let state_diff = state_update.state_diff.into();
 
-        // TODO: is this starknet.config.blocks_on_demand needed here?
+        // StateUpdate needs to be mapped to PendingStateUpdate response only in blocks_on_demand
+        // mode and when block_id is pending
         if starknet.config.blocks_on_demand
             && block_id == ImportedBlockId::Tag(BlockTag::Pending).into()
         {

--- a/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
@@ -1,10 +1,10 @@
 use starknet_core::error::{Error, StateError};
-use starknet_rs_core::types::{BlockId as ImportedBlockId, MsgFromL1};
+use starknet_rs_core::types::{BlockId as ImportedBlockId, BlockTag, MsgFromL1};
 use starknet_types::contract_address::ContractAddress;
 use starknet_types::felt::{ClassHash, TransactionHash};
 use starknet_types::patricia_key::PatriciaKey;
 use starknet_types::rpc::block::{Block, BlockHeader, BlockId};
-use starknet_types::rpc::state::StateUpdate;
+use starknet_types::rpc::state::{PendingStateUpdate, StateUpdate};
 use starknet_types::rpc::transactions::{
     BroadcastedTransaction, EventFilter, EventsChunk, FunctionCall, SimulationFlag,
 };
@@ -71,22 +71,31 @@ impl JsonRpcHandler {
 
     /// starknet_getStateUpdate
     pub async fn get_state_update(&self, block_id: BlockId) -> StrictRpcResult {
+        let starknet = self.api.starknet.read().await;
+
         let state_update =
-            self.api.starknet.read().await.block_state_update(block_id.as_ref()).map_err(
-                |err| match err {
-                    Error::NoBlock => ApiError::BlockNotFound,
-                    unknown_error => ApiError::StarknetDevnetError(unknown_error),
-                },
-            )?;
+            starknet.block_state_update(block_id.as_ref()).map_err(|err| match err {
+                Error::NoBlock => ApiError::BlockNotFound,
+                unknown_error => ApiError::StarknetDevnetError(unknown_error),
+            })?;
 
         let state_diff = state_update.state_diff.into();
 
-        Ok(StarknetResponse::StateUpdate(StateUpdate {
-            block_hash: state_update.block_hash,
-            new_root: state_update.new_root,
-            old_root: state_update.old_root,
-            state_diff,
-        }))
+        if starknet.config.blocks_on_demand
+            && block_id == ImportedBlockId::Tag(BlockTag::Pending).into()
+        {
+            Ok(StarknetResponse::PendingStateUpdate(PendingStateUpdate {
+                old_root: state_update.old_root,
+                state_diff,
+            }))
+        } else {
+            Ok(StarknetResponse::StateUpdate(StateUpdate {
+                block_hash: state_update.block_hash,
+                new_root: state_update.new_root,
+                old_root: state_update.old_root,
+                state_diff,
+            }))
+        }
     }
 
     /// starknet_getStorageAt

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -19,7 +19,7 @@ use starknet_types::rpc::block::Block;
 use starknet_types::rpc::estimate_message_fee::{
     EstimateMessageFeeRequestWrapper, FeeEstimateWrapper,
 };
-use starknet_types::rpc::state::StateUpdate;
+use starknet_types::rpc::state::{PendingStateUpdate, StateUpdate};
 use starknet_types::rpc::transaction_receipt::TransactionReceipt;
 use starknet_types::rpc::transactions::{
     BlockTransactionTrace, EventsChunk, SimulatedTransaction, TransactionTrace, TransactionWithHash,
@@ -354,6 +354,7 @@ impl std::fmt::Display for StarknetRequest {
 pub enum StarknetResponse {
     Block(Block),
     StateUpdate(StateUpdate),
+    PendingStateUpdate(PendingStateUpdate),
     Felt(Felt),
     Transaction(TransactionWithHash),
     TransactionReceiptByTransactionHash(Box<TransactionReceipt>),

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -15,7 +15,7 @@ use models::{
 use serde::{Deserialize, Serialize};
 use starknet_rs_core::types::ContractClass as CodegenContractClass;
 use starknet_types::felt::Felt;
-use starknet_types::rpc::block::Block;
+use starknet_types::rpc::block::{Block, PendingBlock};
 use starknet_types::rpc::estimate_message_fee::{
     EstimateMessageFeeRequestWrapper, FeeEstimateWrapper,
 };
@@ -353,6 +353,7 @@ impl std::fmt::Display for StarknetRequest {
 #[serde(untagged)]
 pub enum StarknetResponse {
     Block(Block),
+    PendingBlock(PendingBlock),
     StateUpdate(StateUpdate),
     PendingStateUpdate(PendingStateUpdate),
     Felt(Felt),

--- a/crates/starknet-devnet-server/src/api/json_rpc/spec_reader/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/spec_reader/mod.rs
@@ -246,7 +246,10 @@ mod tests {
                         StarknetRequest::BlockWithTransactionHashes(_)
                         | StarknetRequest::BlockWithFullTransactions(_)
                         | StarknetRequest::BlockWithReceipts(_) => {
-                            assert!(matches!(sn_response, StarknetResponse::Block(_)));
+                            assert!(matches!(
+                                sn_response,
+                                StarknetResponse::Block(_) | StarknetResponse::PendingBlock(_)
+                            ));
                         }
                         StarknetRequest::BlockHashAndNumber => {
                             assert!(matches!(sn_response, StarknetResponse::BlockHashAndNumber(_)));
@@ -282,7 +285,11 @@ mod tests {
                             ));
                         }
                         StarknetRequest::StateUpdate(_) => {
-                            assert!(matches!(sn_response, StarknetResponse::StateUpdate(_)));
+                            assert!(matches!(
+                                sn_response,
+                                StarknetResponse::StateUpdate(_)
+                                    | StarknetResponse::PendingStateUpdate(_)
+                            ));
                         }
                         StarknetRequest::Syncing => {
                             assert!(matches!(sn_response, StarknetResponse::Syncing(_)));

--- a/crates/starknet-devnet-server/test_data/spec/0.7.1/starknet_api_openrpc.json
+++ b/crates/starknet-devnet-server/test_data/spec/0.7.1/starknet_api_openrpc.json
@@ -44,6 +44,10 @@
                         {
                             "title": "Block with transaction hashes",
                             "$ref": "#/components/schemas/BLOCK_WITH_TX_HASHES"
+                        },
+                        {
+                            "title": "Pending block with transaction hashes",
+                            "$ref": "#/components/schemas/PENDING_BLOCK_WITH_TX_HASHES"
                         }
                     ]
                 }
@@ -143,6 +147,10 @@
                         {
                             "title": "State update",
                             "$ref": "#/components/schemas/STATE_UPDATE"
+                        },
+                        {
+                            "title": "Pending state update",
+                            "$ref": "#/components/schemas/PENDING_STATE_UPDATE"
                         }
                     ]
                 }
@@ -1487,6 +1495,68 @@
                     "l1_da_mode",
                     "starknet_version"
                 ]
+            },
+            "PENDING_BLOCK_HEADER": {
+                "title": "Pending block header",
+                "type": "object",
+                "properties": {
+                    "parent_hash": {
+                        "title": "Parent hash",
+                        "description": "The hash of this block's parent",
+                        "$ref": "#/components/schemas/BLOCK_HASH"
+                    },
+                    "timestamp": {
+                        "title": "Timestamp",
+                        "description": "The time in which the block was created, encoded in Unix time",
+                        "type": "integer",
+                        "minimum": 0
+                    },
+                    "sequencer_address": {
+                        "title": "Sequencer address",
+                        "description": "The StarkNet identity of the sequencer submitting this block",
+                        "$ref": "#/components/schemas/FELT"
+                    },
+                    "l1_gas_price": {
+                        "title": "L1 gas price",
+                        "description": "The price of l1 gas in the block",
+                        "$ref": "#/components/schemas/RESOURCE_PRICE"
+                    },
+                    "l1_data_gas_price": {
+                        "title": "L1 data gas price",
+                        "description": "The price of l1 data gas in the block",
+                        "$ref": "#/components/schemas/RESOURCE_PRICE"
+                    },
+                    "l1_da_mode": {
+                        "title": "L1 da mode",
+                        "type": "string",
+                        "description": "specifies whether the data of this block is published via blob data or calldata",
+                        "enum": [
+                            "BLOB",
+                            "CALLDATA"
+                        ]
+                    },
+                    "starknet_version": {
+                        "title": "Starknet version",
+                        "description": "Semver of the current Starknet protocol",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "parent_hash",
+                    "timestamp",
+                    "sequencer_address",
+                    "l1_gas_price",
+                    "l1_data_gas_price",
+                    "l1_da_mode",
+                    "starknet_version"
+                ],
+                "not": {
+                    "required": [
+                        "block_hash",
+                        "block_number",
+                        "new_root"
+                    ]
+                }
             },
             "BLOCK_WITH_TX_HASHES": {
                 "title": "Block with transaction hashes",

--- a/crates/starknet-devnet-server/test_data/spec/0.7.1/starknet_api_openrpc.json
+++ b/crates/starknet-devnet-server/test_data/spec/0.7.1/starknet_api_openrpc.json
@@ -81,6 +81,10 @@
                         {
                             "title": "Block with transactions",
                             "$ref": "#/components/schemas/BLOCK_WITH_TXS"
+                        },
+                        {
+                            "title": "Pending block with transactions",
+                            "$ref": "#/components/schemas/PENDING_BLOCK_WITH_TXS"
                         }
                     ]
                 }
@@ -114,6 +118,10 @@
                         {
                             "title": "Block with transactions",
                             "$ref": "#/components/schemas/BLOCK_WITH_RECEIPTS"
+                        },
+                        {
+                            "title": "Pending block with transactions",
+                            "$ref": "#/components/schemas/PENDING_BLOCK_WITH_RECEIPTS"
                         }
                     ]
                 }

--- a/crates/starknet-devnet-types/src/rpc/block.rs
+++ b/crates/starknet-devnet-types/src/rpc/block.rs
@@ -97,7 +97,6 @@ pub struct BlockHeader {
 pub struct PendingBlockHeader {
     pub parent_hash: BlockHash,
     pub sequencer_address: ContractAddress,
-    pub new_root: GlobalRootHex,
     pub timestamp: BlockTimestamp,
     pub starknet_version: String,
     pub l1_gas_price: ResourcePrice,

--- a/crates/starknet-devnet-types/src/rpc/block.rs
+++ b/crates/starknet-devnet-types/src/rpc/block.rs
@@ -81,22 +81,20 @@ pub struct PendingBlock {
 #[serde(deny_unknown_fields)]
 pub struct BlockHeader {
     pub block_hash: BlockHash,
+    pub parent_hash: BlockHash,
     pub block_number: BlockNumber,
+    pub sequencer_address: ContractAddress,
     pub new_root: GlobalRootHex,
-    #[serde(flatten)]
-    pub header: BaseBlockHeader,
+    pub timestamp: BlockTimestamp,
+    pub starknet_version: String,
+    pub l1_gas_price: ResourcePrice,
+    pub l1_data_gas_price: ResourcePrice,
+    pub l1_da_mode: L1DataAvailabilityMode,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PendingBlockHeader {
-    #[serde(flatten)]
-    pub header: BaseBlockHeader,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct BaseBlockHeader {
     pub parent_hash: BlockHash,
     pub sequencer_address: ContractAddress,
     pub timestamp: BlockTimestamp,
@@ -105,7 +103,6 @@ pub struct BaseBlockHeader {
     pub l1_data_gas_price: ResourcePrice,
     pub l1_da_mode: L1DataAvailabilityMode,
 }
-
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ResourcePrice {

--- a/crates/starknet-devnet-types/src/rpc/block.rs
+++ b/crates/starknet-devnet-types/src/rpc/block.rs
@@ -81,10 +81,24 @@ pub struct PendingBlock {
 #[serde(deny_unknown_fields)]
 pub struct BlockHeader {
     pub block_hash: BlockHash,
-    pub parent_hash: BlockHash,
     pub block_number: BlockNumber,
-    pub sequencer_address: ContractAddress,
     pub new_root: GlobalRootHex,
+    #[serde(flatten)]
+    pub header: BaseBlockHeader,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PendingBlockHeader {
+    #[serde(flatten)]
+    pub header: BaseBlockHeader,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct BaseBlockHeader {
+    pub parent_hash: BlockHash,
+    pub sequencer_address: ContractAddress,
     pub timestamp: BlockTimestamp,
     pub starknet_version: String,
     pub l1_gas_price: ResourcePrice,
@@ -92,17 +106,6 @@ pub struct BlockHeader {
     pub l1_da_mode: L1DataAvailabilityMode,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct PendingBlockHeader {
-    pub parent_hash: BlockHash,
-    pub sequencer_address: ContractAddress,
-    pub timestamp: BlockTimestamp,
-    pub starknet_version: String,
-    pub l1_gas_price: ResourcePrice,
-    pub l1_data_gas_price: ResourcePrice,
-    pub l1_da_mode: L1DataAvailabilityMode,
-}
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ResourcePrice {

--- a/crates/starknet-devnet-types/src/rpc/block.rs
+++ b/crates/starknet-devnet-types/src/rpc/block.rs
@@ -69,6 +69,14 @@ pub struct Block {
     pub transactions: Transactions,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PendingBlock {
+    #[serde(flatten)]
+    pub header: PendingBlockHeader,
+    pub transactions: Transactions,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct BlockHeader {
@@ -84,6 +92,18 @@ pub struct BlockHeader {
     pub l1_da_mode: L1DataAvailabilityMode,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PendingBlockHeader {
+    pub parent_hash: BlockHash,
+    pub sequencer_address: ContractAddress,
+    pub new_root: GlobalRootHex,
+    pub timestamp: BlockTimestamp,
+    pub starknet_version: String,
+    pub l1_gas_price: ResourcePrice,
+    pub l1_data_gas_price: ResourcePrice,
+    pub l1_da_mode: L1DataAvailabilityMode,
+}
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ResourcePrice {

--- a/crates/starknet-devnet-types/src/rpc/state.rs
+++ b/crates/starknet-devnet-types/src/rpc/state.rs
@@ -18,6 +18,13 @@ pub struct StateUpdate {
     pub state_diff: ThinStateDiff,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PendingStateUpdate {
+    pub old_root: GlobalRootHex,
+    pub state_diff: ThinStateDiff,
+}
+
 #[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct ThinStateDiff {
     pub deployed_contracts: Vec<DeployedContract>,

--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -328,9 +328,9 @@ impl BackgroundDevnet {
 
     pub async fn get_pending_block_with_tx_hashes(
         &self,
-    ) -> Result<BlockWithTxHashes, anyhow::Error> {
+    ) -> Result<MaybePendingBlockWithTxHashes, anyhow::Error> {
         match self.json_rpc_client.get_block_with_tx_hashes(BlockId::Tag(BlockTag::Pending)).await {
-            Ok(MaybePendingBlockWithTxHashes::Block(b)) => Ok(b),
+            Ok(b) => Ok(b),
             other => Err(anyhow::format_err!("Got unexpected block: {other:?}")),
         }
     }

--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -11,7 +11,8 @@ use lazy_static::lazy_static;
 use serde_json::json;
 use starknet_core::constants::ETH_ERC20_CONTRACT_ADDRESS;
 use starknet_rs_core::types::{
-    BlockId, BlockTag, BlockWithTxHashes, FieldElement, FunctionCall, MaybePendingBlockWithTxHashes,
+    BlockId, BlockTag, BlockWithTxHashes, FieldElement, FunctionCall,
+    MaybePendingBlockWithTxHashes, PendingBlockWithTxHashes,
 };
 use starknet_rs_core::utils::get_selector_from_name;
 use starknet_rs_providers::jsonrpc::HttpTransport;
@@ -328,9 +329,9 @@ impl BackgroundDevnet {
 
     pub async fn get_pending_block_with_tx_hashes(
         &self,
-    ) -> Result<MaybePendingBlockWithTxHashes, anyhow::Error> {
+    ) -> Result<PendingBlockWithTxHashes, anyhow::Error> {
         match self.json_rpc_client.get_block_with_tx_hashes(BlockId::Tag(BlockTag::Pending)).await {
-            Ok(b) => Ok(b),
+            Ok(MaybePendingBlockWithTxHashes::PendingBlock(b)) => Ok(b),
             other => Err(anyhow::format_err!("Got unexpected block: {other:?}")),
         }
     }

--- a/crates/starknet-devnet/tests/test_blocks_on_demand.rs
+++ b/crates/starknet-devnet/tests/test_blocks_on_demand.rs
@@ -30,20 +30,14 @@ mod blocks_on_demand_tests {
             .await
             .unwrap();
 
-        match pending_state_update {
-            MaybePendingStateUpdate::PendingUpdate(_) => {}
-            _ => panic!("Invalid state type {:?}", pending_state_update),
-        }
+        assert!(matches!(pending_state_update, MaybePendingStateUpdate::PendingUpdate(_)));
     }
 
     async fn assert_latest_state_update(devnet: &BackgroundDevnet, block_tag: BlockId) {
         let latest_state_update =
             &devnet.json_rpc_client.get_state_update(block_tag).await.unwrap();
 
-        match latest_state_update {
-            MaybePendingStateUpdate::Update(_) => {}
-            _ => panic!("Invalid state type {:?}", latest_state_update),
-        }
+        assert!(matches!(latest_state_update, MaybePendingStateUpdate::Update(_)));
     }
 
     async fn assert_latest_block_with_transactions(

--- a/crates/starknet-devnet/tests/test_blocks_on_demand.rs
+++ b/crates/starknet-devnet/tests/test_blocks_on_demand.rs
@@ -21,7 +21,7 @@ mod blocks_on_demand_tests {
     static DUMMY_AMOUNT: u128 = 1;
 
     async fn assert_pending_state_update(devnet: &BackgroundDevnet) {
-        let latest_state = &devnet
+        let pending_state_update = &devnet
             .send_custom_rpc(
                 "starknet_getStateUpdate",
                 json!(    {
@@ -30,12 +30,12 @@ mod blocks_on_demand_tests {
             )
             .await["result"];
 
-        assert!(latest_state["old_root"].is_string());
-        assert!(latest_state["state_diff"].is_object());
+        assert!(pending_state_update["old_root"].is_string());
+        assert!(pending_state_update["state_diff"].is_object());
     }
 
     async fn assert_latest_state_update(devnet: &BackgroundDevnet) {
-        let latest_state = &devnet
+        let latest_state_update = &devnet
             .send_custom_rpc(
                 "starknet_getStateUpdate",
                 json!(    {
@@ -44,10 +44,10 @@ mod blocks_on_demand_tests {
             )
             .await["result"];
 
-        assert!(latest_state["block_hash"].is_string());
-        assert!(latest_state["new_root"].is_string());
-        assert!(latest_state["old_root"].is_string());
-        assert!(latest_state["state_diff"].is_object());
+        assert!(latest_state_update["block_hash"].is_string());
+        assert!(latest_state_update["new_root"].is_string());
+        assert!(latest_state_update["old_root"].is_string());
+        assert!(latest_state_update["state_diff"].is_object());
     }
 
     async fn assert_latest_block_with_transactions(


### PR DESCRIPTION
## Usage related changes

- update of getBlockWithTxHashes and getStateUpdate consistent with starknet-specs-0.7.1

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
- [x] Updated the docs if needed, including the [TODO section](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#todo-to-reach-feature-parity-with-the-pythonic-devnet)
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#test-execution)
