### PR TITLE
Refactor Starknet test setup

### DIFF
--- a/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
@@ -100,7 +100,7 @@ mod tests {
     use starknet_rs_ff::FieldElement;
     use starknet_types::constants::QUERY_VERSION_OFFSET;
     use starknet_types::contract_address::ContractAddress;
-    use starknet_types::contract_class::{Cairo0Json, ContractClass};
+    use starknet_types::contract_class::ContractClass;
     use starknet_types::felt::Felt;
     use starknet_types::rpc::state::Balance;
     use starknet_types::rpc::transactions::broadcasted_declare_transaction_v1::BroadcastedDeclareTransactionV1;
@@ -119,8 +119,9 @@ mod tests {
     use crate::traits::{Deployed, HashIdentified, HashIdentifiedMut};
     use crate::utils::exported_test_utils::dummy_cairo_0_contract_class;
     use crate::utils::test_utils::{
-        convert_broadcasted_declare_v2_to_v3, dummy_broadcasted_declare_transaction_v2,
-        dummy_cairo_1_contract_class, dummy_contract_address, dummy_felt,
+        cairo_0_account_without_validations, convert_broadcasted_declare_v2_to_v3,
+        dummy_broadcasted_declare_transaction_v2, dummy_cairo_1_contract_class,
+        dummy_contract_address, dummy_felt,
     };
 
     fn broadcasted_declare_transaction_v1(
@@ -455,11 +456,7 @@ mod tests {
     /// Initializes starknet with 1 account - account without validations
     fn setup(acc_balance: Option<u128>) -> (Starknet, ContractAddress) {
         let mut starknet = Starknet::default();
-        let account_json_path = concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/test_artifacts/account_without_validations/account.json"
-        );
-        let contract_class = Cairo0Json::raw_json_from_path(account_json_path).unwrap();
+        let account_class = cairo_0_account_without_validations();
 
         let eth_erc_20_contract =
             predeployed::create_erc20_at_address(ETH_ERC20_CONTRACT_ADDRESS).unwrap();
@@ -472,8 +469,8 @@ mod tests {
             Balance::from(acc_balance.unwrap_or(10000)),
             dummy_felt(),
             dummy_felt(),
-            contract_class.generate_hash().unwrap(),
-            contract_class.into(),
+            account_class.generate_hash().unwrap(),
+            account_class.into(),
             eth_erc_20_contract.get_address(),
             strk_erc20_contract.get_address(),
         )

--- a/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
@@ -216,7 +216,7 @@ mod tests {
 
     #[test]
     fn add_declare_v2_transaction_should_return_rejected_txn_and_not_be_part_of_pending_state() {
-        let (mut starknet, sender) = setup_starknet_with_unvalidated_account(Some(1));
+        let (mut starknet, sender) = setup_starknet_with_unvalidated_account(1);
         let declare_txn = dummy_broadcasted_declare_transaction_v2(&sender.account_address);
 
         match starknet
@@ -234,7 +234,7 @@ mod tests {
 
     #[test]
     fn add_declare_v3_transaction_successful_execution() {
-        let (mut starknet, sender) = setup_starknet_with_unvalidated_account(Some(1e18 as u128));
+        let (mut starknet, sender) = setup_starknet_with_unvalidated_account(1e18 as u128);
 
         let declare_txn = convert_broadcasted_declare_v2_to_v3(
             dummy_broadcasted_declare_transaction_v2(&sender.account_address),
@@ -261,7 +261,7 @@ mod tests {
 
     #[test]
     fn add_declare_v2_transaction_successful_execution() {
-        let (mut starknet, sender) = setup_starknet_with_unvalidated_account(Some(100000000));
+        let (mut starknet, sender) = setup_starknet_with_unvalidated_account(1e8 as u128);
 
         let declare_txn = dummy_broadcasted_declare_transaction_v2(&sender.account_address);
         let (tx_hash, class_hash) = starknet
@@ -288,7 +288,7 @@ mod tests {
 
     #[test]
     fn declare_v2_transaction_successful_storage_change() {
-        let (mut starknet, sender) = setup_starknet_with_unvalidated_account(Some(100000000));
+        let (mut starknet, sender) = setup_starknet_with_unvalidated_account(1e8 as u128);
         let declare_txn = dummy_broadcasted_declare_transaction_v2(&sender.account_address);
         let expected_class_hash =
             ContractClass::Cairo1(declare_txn.contract_class.clone()).generate_hash().unwrap();
@@ -348,7 +348,7 @@ mod tests {
 
     #[test]
     fn add_declare_v1_transaction_should_return_an_error_due_to_low_max_fee() {
-        let (mut starknet, sender) = setup_starknet_with_unvalidated_account(Some(20000));
+        let (mut starknet, sender) = setup_starknet_with_unvalidated_account(20000);
 
         let mut declare_txn = broadcasted_declare_transaction_v1(sender.account_address);
         match declare_txn {
@@ -370,7 +370,7 @@ mod tests {
 
     #[test]
     fn add_declare_v1_transaction_should_return_an_error_due_to_not_enough_balance_on_account() {
-        let (mut starknet, sender) = setup_starknet_with_unvalidated_account(Some(1));
+        let (mut starknet, sender) = setup_starknet_with_unvalidated_account(1);
 
         let declare_txn = broadcasted_declare_transaction_v1(sender.account_address);
         match starknet.add_declare_transaction(declare_txn).unwrap_err() {
@@ -385,8 +385,9 @@ mod tests {
 
     #[test]
     fn add_declare_v1_transaction_successful_execution() {
-        let (mut starknet, sender) = setup_starknet_with_unvalidated_account(None);
+        let (mut starknet, sender) = setup_starknet_with_unvalidated_account(10000);
 
+        let initial_block_count = starknet.blocks.hash_to_block.len();
         let declare_txn = broadcasted_declare_transaction_v1(sender.account_address);
         let (tx_hash, class_hash) = starknet.add_declare_transaction(declare_txn.clone()).unwrap();
 
@@ -405,8 +406,8 @@ mod tests {
         assert!(starknet.pending_state.is_contract_declared(class_hash));
         // check if pending block is reset
         assert!(starknet.pending_block().get_transactions().is_empty());
-        // check if there is generated block
-        assert_eq!(starknet.blocks.hash_to_block.len(), 1);
+        // check if there is one new generated block
+        assert_eq!(starknet.blocks.hash_to_block.len(), initial_block_count + 1);
         // check if transaction is in generated block
         assert_eq!(
             *starknet
@@ -422,7 +423,7 @@ mod tests {
 
     #[test]
     fn declare_v1_transaction_successful_storage_change() {
-        let (mut starknet, sender) = setup_starknet_with_unvalidated_account(None);
+        let (mut starknet, sender) = setup_starknet_with_unvalidated_account(10000);
         let declare_txn = broadcasted_declare_transaction_v1(sender.account_address);
 
         match declare_txn {

--- a/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
@@ -106,7 +106,7 @@ mod tests {
     use starknet_types::rpc::transactions::BroadcastedDeclareTransaction;
     use starknet_types::traits::HashProducer;
 
-    use crate::starknet::tests::setup_starknet_with_unvalidated_account;
+    use crate::starknet::tests::setup_starknet_with_no_signature_check_account;
     use crate::starknet::Starknet;
     use crate::state::CustomStateReader;
     use crate::traits::{HashIdentified, HashIdentifiedMut};
@@ -216,7 +216,7 @@ mod tests {
 
     #[test]
     fn add_declare_v2_transaction_should_return_rejected_txn_and_not_be_part_of_pending_state() {
-        let (mut starknet, sender) = setup_starknet_with_unvalidated_account(1);
+        let (mut starknet, sender) = setup_starknet_with_no_signature_check_account(1);
         let declare_txn = dummy_broadcasted_declare_transaction_v2(&sender.account_address);
 
         match starknet
@@ -234,7 +234,7 @@ mod tests {
 
     #[test]
     fn add_declare_v3_transaction_successful_execution() {
-        let (mut starknet, sender) = setup_starknet_with_unvalidated_account(1e18 as u128);
+        let (mut starknet, sender) = setup_starknet_with_no_signature_check_account(1e18 as u128);
 
         let declare_txn = convert_broadcasted_declare_v2_to_v3(
             dummy_broadcasted_declare_transaction_v2(&sender.account_address),
@@ -261,7 +261,7 @@ mod tests {
 
     #[test]
     fn add_declare_v2_transaction_successful_execution() {
-        let (mut starknet, sender) = setup_starknet_with_unvalidated_account(1e8 as u128);
+        let (mut starknet, sender) = setup_starknet_with_no_signature_check_account(1e8 as u128);
 
         let declare_txn = dummy_broadcasted_declare_transaction_v2(&sender.account_address);
         let (tx_hash, class_hash) = starknet
@@ -288,7 +288,7 @@ mod tests {
 
     #[test]
     fn declare_v2_transaction_successful_storage_change() {
-        let (mut starknet, sender) = setup_starknet_with_unvalidated_account(1e8 as u128);
+        let (mut starknet, sender) = setup_starknet_with_no_signature_check_account(1e8 as u128);
         let declare_txn = dummy_broadcasted_declare_transaction_v2(&sender.account_address);
         let expected_class_hash =
             ContractClass::Cairo1(declare_txn.contract_class.clone()).generate_hash().unwrap();
@@ -348,7 +348,7 @@ mod tests {
 
     #[test]
     fn add_declare_v1_transaction_should_return_an_error_due_to_low_max_fee() {
-        let (mut starknet, sender) = setup_starknet_with_unvalidated_account(20000);
+        let (mut starknet, sender) = setup_starknet_with_no_signature_check_account(20000);
 
         let mut declare_txn = broadcasted_declare_transaction_v1(sender.account_address);
         match declare_txn {
@@ -370,7 +370,7 @@ mod tests {
 
     #[test]
     fn add_declare_v1_transaction_should_return_an_error_due_to_not_enough_balance_on_account() {
-        let (mut starknet, sender) = setup_starknet_with_unvalidated_account(1);
+        let (mut starknet, sender) = setup_starknet_with_no_signature_check_account(1);
 
         let declare_txn = broadcasted_declare_transaction_v1(sender.account_address);
         match starknet.add_declare_transaction(declare_txn).unwrap_err() {
@@ -385,7 +385,7 @@ mod tests {
 
     #[test]
     fn add_declare_v1_transaction_successful_execution() {
-        let (mut starknet, sender) = setup_starknet_with_unvalidated_account(10000);
+        let (mut starknet, sender) = setup_starknet_with_no_signature_check_account(10000);
 
         let initial_block_count = starknet.blocks.hash_to_block.len();
         let declare_txn = broadcasted_declare_transaction_v1(sender.account_address);
@@ -423,7 +423,7 @@ mod tests {
 
     #[test]
     fn declare_v1_transaction_successful_storage_change() {
-        let (mut starknet, sender) = setup_starknet_with_unvalidated_account(10000);
+        let (mut starknet, sender) = setup_starknet_with_no_signature_check_account(10000);
         let declare_txn = broadcasted_declare_transaction_v1(sender.account_address);
 
         match declare_txn {

--- a/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
@@ -83,7 +83,6 @@ mod tests {
     use starknet_rs_ff::FieldElement;
     use starknet_types::constants::QUERY_VERSION_OFFSET;
     use starknet_types::contract_address::ContractAddress;
-    use starknet_types::contract_class::Cairo0Json;
     use starknet_types::felt::{ClassHash, Felt};
     use starknet_types::rpc::transactions::broadcasted_deploy_account_transaction_v1::BroadcastedDeployAccountTransactionV1;
     use starknet_types::rpc::transactions::broadcasted_deploy_account_transaction_v3::BroadcastedDeployAccountTransactionV3;
@@ -101,6 +100,7 @@ mod tests {
     use crate::state::CustomState;
     use crate::traits::{Deployed, HashIdentifiedMut};
     use crate::utils::get_storage_var_address;
+    use crate::utils::test_utils::cairo_0_account_without_validations;
 
     fn test_deploy_account_transaction_v3(
         class_hash: ClassHash,
@@ -174,7 +174,7 @@ mod tests {
 
     #[test]
     fn deploy_account_transaction_v3_with_max_fee_zero_should_return_an_error() {
-        let (mut starknet, account_class_hash, _, _) = setup();
+        let (mut starknet, account_class_hash) = setup();
         let deploy_account_transaction =
             test_deploy_account_transaction_v3(account_class_hash, 0, 0);
 
@@ -193,7 +193,7 @@ mod tests {
 
     #[test]
     fn deploy_account_transaction_v1_should_return_an_error_due_to_not_enough_balance() {
-        let (mut starknet, account_class_hash, _, _) = setup();
+        let (mut starknet, account_class_hash) = setup();
 
         let fee_raw: u128 = 4000;
         let transaction = BroadcastedDeployAccountTransactionV1::new(
@@ -221,7 +221,7 @@ mod tests {
 
     #[test]
     fn deploy_account_transaction_v3_should_return_an_error_due_to_not_enough_balance() {
-        let (mut starknet, account_class_hash, _, _) = setup();
+        let (mut starknet, account_class_hash) = setup();
         let transaction = test_deploy_account_transaction_v3(account_class_hash, 0, 4000);
 
         match starknet
@@ -239,7 +239,7 @@ mod tests {
 
     #[test]
     fn deploy_account_transaction_v1_should_return_an_error_due_to_not_enough_fee() {
-        let (mut starknet, account_class_hash, eth_fee_token_address, _) = setup();
+        let (mut starknet, account_class_hash) = setup();
 
         let fee_raw: u128 = 1;
         let transaction = BroadcastedDeployAccountTransactionV1::new(
@@ -258,8 +258,6 @@ mod tests {
 
         // change balance at address
         let account_address = ContractAddress::from(blockifier_transaction.contract_address);
-        let fee_token_address: starknet_api::core::ContractAddress =
-            eth_fee_token_address.try_into().unwrap();
         let balance_storage_var_address =
             get_storage_var_address("ERC20_balances", &[account_address.into()])
                 .unwrap()
@@ -270,7 +268,7 @@ mod tests {
         starknet
             .pending_state
             .set_storage_at(
-                fee_token_address,
+                starknet.block_context.chain_info().fee_token_addresses.eth_fee_token_address,
                 balance_storage_var_address,
                 account_balance_before_deployment,
             )
@@ -291,7 +289,7 @@ mod tests {
 
     #[test]
     fn test_deploy_account_transaction_v3_successful_execution() {
-        let (mut starknet, account_class_hash, _, strk_fee_token_address) = setup();
+        let (mut starknet, account_class_hash) = setup();
         let transaction = test_deploy_account_transaction_v3(account_class_hash, 0, 4000);
 
         let blockifier_transaction = BroadcastedDeployAccountTransaction::V3(transaction.clone())
@@ -300,8 +298,6 @@ mod tests {
 
         // change balance at address
         let account_address = ContractAddress::from(blockifier_transaction.contract_address);
-        let fee_token_address: starknet_api::core::ContractAddress =
-            strk_fee_token_address.try_into().unwrap();
         let balance_storage_var_address =
             get_storage_var_address("ERC20_balances", &[account_address.into()])
                 .unwrap()
@@ -309,6 +305,8 @@ mod tests {
                 .unwrap();
 
         let account_balance_before_deployment = StarkFelt::from_u128(1000000);
+        let fee_token_address =
+            starknet.block_context.chain_info().fee_token_addresses.strk_fee_token_address;
         starknet
             .pending_state
             .set_storage_at(
@@ -341,7 +339,7 @@ mod tests {
 
     #[test]
     fn deploy_account_transaction_v1_successful_execution() {
-        let (mut starknet, account_class_hash, eth_fee_token_address, _) = setup();
+        let (mut starknet, account_class_hash) = setup();
 
         let transaction = BroadcastedDeployAccountTransactionV1::new(
             &vec![],
@@ -358,8 +356,6 @@ mod tests {
 
         // change balance at address
         let account_address = ContractAddress::from(blockifier_transaction.contract_address);
-        let fee_token_address: starknet_api::core::ContractAddress =
-            eth_fee_token_address.try_into().unwrap();
         let balance_storage_var_address =
             get_storage_var_address("ERC20_balances", &[account_address.into()])
                 .unwrap()
@@ -370,7 +366,7 @@ mod tests {
         starknet
             .pending_state
             .set_storage_at(
-                fee_token_address,
+                starknet.block_context.chain_info().fee_token_addresses.eth_fee_token_address,
                 balance_storage_var_address,
                 account_balance_before_deployment,
             )
@@ -391,12 +387,9 @@ mod tests {
     }
 
     /// Initializes starknet with erc20 contract, 1 declared contract class. Gas price is set to 1
-    fn setup() -> (Starknet, ClassHash, ContractAddress, ContractAddress) {
+    fn setup() -> (Starknet, ClassHash) {
         let mut starknet = Starknet::default();
-        let account_json_path = concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/test_artifacts/account_without_validations/account.json"
-        );
+
         let erc_20_contract =
             predeployed::create_erc20_at_address(ETH_ERC20_CONTRACT_ADDRESS).unwrap();
         erc_20_contract.deploy(&mut starknet.pending_state).unwrap();
@@ -405,10 +398,10 @@ mod tests {
             predeployed::create_erc20_at_address(STRK_ERC20_CONTRACT_ADDRESS).unwrap();
         strk_erc20_contract.deploy(&mut starknet.pending_state).unwrap();
 
-        let contract_class = Cairo0Json::raw_json_from_path(account_json_path).unwrap();
-        let class_hash = contract_class.generate_hash().unwrap();
+        let account_class = cairo_0_account_without_validations();
+        let class_hash = account_class.generate_hash().unwrap();
 
-        starknet.pending_state.declare_contract_class(class_hash, contract_class.into()).unwrap();
+        starknet.pending_state.declare_contract_class(class_hash, account_class.into()).unwrap();
         starknet.block_context = Starknet::init_block_context(
             nonzero!(1u128),
             nonzero!(1u128),
@@ -422,6 +415,6 @@ mod tests {
 
         starknet.restart_pending_block().unwrap();
 
-        (starknet, class_hash, erc_20_contract.get_address(), strk_erc20_contract.get_address())
+        (starknet, class_hash)
     }
 }

--- a/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
@@ -398,10 +398,10 @@ mod tests {
             predeployed::create_erc20_at_address(STRK_ERC20_CONTRACT_ADDRESS).unwrap();
         strk_erc20_contract.deploy(&mut starknet.pending_state).unwrap();
 
-        let account_class = cairo_0_account_without_validations();
-        let class_hash = account_class.generate_hash().unwrap();
+        let contract_class = cairo_0_account_without_validations();
+        let class_hash = contract_class.generate_hash().unwrap();
 
-        starknet.pending_state.declare_contract_class(class_hash, account_class.into()).unwrap();
+        starknet.pending_state.declare_contract_class(class_hash, contract_class.into()).unwrap();
         starknet.block_context = Starknet::init_block_context(
             nonzero!(1u128),
             nonzero!(1u128),

--- a/crates/starknet-devnet-core/src/starknet/get_class_impls.rs
+++ b/crates/starknet-devnet-core/src/starknet/get_class_impls.rs
@@ -52,15 +52,16 @@ mod tests {
 
     use crate::error::Error;
     use crate::starknet::starknet_config::StateArchiveCapacity;
-    use crate::starknet::tests::setup_starknet_with_unvalidated_account_and_state_capacity;
+    use crate::starknet::tests::setup_starknet_with_no_signature_check_account_and_state_capacity;
     use crate::utils::test_utils::dummy_broadcasted_declare_transaction_v2;
 
     #[test]
     fn get_sierra_class() {
-        let (mut starknet, account) = setup_starknet_with_unvalidated_account_and_state_capacity(
-            1e8 as u128,
-            StateArchiveCapacity::Full,
-        );
+        let (mut starknet, account) =
+            setup_starknet_with_no_signature_check_account_and_state_capacity(
+                1e8 as u128,
+                StateArchiveCapacity::Full,
+            );
 
         let declare_txn = dummy_broadcasted_declare_transaction_v2(&account.account_address);
 
@@ -82,10 +83,11 @@ mod tests {
 
     #[test]
     fn get_class_hash_at_generated_accounts() {
-        let (mut starknet, account) = setup_starknet_with_unvalidated_account_and_state_capacity(
-            1e8 as u128,
-            StateArchiveCapacity::Full,
-        );
+        let (mut starknet, account) =
+            setup_starknet_with_no_signature_check_account_and_state_capacity(
+                1e8 as u128,
+                StateArchiveCapacity::Full,
+            );
 
         let block_number = starknet.get_latest_block().unwrap().block_number();
         let block_id = BlockId::Number(block_number.0);
@@ -97,10 +99,11 @@ mod tests {
 
     #[test]
     fn get_class_hash_at_generated_accounts_without_state_archive() {
-        let (mut starknet, account) = setup_starknet_with_unvalidated_account_and_state_capacity(
-            1e8 as u128,
-            StateArchiveCapacity::None,
-        );
+        let (mut starknet, account) =
+            setup_starknet_with_no_signature_check_account_and_state_capacity(
+                1e8 as u128,
+                StateArchiveCapacity::None,
+            );
 
         let block_number = starknet.get_latest_block().unwrap().block_number();
         let block_id = BlockId::Number(block_number.0);
@@ -114,10 +117,11 @@ mod tests {
 
     #[test]
     fn get_class_at_generated_accounts() {
-        let (mut starknet, account) = setup_starknet_with_unvalidated_account_and_state_capacity(
-            1e8 as u128,
-            StateArchiveCapacity::Full,
-        );
+        let (mut starknet, account) =
+            setup_starknet_with_no_signature_check_account_and_state_capacity(
+                1e8 as u128,
+                StateArchiveCapacity::Full,
+            );
 
         let block_number = starknet.get_latest_block().unwrap().block_number();
         let block_id = BlockId::Number(block_number.0);

--- a/crates/starknet-devnet-core/src/starknet/get_class_impls.rs
+++ b/crates/starknet-devnet-core/src/starknet/get_class_impls.rs
@@ -51,7 +51,7 @@ mod tests {
     use nonzero_ext::nonzero;
     use starknet_rs_core::types::BlockId;
     use starknet_types::contract_address::ContractAddress;
-    use starknet_types::contract_class::{Cairo0Json, ContractClass};
+    use starknet_types::contract_class::ContractClass;
     use starknet_types::felt::Felt;
     use starknet_types::rpc::state::Balance;
     use starknet_types::traits::HashProducer;
@@ -65,7 +65,9 @@ mod tests {
     use crate::starknet::starknet_config::{StarknetConfig, StateArchiveCapacity};
     use crate::starknet::Starknet;
     use crate::traits::Deployed;
-    use crate::utils::test_utils::{dummy_broadcasted_declare_transaction_v2, dummy_felt};
+    use crate::utils::test_utils::{
+        cairo_0_account_without_validations, dummy_broadcasted_declare_transaction_v2, dummy_felt,
+    };
 
     fn setup(
         acc_balance: Option<u128>,
@@ -74,18 +76,14 @@ mod tests {
         let mut starknet = Starknet::new(&StarknetConfig { state_archive, ..Default::default() })
             .expect("Could not start Devnet");
 
-        let account_json_path = concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/test_artifacts/account_without_validations/account.json"
-        );
-        let contract_class = Cairo0Json::raw_json_from_path(account_json_path).unwrap();
+        let account_class = cairo_0_account_without_validations();
 
         let acc = Account::new(
             Balance::from(acc_balance.unwrap_or(100)),
             dummy_felt(),
             dummy_felt(),
-            contract_class.generate_hash().unwrap(),
-            contract_class.into(),
+            account_class.generate_hash().unwrap(),
+            account_class.into(),
             ContractAddress::new(Felt::from_prefixed_hex_str(ETH_ERC20_CONTRACT_ADDRESS).unwrap())
                 .unwrap(),
             ContractAddress::new(Felt::from_prefixed_hex_str(STRK_ERC20_CONTRACT_ADDRESS).unwrap())

--- a/crates/starknet-devnet-core/src/starknet/get_class_impls.rs
+++ b/crates/starknet-devnet-core/src/starknet/get_class_impls.rs
@@ -47,71 +47,20 @@ pub fn get_class_at_impl(
 
 #[cfg(test)]
 mod tests {
-
-    use nonzero_ext::nonzero;
     use starknet_rs_core::types::BlockId;
-    use starknet_types::contract_address::ContractAddress;
     use starknet_types::contract_class::ContractClass;
-    use starknet_types::felt::Felt;
-    use starknet_types::rpc::state::Balance;
-    use starknet_types::traits::HashProducer;
 
-    use crate::account::Account;
-    use crate::constants::{
-        self, DEVNET_DEFAULT_CHAIN_ID, DEVNET_DEFAULT_STARTING_BLOCK_NUMBER,
-        ETH_ERC20_CONTRACT_ADDRESS, STRK_ERC20_CONTRACT_ADDRESS,
-    };
     use crate::error::Error;
-    use crate::starknet::starknet_config::{StarknetConfig, StateArchiveCapacity};
-    use crate::starknet::Starknet;
-    use crate::traits::Deployed;
-    use crate::utils::test_utils::{
-        cairo_0_account_without_validations, dummy_broadcasted_declare_transaction_v2, dummy_felt,
-    };
-
-    fn setup(
-        acc_balance: Option<u128>,
-        state_archive: StateArchiveCapacity,
-    ) -> (Starknet, Account) {
-        let mut starknet = Starknet::new(&StarknetConfig { state_archive, ..Default::default() })
-            .expect("Could not start Devnet");
-
-        let account_class = cairo_0_account_without_validations();
-
-        let acc = Account::new(
-            Balance::from(acc_balance.unwrap_or(100)),
-            dummy_felt(),
-            dummy_felt(),
-            account_class.generate_hash().unwrap(),
-            account_class.into(),
-            ContractAddress::new(Felt::from_prefixed_hex_str(ETH_ERC20_CONTRACT_ADDRESS).unwrap())
-                .unwrap(),
-            ContractAddress::new(Felt::from_prefixed_hex_str(STRK_ERC20_CONTRACT_ADDRESS).unwrap())
-                .unwrap(),
-        )
-        .unwrap();
-
-        acc.deploy(&mut starknet.pending_state).unwrap();
-
-        starknet.block_context = Starknet::init_block_context(
-            nonzero!(1u128),
-            nonzero!(1u128),
-            nonzero!(1u128),
-            nonzero!(1u128),
-            constants::ETH_ERC20_CONTRACT_ADDRESS,
-            constants::STRK_ERC20_CONTRACT_ADDRESS,
-            DEVNET_DEFAULT_CHAIN_ID,
-            DEVNET_DEFAULT_STARTING_BLOCK_NUMBER,
-        );
-
-        starknet.restart_pending_block().unwrap();
-
-        (starknet, acc)
-    }
+    use crate::starknet::starknet_config::StateArchiveCapacity;
+    use crate::starknet::tests::setup_starknet_with_unvalidated_account_and_state_capacity;
+    use crate::utils::test_utils::dummy_broadcasted_declare_transaction_v2;
 
     #[test]
     fn get_sierra_class() {
-        let (mut starknet, account) = setup(Some(100000000), StateArchiveCapacity::Full);
+        let (mut starknet, account) = setup_starknet_with_unvalidated_account_and_state_capacity(
+            1e8 as u128,
+            StateArchiveCapacity::Full,
+        );
 
         let declare_txn = dummy_broadcasted_declare_transaction_v2(&account.account_address);
 
@@ -133,9 +82,10 @@ mod tests {
 
     #[test]
     fn get_class_hash_at_generated_accounts() {
-        let (mut starknet, account) = setup(Some(100000000), StateArchiveCapacity::Full);
-        let state_diff = starknet.commit_with_diff().unwrap();
-        starknet.generate_new_block_and_state(state_diff).unwrap();
+        let (mut starknet, account) = setup_starknet_with_unvalidated_account_and_state_capacity(
+            1e8 as u128,
+            StateArchiveCapacity::Full,
+        );
 
         let block_number = starknet.get_latest_block().unwrap().block_number();
         let block_id = BlockId::Number(block_number.0);
@@ -147,9 +97,10 @@ mod tests {
 
     #[test]
     fn get_class_hash_at_generated_accounts_without_state_archive() {
-        let (mut starknet, account) = setup(Some(100000000), StateArchiveCapacity::None);
-        let state_diff = starknet.commit_with_diff().unwrap();
-        starknet.generate_new_block_and_state(state_diff).unwrap();
+        let (mut starknet, account) = setup_starknet_with_unvalidated_account_and_state_capacity(
+            1e8 as u128,
+            StateArchiveCapacity::None,
+        );
 
         let block_number = starknet.get_latest_block().unwrap().block_number();
         let block_id = BlockId::Number(block_number.0);
@@ -163,12 +114,12 @@ mod tests {
 
     #[test]
     fn get_class_at_generated_accounts() {
-        let (mut starknet, account) = setup(Some(100000000), StateArchiveCapacity::Full);
-        let state_diff = starknet.commit_with_diff().unwrap();
-        starknet.generate_new_block_and_state(state_diff).unwrap();
+        let (mut starknet, account) = setup_starknet_with_unvalidated_account_and_state_capacity(
+            1e8 as u128,
+            StateArchiveCapacity::Full,
+        );
 
         let block_number = starknet.get_latest_block().unwrap().block_number();
-        assert_eq!(block_number.0, 0); // defined via block context in setup
         let block_id = BlockId::Number(block_number.0);
 
         let contract_class = starknet.get_class_at(&block_id, account.account_address).unwrap();

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -1405,9 +1405,9 @@ mod tests {
         dummy_felt,
     };
 
-    /// Initializes starknet with 1 account that doesn't require tx without validation and with the
-    /// specified state archive capacity
-    pub(crate) fn setup_starknet_with_unvalidated_account_and_state_capacity(
+    /// Initializes starknet with 1 account that doesn't perform actual tx signature validation.
+    /// Allows specifying the state archive capacity.
+    pub(crate) fn setup_starknet_with_no_signature_check_account_and_state_capacity(
         acc_balance: u128,
         state_archive: StateArchiveCapacity,
     ) -> (Starknet, Account) {
@@ -1441,11 +1441,11 @@ mod tests {
         (starknet, acc)
     }
 
-    /// Initializes starknet with 1 account that doesn't require tx without validation
-    pub(crate) fn setup_starknet_with_unvalidated_account(
+    /// Initializes starknet with 1 account that doesn't perform actual tx signature validation.
+    pub(crate) fn setup_starknet_with_no_signature_check_account(
         acc_balance: u128,
     ) -> (Starknet, Account) {
-        setup_starknet_with_unvalidated_account_and_state_capacity(
+        setup_starknet_with_no_signature_check_account_and_state_capacity(
             acc_balance,
             StateArchiveCapacity::None,
         )

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -1405,15 +1405,18 @@ mod tests {
         dummy_felt,
     };
 
-    /// Initializes starknet with 1 account - account without validations
-    pub(crate) fn setup_starknet_with_unvalidated_account(
+    /// Initializes starknet with 1 account that doesn't require tx without validation and with the
+    /// specified state archive capacity
+    pub(crate) fn setup_starknet_with_unvalidated_account_and_state_capacity(
         acc_balance: u128,
+        state_archive: StateArchiveCapacity,
     ) -> (Starknet, Account) {
         let mut starknet = Starknet::new(&StarknetConfig {
             gas_price_wei: nonzero!(1u128),
             gas_price_strk: nonzero!(1u128),
             data_gas_price_wei: nonzero!(1u128),
             data_gas_price_strk: nonzero!(1u128),
+            state_archive,
             ..Default::default()
         })
         .unwrap();
@@ -1436,6 +1439,16 @@ mod tests {
         starknet.restart_pending_block().unwrap();
 
         (starknet, acc)
+    }
+
+    /// Initializes starknet with 1 account that doesn't require tx without validation
+    pub(crate) fn setup_starknet_with_unvalidated_account(
+        acc_balance: u128,
+    ) -> (Starknet, Account) {
+        setup_starknet_with_unvalidated_account_and_state_capacity(
+            acc_balance,
+            StateArchiveCapacity::None,
+        )
     }
 
     #[test]

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -1407,7 +1407,7 @@ mod tests {
 
     /// Initializes starknet with 1 account - account without validations
     pub(crate) fn setup_starknet_with_unvalidated_account(
-        acc_balance: Option<u128>,
+        acc_balance: u128,
     ) -> (Starknet, Account) {
         let mut starknet = Starknet::new(&StarknetConfig {
             gas_price_wei: nonzero!(1u128),
@@ -1420,7 +1420,7 @@ mod tests {
 
         let account_class = cairo_0_account_without_validations();
         let acc = Account::new(
-            Balance::from(acc_balance.unwrap_or(10000)),
+            Balance::from(acc_balance),
             dummy_felt(),
             dummy_felt(),
             account_class.generate_hash().unwrap(),
@@ -1431,6 +1431,8 @@ mod tests {
         .unwrap();
         acc.deploy(&mut starknet.pending_state).unwrap();
 
+        let state_diff = starknet.commit_with_diff().unwrap();
+        starknet.generate_new_block_and_state(state_diff).unwrap();
         starknet.restart_pending_block().unwrap();
 
         (starknet, acc)

--- a/crates/starknet-devnet-core/src/starknet/state_update.rs
+++ b/crates/starknet-devnet-core/src/starknet/state_update.rs
@@ -26,7 +26,7 @@ mod tests {
     use starknet_types::rpc::transactions::broadcasted_declare_transaction_v2::BroadcastedDeclareTransactionV2;
     use starknet_types::traits::HashProducer;
 
-    use crate::starknet::tests::setup_starknet_with_unvalidated_account;
+    use crate::starknet::tests::setup_starknet_with_no_signature_check_account;
     use crate::state::state_diff::StateDiff;
     use crate::traits::HashIdentifiedMut;
     use crate::utils::casm_hash;
@@ -35,7 +35,7 @@ mod tests {
     #[test]
     /// This test checks that the state update is correct after a declare transaction v2.
     fn correct_state_update_after_declare_transaction_v2() {
-        let (mut starknet, acc) = setup_starknet_with_unvalidated_account(1e18 as u128);
+        let (mut starknet, acc) = setup_starknet_with_no_signature_check_account(1e18 as u128);
         let contract_class = dummy_cairo_1_contract_class();
 
         let sierra_class_hash =

--- a/crates/starknet-devnet-core/src/starknet/state_update.rs
+++ b/crates/starknet-devnet-core/src/starknet/state_update.rs
@@ -17,33 +17,25 @@ pub fn state_update_by_block_id(
 
 #[cfg(test)]
 mod tests {
-    use nonzero_ext::nonzero;
+
     use starknet_api::transaction::Fee;
     use starknet_rs_core::types::{TransactionExecutionStatus, TransactionFinalityStatus};
-    use starknet_types::contract_address::ContractAddress;
     use starknet_types::contract_class::ContractClass;
     use starknet_types::felt::Felt;
-    use starknet_types::rpc::state::{Balance, ThinStateDiff};
+    use starknet_types::rpc::state::ThinStateDiff;
     use starknet_types::rpc::transactions::broadcasted_declare_transaction_v2::BroadcastedDeclareTransactionV2;
     use starknet_types::traits::HashProducer;
 
-    use crate::account::Account;
-    use crate::constants::{
-        self, DEVNET_DEFAULT_CHAIN_ID, DEVNET_DEFAULT_STARTING_BLOCK_NUMBER,
-        ETH_ERC20_CONTRACT_ADDRESS, STRK_ERC20_CONTRACT_ADDRESS,
-    };
-    use crate::starknet::{predeployed, Starknet};
+    use crate::starknet::tests::setup_starknet_with_unvalidated_account;
     use crate::state::state_diff::StateDiff;
-    use crate::traits::{Deployed, HashIdentifiedMut};
+    use crate::traits::HashIdentifiedMut;
     use crate::utils::casm_hash;
-    use crate::utils::test_utils::{
-        cairo_0_account_without_validations, dummy_cairo_1_contract_class, dummy_felt,
-    };
+    use crate::utils::test_utils::dummy_cairo_1_contract_class;
 
     #[test]
     /// This test checks that the state update is correct after a declare transaction v2.
     fn correct_state_update_after_declare_transaction_v2() {
-        let (mut starknet, sender_address) = setup();
+        let (mut starknet, acc) = setup_starknet_with_unvalidated_account(Some(1e18 as u128));
         let contract_class = dummy_cairo_1_contract_class();
 
         let sierra_class_hash =
@@ -57,7 +49,7 @@ mod tests {
         let declare_txn = BroadcastedDeclareTransactionV2::new(
             &contract_class,
             compiled_class_hash,
-            sender_address,
+            acc.account_address,
             Fee(400000),
             &Vec::new(),
             Felt::from(0),
@@ -96,49 +88,5 @@ mod tests {
         let expected_class_diff =
             (expected_state_diff.deprecated_declared_classes, expected_state_diff.declared_classes);
         assert_eq!(class_diff, expected_class_diff);
-    }
-
-    /// Initializes starknet with account_without_validations
-    /// deploys ERC20 contract
-    fn setup() -> (Starknet, ContractAddress) {
-        let mut starknet = Starknet::default();
-        let account_class = cairo_0_account_without_validations();
-
-        let eth_erc_20_contract =
-            predeployed::create_erc20_at_address(ETH_ERC20_CONTRACT_ADDRESS).unwrap();
-        eth_erc_20_contract.deploy(&mut starknet.pending_state).unwrap();
-
-        let acc = Account::new(
-            Balance::from(1e18 as u128),
-            dummy_felt(),
-            dummy_felt(),
-            account_class.generate_hash().unwrap(),
-            account_class.into(),
-            eth_erc_20_contract.get_address(),
-            ContractAddress::new(Felt::from_prefixed_hex_str(STRK_ERC20_CONTRACT_ADDRESS).unwrap())
-                .unwrap(),
-        )
-        .unwrap();
-
-        acc.deploy(&mut starknet.pending_state).unwrap();
-
-        starknet.block_context = Starknet::init_block_context(
-            nonzero!(1u128),
-            nonzero!(1u128),
-            nonzero!(1u128),
-            nonzero!(1u128),
-            constants::ETH_ERC20_CONTRACT_ADDRESS,
-            constants::STRK_ERC20_CONTRACT_ADDRESS,
-            DEVNET_DEFAULT_CHAIN_ID,
-            DEVNET_DEFAULT_STARTING_BLOCK_NUMBER,
-        );
-
-        starknet.restart_pending_block().unwrap();
-
-        // commit the newly declared account class
-        let state_diff = starknet.commit_with_diff().unwrap();
-        starknet.generate_new_block_and_state(state_diff).unwrap();
-
-        (starknet, acc.get_address())
     }
 }

--- a/crates/starknet-devnet-core/src/starknet/state_update.rs
+++ b/crates/starknet-devnet-core/src/starknet/state_update.rs
@@ -21,7 +21,7 @@ mod tests {
     use starknet_api::transaction::Fee;
     use starknet_rs_core::types::{TransactionExecutionStatus, TransactionFinalityStatus};
     use starknet_types::contract_address::ContractAddress;
-    use starknet_types::contract_class::{Cairo0Json, ContractClass};
+    use starknet_types::contract_class::ContractClass;
     use starknet_types::felt::Felt;
     use starknet_types::rpc::state::{Balance, ThinStateDiff};
     use starknet_types::rpc::transactions::broadcasted_declare_transaction_v2::BroadcastedDeclareTransactionV2;
@@ -36,7 +36,9 @@ mod tests {
     use crate::state::state_diff::StateDiff;
     use crate::traits::{Deployed, HashIdentifiedMut};
     use crate::utils::casm_hash;
-    use crate::utils::test_utils::{dummy_cairo_1_contract_class, dummy_felt};
+    use crate::utils::test_utils::{
+        cairo_0_account_without_validations, dummy_cairo_1_contract_class, dummy_felt,
+    };
 
     #[test]
     /// This test checks that the state update is correct after a declare transaction v2.
@@ -100,11 +102,7 @@ mod tests {
     /// deploys ERC20 contract
     fn setup() -> (Starknet, ContractAddress) {
         let mut starknet = Starknet::default();
-        let account_json_path = concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/test_artifacts/account_without_validations/account.json"
-        );
-        let contract_class = Cairo0Json::raw_json_from_path(account_json_path).unwrap();
+        let account_class = cairo_0_account_without_validations();
 
         let eth_erc_20_contract =
             predeployed::create_erc20_at_address(ETH_ERC20_CONTRACT_ADDRESS).unwrap();
@@ -114,8 +112,8 @@ mod tests {
             Balance::from(1e18 as u128),
             dummy_felt(),
             dummy_felt(),
-            contract_class.generate_hash().unwrap(),
-            contract_class.into(),
+            account_class.generate_hash().unwrap(),
+            account_class.into(),
             eth_erc_20_contract.get_address(),
             ContractAddress::new(Felt::from_prefixed_hex_str(STRK_ERC20_CONTRACT_ADDRESS).unwrap())
                 .unwrap(),

--- a/crates/starknet-devnet-core/src/starknet/state_update.rs
+++ b/crates/starknet-devnet-core/src/starknet/state_update.rs
@@ -35,7 +35,7 @@ mod tests {
     #[test]
     /// This test checks that the state update is correct after a declare transaction v2.
     fn correct_state_update_after_declare_transaction_v2() {
-        let (mut starknet, acc) = setup_starknet_with_unvalidated_account(Some(1e18 as u128));
+        let (mut starknet, acc) = setup_starknet_with_unvalidated_account(1e18 as u128);
         let contract_class = dummy_cairo_1_contract_class();
 
         let sierra_class_hash =

--- a/crates/starknet-devnet/tests/common/utils.rs
+++ b/crates/starknet-devnet/tests/common/utils.rs
@@ -59,28 +59,28 @@ pub fn load_json<T: serde::de::DeserializeOwned>(path: &str) -> T {
     loaded
 }
 
-pub type SierraWithHash = (FlattenedSierraClass, FieldElement);
+pub type SierraWithCasmHash = (FlattenedSierraClass, FieldElement);
 
-pub fn get_flattened_sierra_contract_and_casm_hash(sierra_path: &str) -> SierraWithHash {
+pub fn get_flattened_sierra_contract_and_casm_hash(sierra_path: &str) -> SierraWithCasmHash {
     let sierra_string = std::fs::read_to_string(sierra_path).unwrap();
     let sierra_class: SierraClass = serde_json::from_str(&sierra_string).unwrap();
     let casm_json = usc::compile_contract(serde_json::from_str(&sierra_string).unwrap()).unwrap();
     (sierra_class.flatten().unwrap(), casm_hash(casm_json).unwrap())
 }
 
-pub fn get_messaging_contract_in_sierra_and_compiled_class_hash() -> SierraWithHash {
+pub fn get_messaging_contract_in_sierra_and_compiled_class_hash() -> SierraWithCasmHash {
     let sierra_path =
         concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/cairo1/messaging/cairo_1_l1l2.sierra");
     get_flattened_sierra_contract_and_casm_hash(sierra_path)
 }
 
-pub fn get_messaging_lib_in_sierra_and_compiled_class_hash() -> SierraWithHash {
+pub fn get_messaging_lib_in_sierra_and_compiled_class_hash() -> SierraWithCasmHash {
     let sierra_path =
         concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/cairo1/messaging/cairo_1_l1l2_lib.sierra");
     get_flattened_sierra_contract_and_casm_hash(sierra_path)
 }
 
-pub fn get_events_contract_in_sierra_and_compiled_class_hash() -> SierraWithHash {
+pub fn get_events_contract_in_sierra_and_compiled_class_hash() -> SierraWithCasmHash {
     let events_sierra_path = concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/test_data/cairo1/events/events_2.0.1_compiler.sierra"
@@ -88,13 +88,13 @@ pub fn get_events_contract_in_sierra_and_compiled_class_hash() -> SierraWithHash
     get_flattened_sierra_contract_and_casm_hash(events_sierra_path)
 }
 
-pub fn get_block_reader_contract_in_sierra_and_compiled_class_hash() -> SierraWithHash {
+pub fn get_block_reader_contract_in_sierra_and_compiled_class_hash() -> SierraWithCasmHash {
     let timestamp_sierra_path =
         concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/cairo1/block_reader/block_reader.sierra");
     get_flattened_sierra_contract_and_casm_hash(timestamp_sierra_path)
 }
 
-pub fn get_simple_contract_in_sierra_and_compiled_class_hash() -> SierraWithHash {
+pub fn get_simple_contract_in_sierra_and_compiled_class_hash() -> SierraWithCasmHash {
     let contract_path = format!("{}/{}", env!("CARGO_MANIFEST_DIR"), CAIRO_1_CONTRACT_PATH);
     get_flattened_sierra_contract_and_casm_hash(&contract_path)
 }

--- a/crates/starknet-devnet/tests/common/utils.rs
+++ b/crates/starknet-devnet/tests/common/utils.rs
@@ -59,31 +59,28 @@ pub fn load_json<T: serde::de::DeserializeOwned>(path: &str) -> T {
     loaded
 }
 
-pub fn get_flattened_sierra_contract_and_casm_hash(
-    sierra_path: &str,
-) -> (FlattenedSierraClass, FieldElement) {
+pub type SierraWithHash = (FlattenedSierraClass, FieldElement);
+
+pub fn get_flattened_sierra_contract_and_casm_hash(sierra_path: &str) -> SierraWithHash {
     let sierra_string = std::fs::read_to_string(sierra_path).unwrap();
     let sierra_class: SierraClass = serde_json::from_str(&sierra_string).unwrap();
     let casm_json = usc::compile_contract(serde_json::from_str(&sierra_string).unwrap()).unwrap();
     (sierra_class.flatten().unwrap(), casm_hash(casm_json).unwrap())
 }
 
-pub fn get_messaging_contract_in_sierra_and_compiled_class_hash()
--> (FlattenedSierraClass, FieldElement) {
+pub fn get_messaging_contract_in_sierra_and_compiled_class_hash() -> SierraWithHash {
     let sierra_path =
         concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/cairo1/messaging/cairo_1_l1l2.sierra");
     get_flattened_sierra_contract_and_casm_hash(sierra_path)
 }
 
-pub fn get_messaging_lib_in_sierra_and_compiled_class_hash() -> (FlattenedSierraClass, FieldElement)
-{
+pub fn get_messaging_lib_in_sierra_and_compiled_class_hash() -> SierraWithHash {
     let sierra_path =
         concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/cairo1/messaging/cairo_1_l1l2_lib.sierra");
     get_flattened_sierra_contract_and_casm_hash(sierra_path)
 }
 
-pub fn get_events_contract_in_sierra_and_compiled_class_hash()
--> (FlattenedSierraClass, FieldElement) {
+pub fn get_events_contract_in_sierra_and_compiled_class_hash() -> SierraWithHash {
     let events_sierra_path = concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/test_data/cairo1/events/events_2.0.1_compiler.sierra"
@@ -91,15 +88,13 @@ pub fn get_events_contract_in_sierra_and_compiled_class_hash()
     get_flattened_sierra_contract_and_casm_hash(events_sierra_path)
 }
 
-pub fn get_block_reader_contract_in_sierra_and_compiled_class_hash()
--> (FlattenedSierraClass, FieldElement) {
+pub fn get_block_reader_contract_in_sierra_and_compiled_class_hash() -> SierraWithHash {
     let timestamp_sierra_path =
         concat!(env!("CARGO_MANIFEST_DIR"), "/test_data/cairo1/block_reader/block_reader.sierra");
     get_flattened_sierra_contract_and_casm_hash(timestamp_sierra_path)
 }
 
-pub fn get_simple_contract_in_sierra_and_compiled_class_hash()
--> (FlattenedSierraClass, FieldElement) {
+pub fn get_simple_contract_in_sierra_and_compiled_class_hash() -> SierraWithHash {
     let contract_path = format!("{}/{}", env!("CARGO_MANIFEST_DIR"), CAIRO_1_CONTRACT_PATH);
     get_flattened_sierra_contract_and_casm_hash(&contract_path)
 }


### PR DESCRIPTION
## Usage related changes

- None, hopefully

## Development related changes

- Replace the multiple `fn setup(acc_balance: Option<u128>) -> (Starknet, ContractAddress, ...)` definitions with:
  - `fn setup_starknet_with_unvalidated_account(acc_balance: u128)`
  - `fn setup_starknet_with_unvalidated_account_and_state_capacity(acc_balance: u128, state_archive: StateArchiveCapacity)`
- Instead of passing around the fee token addresses, rely on `starknet.block_context.chain_info()`
- Created while implementing the proposal in https://github.com/0xSpaceShard/starknet-devnet-rs/issues/272#issuecomment-1924033491
  - With this PR it should be easier
- Extract `(FlattenedSierraClass, FieldElement)` to `SierraWithHash`

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#test-execution)
