### PR TITLE
Test forking of HTTPS origin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3064,16 +3064,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hdrhistogram"
-version = "7.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
-dependencies = [
- "byteorder",
- "num-traits 0.2.18",
-]
-
-[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5623,7 +5613,6 @@ dependencies = [
  "starknet-devnet-types",
  "thiserror",
  "tokio",
- "tower",
  "tower-http",
  "tracing",
 ]
@@ -6211,14 +6200,9 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "hdrhistogram",
- "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
- "slab",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ keywords = ["starknet", "cairo", "testnet", "local", "server"]
 # axum
 axum = { version = "0.7" }
 tower-http = { version = "0.5", features = ["full"] }
-tower = { version = "0.4", features = ["full"] }
 
 # async
 tokio = { version = "1", features = [

--- a/README.md
+++ b/README.md
@@ -203,13 +203,11 @@ $ docker run -e RUST_LOG=<LEVEL> shardlabs/starknet-devnet-rs
 ```
 
 By default, logging of request and response data is turned off.
-To see the request and/or response body, additional level have to be provided via `RUST_LOG` environment variable.
-To log the request body use `REQUEST`, to log the response body use `RESPONSE`.
+To see the request and/or response body, additional levels can be specified via the `RUST_LOG` environment variable: `REQUEST` for request body, `RESPONSE` for response body.
 
-NOTE! that logging request and response requires at least logging level `INFO`.
+NOTE! Logging request and response requires at least logging level `INFO`.
 
-The following two commands will log request and response data with log level `INFO`.
-Example:
+For example, the following two commands will log request and response data with log level `INFO`.
 
 ```
 $ RUST_LOG="REQUEST,RESPONSE" starknet-devnet

--- a/crates/starknet-devnet-server/Cargo.toml
+++ b/crates/starknet-devnet-server/Cargo.toml
@@ -14,7 +14,6 @@ description = "Server component of devnet"
 axum = { workspace = true }
 reqwest = { workspace = true }
 tower-http = { workspace = true }
-tower = { workspace = true }
 
 # tracing
 tracing = { workspace = true }

--- a/crates/starknet-devnet/tests/test_fork.rs
+++ b/crates/starknet-devnet/tests/test_fork.rs
@@ -586,4 +586,24 @@ mod fork_tests {
             .unwrap();
         assert_eq!(second_fork_block_number, [FieldElement::from(5_u8)]); // origin block + declare + deploy
     }
+
+    #[tokio::test]
+    async fn test_forking_https() {
+        let origin_url = "https://rpc.pathfinder.equilibrium.co/integration-sepolia/rpc/v0_7";
+        let fork_block = 2;
+        let fork_devnet = BackgroundDevnet::spawn_with_additional_args(&[
+            "--fork-network",
+            origin_url,
+            "--fork-block",
+            &fork_block.to_string(),
+        ])
+        .await
+        .unwrap();
+
+        fork_devnet
+            .json_rpc_client
+            .get_block_with_tx_hashes(BlockId::Number(fork_block - 1))
+            .await
+            .unwrap();
+    }
 }

--- a/crates/starknet-devnet/tests/test_fork.rs
+++ b/crates/starknet-devnet/tests/test_fork.rs
@@ -602,6 +602,7 @@ mod fork_tests {
 
         fork_devnet
             .json_rpc_client
+            // -1 to force fetching from origin
             .get_block_with_tx_hashes(BlockId::Number(fork_block - 1))
             .await
             .unwrap();


### PR DESCRIPTION
## Usage related changes

- Closes #424
  - Actually made closeable by #469

## Development related changes

- Remove unused dependency: `tower`
- Improve testing: add case for #424
- Reduced line count in docs (without sacrificing legibility IMO)

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
- [x] Updated the docs if needed, including the [TODO section](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#todo-to-reach-feature-parity-with-the-pythonic-devnet)
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#test-execution)
