### PR TITLE
Test Argent account support

### DIFF
--- a/crates/starknet-devnet/tests/common/constants.rs
+++ b/crates/starknet-devnet/tests/common/constants.rs
@@ -50,3 +50,8 @@ pub const MESSAGING_L1_CONTRACT_ADDRESS: &str = "0xe7f1725e7734ce288f8367e1bb143
 /// Cairo 1 account which panics on validation
 pub const INVALID_ACCOUNT_SIERRA_PATH: &str =
     "test_data/cairo1/invalid_account/invalid_account.sierra";
+
+/// Forking
+pub const SEPOLIA_URL: &str = "http://rpc.pathfinder.equilibrium.co/integration-sepolia/rpc/v0_7";
+pub const SEPOLIA_GENESIS_BLOCK_HASH: &str =
+    "0x19f675d3fb226821493a6ab9a1955e384bba80f130de625621a418e9a7c0ca3";

--- a/crates/starknet-devnet/tests/common/constants.rs
+++ b/crates/starknet-devnet/tests/common/constants.rs
@@ -51,6 +51,11 @@ pub const MESSAGING_L1_CONTRACT_ADDRESS: &str = "0xe7f1725e7734ce288f8367e1bb143
 pub const INVALID_ACCOUNT_SIERRA_PATH: &str =
     "test_data/cairo1/invalid_account/invalid_account.sierra";
 
+/// hash of the sierra artifact at commit d9f5220059c1e61ff87e4a5752522569135e464c of
+/// argentlabs/argent-contracts-starknet:main
+pub const ARGENT_ACCOUNT_CLASS_HASH: &str =
+    "0x029927c8af6bccf3f6fda035981e765a7bdbf18a2dc0d630494f8758aa908e2b";
+
 /// Forking
 pub const INTEGRATION_SEPOLIA_URL: &str =
     "http://rpc.pathfinder.equilibrium.co/integration-sepolia/rpc/v0_7";

--- a/crates/starknet-devnet/tests/common/constants.rs
+++ b/crates/starknet-devnet/tests/common/constants.rs
@@ -52,6 +52,8 @@ pub const INVALID_ACCOUNT_SIERRA_PATH: &str =
     "test_data/cairo1/invalid_account/invalid_account.sierra";
 
 /// Forking
-pub const SEPOLIA_URL: &str = "http://rpc.pathfinder.equilibrium.co/integration-sepolia/rpc/v0_7";
-pub const SEPOLIA_GENESIS_BLOCK_HASH: &str =
+pub const INTEGRATION_SEPOLIA_URL: &str =
+    "http://rpc.pathfinder.equilibrium.co/integration-sepolia/rpc/v0_7";
+pub const MAINNET_URL: &str = "http://rpc.pathfinder.equilibrium.co/mainnet/rpc/v0_7";
+pub const INTEGRATION_SEPOLIA_GENESIS_BLOCK_HASH: &str =
     "0x19f675d3fb226821493a6ab9a1955e384bba80f130de625621a418e9a7c0ca3";

--- a/crates/starknet-devnet/tests/common/utils.rs
+++ b/crates/starknet-devnet/tests/common/utils.rs
@@ -5,14 +5,17 @@ use std::process::{Child, Command};
 use std::sync::Arc;
 
 use server::test_utils::exported_test_utils::assert_contains;
+use starknet_core::constants::CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH;
 use starknet_core::random_number_generator::generate_u32_random_number;
 use starknet_core::utils::casm_hash;
-use starknet_rs_accounts::{Account, SingleOwnerAccount};
+use starknet_rs_accounts::{
+    Account, AccountFactory, ArgentAccountFactory, OpenZeppelinAccountFactory, SingleOwnerAccount,
+};
 use starknet_rs_contract::ContractFactory;
 use starknet_rs_core::types::contract::SierraClass;
 use starknet_rs_core::types::{
-    BlockId, BlockTag, ContractClass, ExecutionResult, FieldElement, FlattenedSierraClass,
-    FunctionCall,
+    BlockId, BlockTag, ContractClass, DeployAccountTransactionResult, ExecutionResult,
+    FieldElement, FlattenedSierraClass, FunctionCall,
 };
 use starknet_rs_core::utils::{get_selector_from_name, get_udc_deployed_address};
 use starknet_rs_providers::jsonrpc::HttpTransport;
@@ -20,7 +23,7 @@ use starknet_rs_providers::{JsonRpcClient, Provider};
 use starknet_rs_signers::LocalWallet;
 
 use super::background_devnet::BackgroundDevnet;
-use super::constants::CAIRO_1_CONTRACT_PATH;
+use super::constants::{ARGENT_ACCOUNT_CLASS_HASH, CAIRO_1_CONTRACT_PATH, CHAIN_ID};
 
 pub enum ImpersonationAction {
     ImpersonateAccount(FieldElement),
@@ -274,6 +277,51 @@ pub async fn declare_deploy(
     );
 
     Ok((declaration_result.class_hash, contract_address))
+}
+
+pub async fn deploy_oz_account(
+    devnet: &BackgroundDevnet,
+) -> Result<(DeployAccountTransactionResult, LocalWallet), anyhow::Error> {
+    let signer = get_deployable_account_signer();
+    let salt = FieldElement::THREE;
+    let factory = OpenZeppelinAccountFactory::new(
+        FieldElement::from_hex_be(CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH)?,
+        CHAIN_ID,
+        signer.clone(),
+        devnet.clone_provider(),
+    )
+    .await?;
+
+    let deployment = factory.deploy(salt);
+
+    let account_address = deployment.address();
+    devnet.mint(account_address, 1e18 as u128).await;
+    let deployment_result = deployment.send().await?;
+
+    Ok((deployment_result, signer))
+}
+
+pub async fn deploy_argent_account(
+    devnet: &BackgroundDevnet,
+) -> Result<(DeployAccountTransactionResult, LocalWallet), anyhow::Error> {
+    let signer = get_deployable_account_signer();
+    let salt = FieldElement::THREE;
+    let factory = ArgentAccountFactory::new(
+        FieldElement::from_hex_be(ARGENT_ACCOUNT_CLASS_HASH)?,
+        CHAIN_ID,
+        FieldElement::ZERO,
+        signer.clone(),
+        devnet.clone_provider(),
+    )
+    .await?;
+
+    let deployment = factory.deploy(salt);
+
+    let account_address = deployment.address();
+    devnet.mint(account_address, 1e18 as u128).await;
+    let deployment_result = deployment.send().await?;
+
+    Ok((deployment_result, signer))
 }
 
 #[cfg(test)]

--- a/crates/starknet-devnet/tests/common/utils.rs
+++ b/crates/starknet-devnet/tests/common/utils.rs
@@ -279,6 +279,7 @@ pub async fn declare_deploy(
     Ok((declaration_result.class_hash, contract_address))
 }
 
+/// Assumes the Cairo1 OpenZepplin contract is declared in the target network.
 pub async fn deploy_oz_account(
     devnet: &BackgroundDevnet,
 ) -> Result<(DeployAccountTransactionResult, LocalWallet), anyhow::Error> {
@@ -301,6 +302,7 @@ pub async fn deploy_oz_account(
     Ok((deployment_result, signer))
 }
 
+/// Assumes the Argent account contract is declared in the target network.
 pub async fn deploy_argent_account(
     devnet: &BackgroundDevnet,
 ) -> Result<(DeployAccountTransactionResult, LocalWallet), anyhow::Error> {

--- a/crates/starknet-devnet/tests/test_account_selection.rs
+++ b/crates/starknet-devnet/tests/test_account_selection.rs
@@ -111,6 +111,7 @@ mod test_account_selection {
     }
 
     #[tokio::test]
+    /// Relying on forking: the origin network is expected to have the account class declared.
     async fn can_deploy_new_argent_account() {
         let cli_args = ["--fork-network", MAINNET_URL];
         let devnet = BackgroundDevnet::spawn_with_additional_args(&cli_args).await.unwrap();

--- a/crates/starknet-devnet/tests/test_account_selection.rs
+++ b/crates/starknet-devnet/tests/test_account_selection.rs
@@ -228,25 +228,24 @@ mod test_account_selection {
         assert_tx_successful(&invoke_result.transaction_hash, &devnet.json_rpc_client).await;
     }
 
-    /// Common body for tests defined below
-    async fn can_declare_deploy_invoke_using_predeployed_test_body(devnet_args: &[&str]) {
-        let devnet = BackgroundDevnet::spawn_with_additional_args(devnet_args).await.unwrap();
+    #[tokio::test]
+    async fn can_declare_deploy_invoke_using_predeployed_cairo1() {
+        let cli_args = ["--account-class", "cairo1"];
+        let devnet = BackgroundDevnet::spawn_with_additional_args(&cli_args).await.unwrap();
 
-        // get account
         let (signer, account_address) = devnet.get_first_predeployed_account().await;
         can_declare_deploy_invoke_cairo0_using_account(&devnet, &signer, account_address).await;
         can_declare_deploy_invoke_cairo1_using_account(&devnet, &signer, account_address).await;
     }
 
     #[tokio::test]
-    async fn can_declare_deploy_invoke_using_predeployed_cairo1() {
-        can_declare_deploy_invoke_using_predeployed_test_body(&["--account-class", "cairo1"]).await;
-    }
-
-    #[tokio::test]
     async fn can_declare_deploy_invoke_using_predeployed_custom() {
         let cli_args = ["--account-class-custom", CAIRO_1_ACCOUNT_CONTRACT_SIERRA_PATH];
-        can_declare_deploy_invoke_using_predeployed_test_body(&cli_args).await;
+        let devnet = BackgroundDevnet::spawn_with_additional_args(&cli_args).await.unwrap();
+
+        let (signer, account_address) = devnet.get_first_predeployed_account().await;
+        can_declare_deploy_invoke_cairo0_using_account(&devnet, &signer, account_address).await;
+        can_declare_deploy_invoke_cairo1_using_account(&devnet, &signer, account_address).await;
     }
 
     async fn assert_supports_isrc6(devnet: &BackgroundDevnet, account_address: FieldElement) {

--- a/crates/starknet-devnet/tests/test_fork.rs
+++ b/crates/starknet-devnet/tests/test_fork.rs
@@ -56,12 +56,8 @@ mod fork_tests {
 
     #[tokio::test]
     async fn test_forking_sepolia_genesis_block() {
-        let fork_devnet = BackgroundDevnet::spawn_with_additional_args(&[
-            "--fork-network",
-            INTEGRATION_SEPOLIA_URL,
-        ])
-        .await
-        .unwrap();
+        let cli_args = ["--fork-network", INTEGRATION_SEPOLIA_URL];
+        let fork_devnet = BackgroundDevnet::spawn_with_additional_args(&cli_args).await.unwrap();
 
         let resp = &fork_devnet
             .json_rpc_client
@@ -78,12 +74,8 @@ mod fork_tests {
 
     #[tokio::test]
     async fn test_getting_non_existent_block_from_origin() {
-        let fork_devnet = BackgroundDevnet::spawn_with_additional_args(&[
-            "--fork-network",
-            INTEGRATION_SEPOLIA_URL,
-        ])
-        .await
-        .expect("Could not start Devnet");
+        let cli_args = ["--fork-network", INTEGRATION_SEPOLIA_URL];
+        let fork_devnet = BackgroundDevnet::spawn_with_additional_args(&cli_args).await.unwrap();
 
         let non_existent_block_hash = "0x123456";
         let resp = &fork_devnet

--- a/crates/starknet-devnet/tests/test_fork.rs
+++ b/crates/starknet-devnet/tests/test_fork.rs
@@ -23,7 +23,9 @@ mod fork_tests {
     use starknet_types::rpc::transaction_receipt::FeeUnit;
 
     use crate::common::background_devnet::BackgroundDevnet;
-    use crate::common::constants::{self, SEPOLIA_GENESIS_BLOCK_HASH, SEPOLIA_URL};
+    use crate::common::constants::{
+        self, INTEGRATION_SEPOLIA_GENESIS_BLOCK_HASH, INTEGRATION_SEPOLIA_URL,
+    };
     use crate::common::utils::{
         assert_cairo1_classes_equal, assert_tx_successful, declare_deploy,
         get_block_reader_contract_in_sierra_and_compiled_class_hash, get_contract_balance,
@@ -54,15 +56,17 @@ mod fork_tests {
 
     #[tokio::test]
     async fn test_forking_sepolia_genesis_block() {
-        let fork_devnet =
-            BackgroundDevnet::spawn_with_additional_args(&["--fork-network", SEPOLIA_URL])
-                .await
-                .unwrap();
+        let fork_devnet = BackgroundDevnet::spawn_with_additional_args(&[
+            "--fork-network",
+            INTEGRATION_SEPOLIA_URL,
+        ])
+        .await
+        .unwrap();
 
         let resp = &fork_devnet
             .json_rpc_client
             .get_block_with_tx_hashes(BlockId::Hash(
-                FieldElement::from_hex_be(SEPOLIA_GENESIS_BLOCK_HASH).unwrap(),
+                FieldElement::from_hex_be(INTEGRATION_SEPOLIA_GENESIS_BLOCK_HASH).unwrap(),
             ))
             .await;
 
@@ -74,10 +78,12 @@ mod fork_tests {
 
     #[tokio::test]
     async fn test_getting_non_existent_block_from_origin() {
-        let fork_devnet =
-            BackgroundDevnet::spawn_with_additional_args(&["--fork-network", SEPOLIA_URL])
-                .await
-                .expect("Could not start Devnet");
+        let fork_devnet = BackgroundDevnet::spawn_with_additional_args(&[
+            "--fork-network",
+            INTEGRATION_SEPOLIA_URL,
+        ])
+        .await
+        .expect("Could not start Devnet");
 
         let non_existent_block_hash = "0x123456";
         let resp = &fork_devnet
@@ -579,7 +585,7 @@ mod fork_tests {
 
     #[tokio::test]
     async fn test_forking_https() {
-        let origin_url = SEPOLIA_URL;
+        let origin_url = INTEGRATION_SEPOLIA_URL;
         let fork_block = 2;
         let fork_devnet = BackgroundDevnet::spawn_with_additional_args(&[
             "--fork-network",

--- a/crates/starknet-devnet/tests/test_fork.rs
+++ b/crates/starknet-devnet/tests/test_fork.rs
@@ -23,17 +23,13 @@ mod fork_tests {
     use starknet_types::rpc::transaction_receipt::FeeUnit;
 
     use crate::common::background_devnet::BackgroundDevnet;
-    use crate::common::constants;
+    use crate::common::constants::{self, SEPOLIA_GENESIS_BLOCK_HASH, SEPOLIA_URL};
     use crate::common::utils::{
         assert_cairo1_classes_equal, assert_tx_successful, declare_deploy,
         get_block_reader_contract_in_sierra_and_compiled_class_hash, get_contract_balance,
         get_simple_contract_in_sierra_and_compiled_class_hash, resolve_path,
         send_ctrl_c_signal_and_wait,
     };
-
-    const SEPOLIA_URL: &str = "http://rpc.pathfinder.equilibrium.co/integration-sepolia/rpc/v0_7";
-    const SEPOLIA_GENESIS_BLOCK_HASH: &str =
-        "0x19f675d3fb226821493a6ab9a1955e384bba80f130de625621a418e9a7c0ca3";
 
     #[tokio::test]
     async fn test_fork_status() {
@@ -583,7 +579,7 @@ mod fork_tests {
 
     #[tokio::test]
     async fn test_forking_https() {
-        let origin_url = "https://rpc.pathfinder.equilibrium.co/integration-sepolia/rpc/v0_7";
+        let origin_url = SEPOLIA_URL;
         let fork_block = 2;
         let fork_devnet = BackgroundDevnet::spawn_with_additional_args(&[
             "--fork-network",


### PR DESCRIPTION
## Usage related changes

- None

## Development related changes

- Add Argent account testing
  - by relying on forking, as per #477
  - only tests interaction with a Cairo1 contract (Cairo0 seems to not work)
- The majority of line changes is just refactoring of account testing
  - continuation of #476
- Extract some constants (related to forking and account class hash)
- Define OZ and Argent account deployment utility functions
- Removed functions that extracted common functionality because the common functionality was no longer substantial; the new look is more explicit IMO:
  - `can_deploy_new_account_test_body`
  - `can_declare_deploy_invoke_using_predeployed_test_body` 

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#test-execution)
