### PR TITLE
Improve account class testing

### DIFF
--- a/crates/starknet-devnet/tests/common/utils.rs
+++ b/crates/starknet-devnet/tests/common/utils.rs
@@ -107,6 +107,11 @@ pub async fn assert_tx_successful<T: Provider>(tx_hash: &FieldElement, client: &
         ExecutionResult::Succeeded => (),
         other => panic!("Should have succeeded; got: {other:?}"),
     }
+
+    match receipt.finality_status() {
+        starknet_rs_core::types::TransactionFinalityStatus::AcceptedOnL2 => (),
+        other => panic!("Should have been accepted on L2; got: {other:?}"),
+    }
 }
 
 pub async fn get_contract_balance(


### PR DESCRIPTION
## Usage related changes

- None

## Development related changes

- Include cairo0 and cairo1 contract interaction in account class testing.
- Remove explicit providing of nonce and max_fee (now implicitly estimated), so that the util function can be reused between tests.
- Expand `assert_tx_successful` to include finality status assertion.
- Change the return value of the `deploy_account` util function to include the signer (needed in some test cases).
- Reduce line count by extracting BackgroundDevnet CLI args to a separate line.

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#test-execution)
