### PR TITLE
Support disabling account impersonation

### DIFF
--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -1263,6 +1263,11 @@ impl Starknet {
                 msg: "Account impersonation is supported when forking mode is enabled.".to_string(),
             });
         }
+        if self.config.disable_account_impersonation {
+            return Err(Error::UnsupportedAction {
+                msg: "Account impersonation is disabled.".to_string(),
+            });
+        }
         if self.pending_state.is_contract_deployed_locally(account)? {
             return Err(Error::UnsupportedAction {
                 msg: "Account is in local state, cannot be impersonated".to_string(),
@@ -1287,8 +1292,23 @@ impl Starknet {
     /// # Arguments
     /// * `auto_impersonation` - If true, auto impersonate every account that is not part of the
     ///   state, otherwise dont auto impersonate
-    pub fn set_auto_impersonate_account(&mut self, auto_impersonation: bool) {
+    pub fn set_auto_impersonate_account(
+        &mut self,
+        auto_impersonation: bool,
+    ) -> DevnetResult<(), Error> {
+        if self.config.fork_config.url.is_none() {
+            return Err(Error::UnsupportedAction {
+                msg: "Account impersonation is supported when forking mode is enabled.".to_string(),
+            });
+        }
+        if self.config.disable_account_impersonation {
+            return Err(Error::UnsupportedAction {
+                msg: "Account impersonation is disabled.".to_string(),
+            });
+        }
         self.cheats.set_auto_impersonate(auto_impersonation);
+
+        Ok(())
     }
 
     /// Returns true if the account is not part of the state and is impersonated

--- a/crates/starknet-devnet-core/src/starknet/starknet_config.rs
+++ b/crates/starknet-devnet-core/src/starknet/starknet_config.rs
@@ -86,6 +86,7 @@ pub struct StarknetConfig {
     pub re_execute_on_init: bool,
     pub state_archive: StateArchiveCapacity,
     pub fork_config: ForkConfig,
+    pub disable_account_impersonation: bool,
 }
 
 impl Default for StarknetConfig {
@@ -113,6 +114,7 @@ impl Default for StarknetConfig {
             re_execute_on_init: true,
             state_archive: StateArchiveCapacity::default(),
             fork_config: ForkConfig::default(),
+            disable_account_impersonation: false,
         }
     }
 }

--- a/crates/starknet-devnet-server/src/api/json_rpc/write_endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/write_endpoints.rs
@@ -71,7 +71,7 @@ impl JsonRpcHandler {
     // devnet_autoImpersonate | devnet_stopAutoImpersonate
     pub async fn set_auto_impersonate(&self, auto_impersonation: bool) -> StrictRpcResult {
         let mut starknet = self.api.starknet.write().await;
-        starknet.set_auto_impersonate_account(auto_impersonation);
+        starknet.set_auto_impersonate_account(auto_impersonation)?;
         Ok(StarknetResponse::Empty)
     }
 }

--- a/crates/starknet-devnet/src/cli.rs
+++ b/crates/starknet-devnet/src/cli.rs
@@ -191,7 +191,7 @@ pub(crate) struct Args {
 
     #[arg(long = "disable-account-impersonation")]
     #[arg(env = "DISABLE_ACCOUNT_IMPERSONATION")]
-    #[arg(help = "Disables possibility to impersonate accounts;")]
+    #[arg(help = "Disables the possibility to impersonate accounts;")]
     disable_account_impersonation: bool,
 }
 

--- a/crates/starknet-devnet/src/cli.rs
+++ b/crates/starknet-devnet/src/cli.rs
@@ -188,6 +188,11 @@ pub(crate) struct Args {
     #[arg(help = "Specify the maximum HTTP request body size;")]
     #[arg(default_value_t = DEVNET_DEFAULT_REQUEST_BODY_SIZE_LIMIT)]
     request_body_size_limit: usize,
+
+    #[arg(long = "disable-account-impersonation")]
+    #[arg(env = "DISABLE_ACCOUNT_IMPERSONATION")]
+    #[arg(help = "Disables possibility to impersonate accounts;")]
+    disable_account_impersonation: bool,
 }
 
 impl Args {
@@ -223,6 +228,7 @@ impl Args {
                 url: self.fork_network.clone(),
                 block_number: self.fork_block,
             },
+            disable_account_impersonation: self.disable_account_impersonation,
         };
 
         let RequestResponseLogging { log_request, log_response } =

--- a/crates/starknet-devnet/tests/general_integration_tests.rs
+++ b/crates/starknet-devnet/tests/general_integration_tests.rs
@@ -85,7 +85,8 @@ mod general_integration_tests {
                 "request_body_size_limit": 1000,
             },
             "blocks_on_demand": true,
-            "lite_mode": false
+            "lite_mode": false,
+            "disable_account_impersonation": false,
         });
 
         let devnet = BackgroundDevnet::spawn_with_additional_args(&[

--- a/crates/starknet-devnet/tests/test_account_impersonation.rs
+++ b/crates/starknet-devnet/tests/test_account_impersonation.rs
@@ -69,6 +69,44 @@ mod impersonated_account_tests {
     }
 
     #[tokio::test]
+    async fn test_account_impersonation_have_to_return_an_error_when_account_impersonation_is_disabled()
+     {
+        let origin_devnet =
+            BackgroundDevnet::spawn_forkable_devnet().await.expect("Could not start Devnet");
+
+        let args = [
+            "--fork-network",
+            origin_devnet.url.as_str(),
+            "--accounts",
+            "0",
+            "--disable-account-impersonation",
+        ];
+        let forked_devnet = BackgroundDevnet::spawn_with_additional_args(&args).await.unwrap();
+
+        let impersonation_err = forked_devnet
+            .execute_impersonation_action(&ImpersonationAction::ImpersonateAccount(
+                FieldElement::ONE,
+            ))
+            .await
+            .unwrap_err();
+
+        assert_anyhow_error_contains_message(
+            impersonation_err,
+            "account impersonation is disabled",
+        );
+
+        let impersonation_err = forked_devnet
+            .execute_impersonation_action(&ImpersonationAction::AutoImpersonate)
+            .await
+            .unwrap_err();
+
+        assert_anyhow_error_contains_message(
+            impersonation_err,
+            "account impersonation is disabled",
+        );
+    }
+
+    #[tokio::test]
     async fn test_impersonated_of_a_predeployed_account_account_can_send_transaction() {
         let devnet =
             BackgroundDevnet::spawn_forkable_devnet().await.expect("Could not start Devnet");

--- a/website/docs/account-impersonation.md
+++ b/website/docs/account-impersonation.md
@@ -18,6 +18,8 @@ Devnet allows you to use impersonated account from mainnet/testnet. This means t
 
 :::
 
+User can disable account impersonation feature, by starting devnet with cli flag `disable-account-impersonation` or using environment variable `DISABLE_ACCOUNT_IMPERSONATION`. Every subsequent JSON-RPC request will return an error. This feature can be used in CTFs to stop participants from easily solving the task.
+
 ## API
 
 Account impersonation follows JSON-RPC method specification. Each method returns an empty response:

--- a/website/docs/account-impersonation.md
+++ b/website/docs/account-impersonation.md
@@ -18,7 +18,7 @@ Devnet allows you to use impersonated account from mainnet/testnet. This means t
 
 :::
 
-User can disable account impersonation feature, by starting devnet with cli flag `disable-account-impersonation` or using environment variable `DISABLE_ACCOUNT_IMPERSONATION`. Every subsequent JSON-RPC request will return an error. This feature can be used in CTFs to stop participants from easily solving the task.
+Users can disable account impersonation by starting Devnet with CLI flag `--disable-account-impersonation` or by setting environment variable `DISABLE_ACCOUNT_IMPERSONATION`. Every subsequent JSON-RPC impersonation request will return an error. This feature can be used in CTFs to prevent participants from easily solving the task.
 
 ## API
 


### PR DESCRIPTION
## Usage related changes

User can specify to disable account impersonation by:
cli flag `--disable-account-impersonation`
env var `DISABLE_ACCOUNT_IMPERSONATION`

## Development related changes

- Added cli flag
- Added integration test

## Checklist:

- [ ] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
- [ ] No spelling errors - `./scripts/check_spelling.sh`
- [ ] Performed code self-review
- [ ] Rebased to the latest commit of the target branch (or merged it into my branch)
- [ ] Updated the docs if needed - `./website/README.md`
- [ ] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#test-execution)
