### PR TITLE
Unify rpc

### DIFF
--- a/crates/starknet-devnet-core/src/starknet/starknet_config.rs
+++ b/crates/starknet-devnet-core/src/starknet/starknet_config.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroU128;
 
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Serialize, Serializer};
 use starknet_types::chain_id::ChainId;
 use starknet_types::contract_class::ContractClass;
 use starknet_types::felt::Felt;

--- a/crates/starknet-devnet-core/src/starknet/starknet_config.rs
+++ b/crates/starknet-devnet-core/src/starknet/starknet_config.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroU128;
 
-use serde::{Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer};
 use starknet_types::chain_id::ChainId;
 use starknet_types::contract_class::ContractClass;
 use starknet_types::felt::Felt;

--- a/crates/starknet-devnet-server/src/api/http/endpoints/accounts.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/accounts.rs
@@ -38,6 +38,7 @@ pub(crate) async fn get_predeployed_accounts_impl(
 }
 
 #[derive(serde::Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct BalanceQuery {
     address: Felt,
     unit: Option<FeeUnit>,

--- a/crates/starknet-devnet-server/src/api/http/endpoints/blocks.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/blocks.rs
@@ -4,18 +4,23 @@ use axum::Json;
 use crate::api::http::error::HttpApiError;
 use crate::api::http::models::{AbortedBlocks, AbortingBlocks, CreatedBlock};
 use crate::api::http::{HttpApiHandler, HttpApiResult};
+use crate::api::Api;
 
 pub async fn create_block(
     State(state): State<HttpApiHandler>,
 ) -> HttpApiResult<Json<CreatedBlock>> {
-    let mut starknet = state.api.starknet.write().await;
+    create_block_impl(&state.api).await.map(Json::from)
+}
+
+pub(crate) async fn create_block_impl(api: &Api) -> HttpApiResult<CreatedBlock> {
+    let mut starknet = api.starknet.write().await;
     starknet
         .create_block_dump_event(None)
         .map_err(|err| HttpApiError::CreateEmptyBlockError { msg: err.to_string() })?;
 
     let last_block = starknet.get_latest_block();
     match last_block {
-        Ok(block) => Ok(Json(CreatedBlock { block_hash: block.block_hash() })),
+        Ok(block) => Ok(CreatedBlock { block_hash: block.block_hash() }),
         Err(err) => Err(HttpApiError::CreateEmptyBlockError { msg: err.to_string() }),
     }
 }
@@ -24,10 +29,17 @@ pub async fn abort_blocks(
     State(state): State<HttpApiHandler>,
     Json(data): Json<AbortingBlocks>,
 ) -> HttpApiResult<Json<AbortedBlocks>> {
-    let mut starknet = state.api.starknet.write().await;
+    abort_blocks_impl(&state.api, data).await.map(Json::from)
+}
+
+pub(crate) async fn abort_blocks_impl(
+    api: &Api,
+    data: AbortingBlocks,
+) -> HttpApiResult<AbortedBlocks> {
+    let mut starknet = api.starknet.write().await;
     let aborted = starknet
         .abort_blocks(data.starting_block_hash)
         .map_err(|err| HttpApiError::BlockAbortError { msg: (err.to_string()) })?;
 
-    Ok(Json(AbortedBlocks { aborted }))
+    Ok(AbortedBlocks { aborted })
 }

--- a/crates/starknet-devnet-server/src/api/http/endpoints/dump_load.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/dump_load.rs
@@ -4,12 +4,17 @@ use axum::Json;
 use crate::api::http::error::HttpApiError;
 use crate::api::http::models::{DumpPath, LoadPath};
 use crate::api::http::{HttpApiHandler, HttpApiResult};
+use crate::api::Api;
 
 pub async fn dump(
     State(state): State<HttpApiHandler>,
     Json(path): Json<DumpPath>,
 ) -> HttpApiResult<()> {
-    let starknet = state.api.starknet.write().await;
+    dump_impl(&state.api, path).await
+}
+
+pub(crate) async fn dump_impl(api: &Api, path: DumpPath) -> HttpApiResult<()> {
+    let starknet = api.starknet.write().await;
 
     if starknet.config.dump_on.is_none() {
         return Err(HttpApiError::DumpError {
@@ -47,12 +52,16 @@ pub async fn load(
     State(state): State<HttpApiHandler>,
     Json(path): Json<LoadPath>,
 ) -> HttpApiResult<()> {
+    load_impl(&state.api, path).await
+}
+
+pub(crate) async fn load_impl(api: &Api, path: LoadPath) -> HttpApiResult<()> {
     let file_path = std::path::Path::new(&path.path);
     if path.path.is_empty() || !file_path.exists() {
         return Err(HttpApiError::FileNotFound);
     }
 
-    let mut starknet = state.api.starknet.write().await;
+    let mut starknet = api.starknet.write().await;
     let events =
         starknet.load_events_custom_path(Some(path.path)).map_err(|_| HttpApiError::LoadError)?;
     starknet.re_execute(events).map_err(|_| HttpApiError::ReExecutionError)?;

--- a/crates/starknet-devnet-server/src/api/http/endpoints/mod.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/mod.rs
@@ -1,6 +1,6 @@
 use axum::extract::State;
 use axum::Json;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use starknet_core::starknet::starknet_config::StarknetConfig;
 
 use super::error::HttpApiError;

--- a/crates/starknet-devnet-server/src/api/http/endpoints/time.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/time.rs
@@ -4,12 +4,24 @@ use axum::Json;
 use crate::api::http::error::HttpApiError;
 use crate::api::http::models::{IncreaseTime, IncreaseTimeResponse, SetTime, SetTimeResponse};
 use crate::api::http::{HttpApiHandler, HttpApiResult};
+use crate::api::Api;
 
 pub async fn set_time(
     State(state): State<HttpApiHandler>,
     Json(data): Json<SetTime>,
 ) -> HttpApiResult<Json<SetTimeResponse>> {
-    let mut starknet = state.api.starknet.write().await;
+    set_time_impl(&state.api, data).await.map(Json::from)
+}
+
+pub async fn increase_time(
+    State(state): State<HttpApiHandler>,
+    Json(data): Json<IncreaseTime>,
+) -> HttpApiResult<Json<IncreaseTimeResponse>> {
+    increase_time_impl(&state.api, data).await.map(Json::from)
+}
+
+pub(crate) async fn set_time_impl(api: &Api, data: SetTime) -> HttpApiResult<SetTimeResponse> {
+    let mut starknet = api.starknet.write().await;
     let generate_block = data.generate_block.unwrap_or(true);
 
     starknet
@@ -17,34 +29,34 @@ pub async fn set_time(
         .map_err(|err| HttpApiError::BlockSetTimeError { msg: err.to_string() })?;
 
     if !generate_block {
-        return Ok(Json(SetTimeResponse { block_timestamp: data.time, block_hash: None }));
+        return Ok(SetTimeResponse { block_timestamp: data.time, block_hash: None });
     }
 
     let last_block = starknet.get_latest_block();
     match last_block {
-        Ok(block) => Ok(Json(SetTimeResponse {
+        Ok(block) => Ok(SetTimeResponse {
             block_timestamp: block.timestamp().0,
             block_hash: Some(block.block_hash()),
-        })),
+        }),
         Err(err) => Err(HttpApiError::CreateEmptyBlockError { msg: err.to_string() }),
     }
 }
 
-pub async fn increase_time(
-    State(state): State<HttpApiHandler>,
-    Json(data): Json<IncreaseTime>,
-) -> HttpApiResult<Json<IncreaseTimeResponse>> {
-    let mut starknet = state.api.starknet.write().await;
+pub(crate) async fn increase_time_impl(
+    api: &Api,
+    data: IncreaseTime,
+) -> HttpApiResult<IncreaseTimeResponse> {
+    let mut starknet = api.starknet.write().await;
     starknet
         .increase_time(data.time)
         .map_err(|err| HttpApiError::BlockIncreaseTimeError { msg: err.to_string() })?;
 
     let last_block = starknet.get_latest_block();
     match last_block {
-        Ok(block) => Ok(Json(IncreaseTimeResponse {
+        Ok(block) => Ok(IncreaseTimeResponse {
             timestamp_increased_by: data.time,
             block_hash: block.block_hash(),
-        })),
+        }),
         Err(err) => Err(HttpApiError::CreateEmptyBlockError { msg: err.to_string() }),
     }
 }

--- a/crates/starknet-devnet-server/src/api/http/error.rs
+++ b/crates/starknet-devnet-server/src/api/http/error.rs
@@ -4,6 +4,9 @@ use axum::Json;
 use serde_json::json;
 use thiserror::Error;
 
+use crate::api::json_rpc::WILDCARD_RPC_ERROR_CODE;
+use crate::rpc_core::error::RpcError;
+
 #[derive(Error, Debug)]
 pub enum HttpApiError {
     #[error("{0}")]
@@ -32,6 +35,15 @@ pub enum HttpApiError {
     MessagingError { msg: String },
     #[error("Invalid value: {msg}")]
     InvalidValueError { msg: String },
+}
+
+impl HttpApiError {
+    pub fn http_api_error_to_rpc_error(&self) -> RpcError {
+        let error_message = self.to_string();
+        let error_rpc_code =
+            crate::rpc_core::error::ErrorCode::ServerError(WILDCARD_RPC_ERROR_CODE);
+        RpcError { code: error_rpc_code, message: error_message.into(), data: None }
+    }
 }
 
 impl IntoResponse for HttpApiError {

--- a/crates/starknet-devnet-server/src/api/http/mod.rs
+++ b/crates/starknet-devnet-server/src/api/http/mod.rs
@@ -1,7 +1,7 @@
 pub mod endpoints;
 pub mod error;
 #[allow(unused)]
-mod models;
+pub(crate) mod models;
 
 use self::error::HttpApiError;
 use super::Api;

--- a/crates/starknet-devnet-server/src/api/http/models.rs
+++ b/crates/starknet-devnet-server/src/api/http/models.rs
@@ -27,6 +27,7 @@ pub struct PostmanLoadL1MessagingContract {
 }
 
 #[derive(Serialize)]
+#[cfg_attr(test, derive(Deserialize))]
 pub struct MessageHash {
     pub message_hash: Hash256,
 }
@@ -37,44 +38,52 @@ pub struct TxHash {
 }
 
 #[derive(Serialize)]
+#[cfg_attr(test, derive(Deserialize))]
 pub struct CreatedBlock {
     pub block_hash: BlockHash,
 }
 
 #[derive(Deserialize)]
+#[cfg_attr(test, derive(Debug))]
 pub struct AbortingBlocks {
     pub(crate) starting_block_hash: BlockHash,
 }
 
 #[derive(Serialize)]
+#[cfg_attr(test, derive(Deserialize))]
 pub struct AbortedBlocks {
     pub(crate) aborted: Vec<BlockHash>,
 }
 
 #[derive(Deserialize)]
+#[cfg_attr(test, derive(Debug))]
 pub struct IncreaseTime {
     pub time: u64,
 }
 
 #[derive(Deserialize)]
+#[cfg_attr(test, derive(Debug))]
 pub struct SetTime {
     pub time: u64,
     pub generate_block: Option<bool>,
 }
 
 #[derive(Serialize)]
+#[cfg_attr(test, derive(Deserialize))]
 pub struct SetTimeResponse {
     pub block_timestamp: u64,
     pub block_hash: Option<BlockHash>,
 }
 
 #[derive(Serialize)]
+#[cfg_attr(test, derive(Deserialize))]
 pub struct IncreaseTimeResponse {
     pub timestamp_increased_by: u64,
     pub block_hash: BlockHash,
 }
 
 #[derive(Serialize)]
+#[cfg_attr(test, derive(Deserialize))]
 pub struct SerializableAccount {
     pub initial_balance: String,
     pub address: ContractAddress,
@@ -83,6 +92,7 @@ pub struct SerializableAccount {
 }
 
 #[derive(Serialize)]
+#[cfg_attr(test, derive(Deserialize))]
 pub struct AccountBalanceResponse {
     pub amount: String,
     pub unit: FeeUnit,
@@ -104,6 +114,7 @@ pub struct MintTokensRequest {
 }
 
 #[derive(Serialize)]
+#[cfg_attr(test, derive(Deserialize))]
 pub struct MintTokensResponse {
     /// decimal repr
     pub new_balance: String,
@@ -119,7 +130,7 @@ pub struct ForkStatus {
     pub block: Option<u64>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct FlushedMessages {
     pub messages_to_l1: Vec<MessageToL1>,
     pub messages_to_l2: Vec<MessageToL2>,
@@ -128,8 +139,9 @@ pub struct FlushedMessages {
 }
 
 #[derive(Serialize, Deserialize)]
+#[cfg_attr(test, derive(Debug))]
 pub struct FlushParameters {
-    pub dry_run: bool,
+    pub dry_run: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/crates/starknet-devnet-server/src/api/http/models.rs
+++ b/crates/starknet-devnet-server/src/api/http/models.rs
@@ -10,19 +10,23 @@ use starknet_types::serde_helpers::dec_string::deserialize_biguint;
 
 use crate::api::http::error::HttpApiError;
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
+#[cfg_attr(test, derive(Debug))]
 pub struct DumpPath {
     pub path: Option<String>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
+#[cfg_attr(test, derive(Debug))]
 pub struct LoadPath {
     pub path: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(test, derive(Debug))]
 pub struct PostmanLoadL1MessagingContract {
     pub network_url: String,
     pub address: Option<String>,
@@ -44,6 +48,7 @@ pub struct CreatedBlock {
 }
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 #[cfg_attr(test, derive(Debug))]
 pub struct AbortingBlocks {
     pub(crate) starting_block_hash: BlockHash,
@@ -55,12 +60,14 @@ pub struct AbortedBlocks {
 }
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 #[cfg_attr(test, derive(Debug))]
 pub struct IncreaseTime {
     pub time: u64,
 }
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 #[cfg_attr(test, derive(Debug))]
 pub struct SetTime {
     pub time: u64,
@@ -99,7 +106,9 @@ pub struct FeeToken {
     address: ContractAddress,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(test, derive(Debug))]
 pub struct MintTokensRequest {
     pub address: ContractAddress,
     #[serde(deserialize_with = "deserialize_biguint")]
@@ -133,6 +142,7 @@ pub struct FlushedMessages {
 }
 
 #[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 #[cfg_attr(test, derive(Debug))]
 pub struct FlushParameters {
     pub dry_run: Option<bool>,

--- a/crates/starknet-devnet-server/src/api/http/models.rs
+++ b/crates/starknet-devnet-server/src/api/http/models.rs
@@ -27,7 +27,6 @@ pub struct PostmanLoadL1MessagingContract {
 }
 
 #[derive(Serialize)]
-#[cfg_attr(test, derive(Deserialize))]
 pub struct MessageHash {
     pub message_hash: Hash256,
 }
@@ -38,7 +37,6 @@ pub struct TxHash {
 }
 
 #[derive(Serialize)]
-#[cfg_attr(test, derive(Deserialize))]
 pub struct CreatedBlock {
     pub block_hash: BlockHash,
 }
@@ -50,7 +48,6 @@ pub struct AbortingBlocks {
 }
 
 #[derive(Serialize)]
-#[cfg_attr(test, derive(Deserialize))]
 pub struct AbortedBlocks {
     pub(crate) aborted: Vec<BlockHash>,
 }
@@ -69,21 +66,18 @@ pub struct SetTime {
 }
 
 #[derive(Serialize)]
-#[cfg_attr(test, derive(Deserialize))]
 pub struct SetTimeResponse {
     pub block_timestamp: u64,
     pub block_hash: Option<BlockHash>,
 }
 
 #[derive(Serialize)]
-#[cfg_attr(test, derive(Deserialize))]
 pub struct IncreaseTimeResponse {
     pub timestamp_increased_by: u64,
     pub block_hash: BlockHash,
 }
 
 #[derive(Serialize)]
-#[cfg_attr(test, derive(Deserialize))]
 pub struct SerializableAccount {
     pub initial_balance: String,
     pub address: ContractAddress,
@@ -92,7 +86,6 @@ pub struct SerializableAccount {
 }
 
 #[derive(Serialize)]
-#[cfg_attr(test, derive(Deserialize))]
 pub struct AccountBalanceResponse {
     pub amount: String,
     pub unit: FeeUnit,
@@ -114,7 +107,6 @@ pub struct MintTokensRequest {
 }
 
 #[derive(Serialize)]
-#[cfg_attr(test, derive(Deserialize))]
 pub struct MintTokensResponse {
     /// decimal repr
     pub new_balance: String,

--- a/crates/starknet-devnet-server/src/api/http/models.rs
+++ b/crates/starknet-devnet-server/src/api/http/models.rs
@@ -11,11 +11,13 @@ use starknet_types::serde_helpers::dec_string::deserialize_biguint;
 use crate::api::http::error::HttpApiError;
 
 #[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct DumpPath {
     pub path: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct LoadPath {
     pub path: String,
 }

--- a/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
@@ -15,6 +15,10 @@ use starknet_types::starknet_api::block::BlockStatus;
 use super::error::{ApiError, StrictRpcResult};
 use super::models::{BlockHashAndNumberOutput, SyncingOutput, TransactionStatusOutput};
 use super::{JsonRpcHandler, StarknetResponse, RPC_SPEC_VERSION};
+use crate::api::http::endpoints::accounts::{
+    get_account_balance_impl, get_predeployed_accounts_impl, BalanceQuery,
+};
+use crate::api::http::endpoints::DevnetConfig;
 
 const DEFAULT_CONTINUATION_TOKEN: &str = "0";
 
@@ -442,4 +446,33 @@ impl JsonRpcHandler {
             Err(err) => Err(err.into()),
         }
     }
+
+    /// devnet_isAlive
+    pub fn is_alive(&self) -> StrictRpcResult {
+        Ok(StarknetResponse::String("Alive!!!".to_string()))
+    }
+
+    /// devnet_predeployedAccounts
+    pub async fn get_predeployed_accounts(&self) -> StrictRpcResult {
+        let predeployed_accounts =
+            get_predeployed_accounts_impl(&self.api).await.map_err(ApiError::from)?;
+
+        Ok(StarknetResponse::PredeployedAccounts(predeployed_accounts))
+    }
+
+    /// devnet_accountBalance
+    pub async fn get_account_balance(&self, params: BalanceQuery) -> StrictRpcResult {
+        let account_balance =
+            get_account_balance_impl(&self.api, params).await.map_err(ApiError::from)?;
+
+        Ok(StarknetResponse::AccountBalance(account_balance))
+    }
+
+    // /// devnet_config
+    // pub async fn get_devnet_config(&self) -> StrictRpcResult {
+    //     Ok(StarknetResponse::DevnetConfig(DevnetConfig {
+    //         starknet_config: self.api.starknet.read().await.config.clone(),
+    //         server_config: self.server_config.clone(),
+    //     }))
+    // }
 }

--- a/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
@@ -14,7 +14,7 @@ use starknet_types::starknet_api::block::BlockStatus;
 
 use super::error::{ApiError, StrictRpcResult};
 use super::models::{BlockHashAndNumberOutput, SyncingOutput, TransactionStatusOutput};
-use super::{JsonRpcHandler, StarknetResponse, RPC_SPEC_VERSION};
+use super::{DevnetResponse, JsonRpcHandler, JsonRpcResponse, StarknetResponse, RPC_SPEC_VERSION};
 use crate::api::http::endpoints::accounts::{
     get_account_balance_impl, get_predeployed_accounts_impl, BalanceQuery,
 };
@@ -26,7 +26,7 @@ const DEFAULT_CONTINUATION_TOKEN: &str = "0";
 impl JsonRpcHandler {
     /// starknet_specVersion
     pub fn spec_version(&self) -> StrictRpcResult {
-        Ok(StarknetResponse::String(RPC_SPEC_VERSION.to_string()))
+        Ok(StarknetResponse::String(RPC_SPEC_VERSION.to_string()).into())
     }
 
     /// starknet_getBlockWithTxHashes
@@ -44,7 +44,8 @@ impl JsonRpcHandler {
                 transactions: starknet_types::rpc::transactions::Transactions::Hashes(
                     block.get_transactions().to_owned(),
                 ),
-            }))
+            })
+            .into())
         } else {
             Ok(StarknetResponse::Block(Block {
                 status: *block.status(),
@@ -52,7 +53,8 @@ impl JsonRpcHandler {
                 transactions: starknet_types::rpc::transactions::Transactions::Hashes(
                     block.get_transactions().to_owned(),
                 ),
-            }))
+            })
+            .into())
         }
     }
 
@@ -68,8 +70,8 @@ impl JsonRpcHandler {
             })?;
 
         match block {
-            BlockResult::Block(b) => Ok(StarknetResponse::Block(b)),
-            BlockResult::PendingBlock(b) => Ok(StarknetResponse::PendingBlock(b)),
+            BlockResult::Block(b) => Ok(StarknetResponse::Block(b).into()),
+            BlockResult::PendingBlock(b) => Ok(StarknetResponse::PendingBlock(b).into()),
         }
     }
 
@@ -85,8 +87,8 @@ impl JsonRpcHandler {
             )?;
 
         match block {
-            BlockResult::Block(b) => Ok(StarknetResponse::Block(b)),
-            BlockResult::PendingBlock(b) => Ok(StarknetResponse::PendingBlock(b)),
+            BlockResult::Block(b) => Ok(StarknetResponse::Block(b).into()),
+            BlockResult::PendingBlock(b) => Ok(StarknetResponse::PendingBlock(b).into()),
         }
     }
 
@@ -101,8 +103,10 @@ impl JsonRpcHandler {
             })?;
 
         match state_update {
-            StateUpdateResult::StateUpdate(s) => Ok(StarknetResponse::StateUpdate(s)),
-            StateUpdateResult::PendingStateUpdate(s) => Ok(StarknetResponse::PendingStateUpdate(s)),
+            StateUpdateResult::StateUpdate(s) => Ok(StarknetResponse::StateUpdate(s).into()),
+            StateUpdateResult::PendingStateUpdate(s) => {
+                Ok(StarknetResponse::PendingStateUpdate(s).into())
+            }
         }
     }
 
@@ -128,7 +132,7 @@ impl JsonRpcHandler {
                 unknown_error => ApiError::StarknetDevnetError(unknown_error),
             })?;
 
-        Ok(StarknetResponse::Felt(felt))
+        Ok(StarknetResponse::Felt(felt).into())
     }
 
     /// starknet_getTransactionByHash
@@ -137,7 +141,7 @@ impl JsonRpcHandler {
         transaction_hash: TransactionHash,
     ) -> StrictRpcResult {
         match self.api.starknet.read().await.get_transaction_by_hash(transaction_hash) {
-            Ok(transaction) => Ok(StarknetResponse::Transaction(transaction.clone())),
+            Ok(transaction) => Ok(StarknetResponse::Transaction(transaction.clone()).into()),
             Err(Error::NoTransaction) => Err(ApiError::TransactionNotFound),
             Err(err) => Err(err.into()),
         }
@@ -159,7 +163,8 @@ impl JsonRpcHandler {
                 Ok(StarknetResponse::TransactionStatusByHash(TransactionStatusOutput {
                     execution_status,
                     finality_status,
-                }))
+                })
+                .into())
             }
             Err(Error::NoTransaction) => Err(ApiError::TransactionNotFound),
             Err(err) => Err(err.into()),
@@ -179,7 +184,7 @@ impl JsonRpcHandler {
             .await
             .get_transaction_by_block_id_and_index(block_id.as_ref(), index)
         {
-            Ok(transaction) => Ok(StarknetResponse::Transaction(transaction.clone())),
+            Ok(transaction) => Ok(StarknetResponse::Transaction(transaction.clone()).into()),
             Err(Error::InvalidTransactionIndexInBlock) => {
                 Err(ApiError::InvalidTransactionIndexInBlock)
             }
@@ -195,7 +200,7 @@ impl JsonRpcHandler {
     ) -> StrictRpcResult {
         match self.api.starknet.read().await.get_transaction_receipt_by_hash(&transaction_hash) {
             Ok(receipt) => {
-                Ok(StarknetResponse::TransactionReceiptByTransactionHash(Box::new(receipt)))
+                Ok(StarknetResponse::TransactionReceiptByTransactionHash(Box::new(receipt)).into())
             }
             Err(Error::NoTransaction) => Err(ApiError::TransactionNotFound),
             Err(err) => Err(err.into()),
@@ -205,7 +210,9 @@ impl JsonRpcHandler {
     /// starknet_getClass
     pub async fn get_class(&self, block_id: BlockId, class_hash: ClassHash) -> StrictRpcResult {
         match self.api.starknet.write().await.get_class(block_id.as_ref(), class_hash) {
-            Ok(contract_class) => Ok(StarknetResponse::ContractClass(contract_class.try_into()?)),
+            Ok(contract_class) => {
+                Ok(StarknetResponse::ContractClass(contract_class.try_into()?).into())
+            }
             Err(e) => Err(match e {
                 Error::NoBlock => ApiError::BlockNotFound,
                 Error::StateError(_) => ApiError::ClassHashNotFound,
@@ -222,7 +229,9 @@ impl JsonRpcHandler {
         contract_address: ContractAddress,
     ) -> StrictRpcResult {
         match self.api.starknet.write().await.get_class_at(block_id.as_ref(), contract_address) {
-            Ok(contract_class) => Ok(StarknetResponse::ContractClass(contract_class.try_into()?)),
+            Ok(contract_class) => {
+                Ok(StarknetResponse::ContractClass(contract_class.try_into()?).into())
+            }
             Err(Error::NoBlock) => Err(ApiError::BlockNotFound),
             Err(Error::StateError(StateError::NoneClassHash(_))) => {
                 // NoneClassHash can be returned only when forking, otherwise it means that
@@ -247,7 +256,7 @@ impl JsonRpcHandler {
     ) -> StrictRpcResult {
         match self.api.starknet.write().await.get_class_hash_at(block_id.as_ref(), contract_address)
         {
-            Ok(class_hash) => Ok(StarknetResponse::Felt(class_hash)),
+            Ok(class_hash) => Ok(StarknetResponse::Felt(class_hash).into()),
             Err(Error::NoBlock) => Err(ApiError::BlockNotFound),
             Err(Error::ContractNotFound) => Err(ApiError::ContractNotFound),
             Err(e @ Error::NoStateAtBlock { .. }) => {
@@ -261,7 +270,7 @@ impl JsonRpcHandler {
     pub async fn get_block_txs_count(&self, block_id: BlockId) -> StrictRpcResult {
         let num_trans_count = self.api.starknet.read().await.get_block_txs_count(block_id.as_ref());
         match num_trans_count {
-            Ok(count) => Ok(StarknetResponse::BlockTransactionCount(count)),
+            Ok(count) => Ok(StarknetResponse::BlockTransactionCount(count).into()),
             Err(_) => Err(ApiError::NoBlocks),
         }
     }
@@ -276,7 +285,7 @@ impl JsonRpcHandler {
             request.entry_point_selector,
             request.calldata,
         ) {
-            Ok(result) => Ok(StarknetResponse::Call(result)),
+            Ok(result) => Ok(StarknetResponse::Call(result).into()),
             Err(Error::NoBlock) => Err(ApiError::BlockNotFound),
             Err(Error::ContractNotFound) => Err(ApiError::ContractNotFound),
             Err(e @ Error::NoStateAtBlock { .. }) => {
@@ -295,7 +304,7 @@ impl JsonRpcHandler {
     ) -> StrictRpcResult {
         let mut starknet = self.api.starknet.write().await;
         match starknet.estimate_fee(block_id.as_ref(), &request, &simulation_flags) {
-            Ok(result) => Ok(StarknetResponse::EstimateFee(result)),
+            Ok(result) => Ok(StarknetResponse::EstimateFee(result).into()),
             Err(Error::ContractNotFound) => Err(ApiError::ContractNotFound),
             Err(Error::NoBlock) => Err(ApiError::BlockNotFound),
             Err(e @ Error::NoStateAtBlock { .. }) => {
@@ -311,7 +320,7 @@ impl JsonRpcHandler {
         message: MsgFromL1,
     ) -> StrictRpcResult {
         match self.api.starknet.write().await.estimate_message_fee(block_id, message) {
-            Ok(result) => Ok(StarknetResponse::EstimateMessageFee(result)),
+            Ok(result) => Ok(StarknetResponse::EstimateMessageFee(result).into()),
             Err(Error::ContractNotFound) => Err(ApiError::ContractNotFound),
             Err(Error::NoBlock) => Err(ApiError::BlockNotFound),
             Err(e @ Error::NoStateAtBlock { .. }) => {
@@ -328,7 +337,7 @@ impl JsonRpcHandler {
             unknown_error => ApiError::StarknetDevnetError(unknown_error),
         })?;
 
-        Ok(StarknetResponse::BlockNumber(block.block_number()))
+        Ok(StarknetResponse::BlockNumber(block.block_number()).into())
     }
 
     /// starknet_blockHashAndNumber
@@ -341,19 +350,20 @@ impl JsonRpcHandler {
         Ok(StarknetResponse::BlockHashAndNumber(BlockHashAndNumberOutput {
             block_hash: block.block_hash(),
             block_number: block.block_number(),
-        }))
+        })
+        .into())
     }
 
     /// starknet_chainId
     pub async fn chain_id(&self) -> StrictRpcResult {
         let chain_id = self.api.starknet.read().await.chain_id();
 
-        Ok(StarknetResponse::Felt(chain_id.to_felt()))
+        Ok(StarknetResponse::Felt(chain_id.to_felt()).into())
     }
 
     /// starknet_syncing
     pub async fn syncing(&self) -> StrictRpcResult {
-        Ok(StarknetResponse::Syncing(SyncingOutput::False(false)))
+        Ok(StarknetResponse::Syncing(SyncingOutput::False(false)).into())
     }
 
     /// starknet_getEvents
@@ -378,7 +388,8 @@ impl JsonRpcHandler {
         Ok(StarknetResponse::Events(EventsChunk {
             events,
             continuation_token: if has_more_events { Some((page + 1).to_string()) } else { None },
-        }))
+        })
+        .into())
     }
 
     /// starknet_getNonce
@@ -400,7 +411,7 @@ impl JsonRpcHandler {
                 unknown_error => ApiError::StarknetDevnetError(unknown_error),
             })?;
 
-        Ok(StarknetResponse::Felt(nonce))
+        Ok(StarknetResponse::Felt(nonce).into())
     }
 
     /// starknet_simulateTransactions
@@ -413,7 +424,7 @@ impl JsonRpcHandler {
         // borrowing as write/mutable because trace calculation requires so
         let mut starknet = self.api.starknet.write().await;
         match starknet.simulate_transactions(block_id.as_ref(), &transactions, simulation_flags) {
-            Ok(result) => Ok(StarknetResponse::SimulateTransactions(result)),
+            Ok(result) => Ok(StarknetResponse::SimulateTransactions(result).into()),
             Err(Error::ContractNotFound) => Err(ApiError::ContractNotFound),
             Err(Error::NoBlock) => Err(ApiError::BlockNotFound),
             Err(e @ Error::NoStateAtBlock { .. }) => {
@@ -430,7 +441,7 @@ impl JsonRpcHandler {
     ) -> StrictRpcResult {
         let starknet = self.api.starknet.read().await;
         match starknet.get_transaction_trace_by_hash(transaction_hash) {
-            Ok(result) => Ok(StarknetResponse::TraceTransaction(result)),
+            Ok(result) => Ok(StarknetResponse::TraceTransaction(result).into()),
             Err(Error::NoTransaction) => Err(ApiError::TransactionNotFound),
             Err(Error::UnsupportedTransactionType) => Err(ApiError::NoTraceAvailable),
             Err(err) => Err(err.into()),
@@ -441,7 +452,7 @@ impl JsonRpcHandler {
     pub async fn get_trace_block_transactions(&self, block_id: BlockId) -> StrictRpcResult {
         let starknet = self.api.starknet.read().await;
         match starknet.get_transaction_traces_from_block(block_id.as_ref()) {
-            Ok(result) => Ok(StarknetResponse::BlockTransactionTraces(result)),
+            Ok(result) => Ok(StarknetResponse::BlockTransactionTraces(result).into()),
             Err(Error::NoBlock) => Err(ApiError::BlockNotFound),
             Err(err) => Err(err.into()),
         }
@@ -449,7 +460,7 @@ impl JsonRpcHandler {
 
     /// devnet_isAlive
     pub fn is_alive(&self) -> StrictRpcResult {
-        Ok(StarknetResponse::String("Alive!!!".to_string()))
+        Ok(StarknetResponse::String("Alive!!!".to_string()).into())
     }
 
     /// devnet_predeployedAccounts
@@ -457,7 +468,7 @@ impl JsonRpcHandler {
         let predeployed_accounts =
             get_predeployed_accounts_impl(&self.api).await.map_err(ApiError::from)?;
 
-        Ok(StarknetResponse::PredeployedAccounts(predeployed_accounts))
+        Ok(DevnetResponse::PredeployedAccounts(predeployed_accounts).into())
     }
 
     /// devnet_accountBalance
@@ -465,14 +476,15 @@ impl JsonRpcHandler {
         let account_balance =
             get_account_balance_impl(&self.api, params).await.map_err(ApiError::from)?;
 
-        Ok(StarknetResponse::AccountBalance(account_balance))
+        Ok(DevnetResponse::AccountBalance(account_balance).into())
     }
 
-    // /// devnet_config
-    // pub async fn get_devnet_config(&self) -> StrictRpcResult {
-    //     Ok(StarknetResponse::DevnetConfig(DevnetConfig {
-    //         starknet_config: self.api.starknet.read().await.config.clone(),
-    //         server_config: self.server_config.clone(),
-    //     }))
-    // }
+    /// devnet_config
+    pub async fn get_devnet_config(&self) -> Result<JsonRpcResponse, ApiError> {
+        Ok(DevnetResponse::DevnetConfig(DevnetConfig {
+            starknet_config: self.api.starknet.read().await.config.clone(),
+            server_config: self.server_config.clone(),
+        })
+        .into())
+    }
 }

--- a/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
@@ -463,7 +463,7 @@ impl JsonRpcHandler {
         Ok(StarknetResponse::String("Alive!!!".to_string()).into())
     }
 
-    /// devnet_predeployedAccounts
+    /// devnet_getPredeployedAccounts
     pub async fn get_predeployed_accounts(&self) -> StrictRpcResult {
         let predeployed_accounts =
             get_predeployed_accounts_impl(&self.api).await.map_err(ApiError::from)?;
@@ -471,7 +471,7 @@ impl JsonRpcHandler {
         Ok(DevnetResponse::PredeployedAccounts(predeployed_accounts).into())
     }
 
-    /// devnet_accountBalance
+    /// devnet_getAccountBalance
     pub async fn get_account_balance(&self, params: BalanceQuery) -> StrictRpcResult {
         let account_balance =
             get_account_balance_impl(&self.api, params).await.map_err(ApiError::from)?;
@@ -479,7 +479,7 @@ impl JsonRpcHandler {
         Ok(DevnetResponse::AccountBalance(account_balance).into())
     }
 
-    /// devnet_config
+    /// devnet_getConfig
     pub async fn get_devnet_config(&self) -> Result<JsonRpcResponse, ApiError> {
         Ok(DevnetResponse::DevnetConfig(DevnetConfig {
             starknet_config: self.api.starknet.read().await.config.clone(),

--- a/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
@@ -458,11 +458,6 @@ impl JsonRpcHandler {
         }
     }
 
-    /// devnet_isAlive
-    pub fn is_alive(&self) -> StrictRpcResult {
-        Ok(StarknetResponse::String("Alive!!!".to_string()).into())
-    }
-
     /// devnet_getPredeployedAccounts
     pub async fn get_predeployed_accounts(&self) -> StrictRpcResult {
         let predeployed_accounts =

--- a/crates/starknet-devnet-server/src/api/json_rpc/error.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/error.rs
@@ -3,7 +3,7 @@ use starknet_types;
 use thiserror::Error;
 use tracing::error;
 
-use super::{StarknetResponse, WILDCARD_RPC_ERROR_CODE};
+use super::{JsonRpcResponse, WILDCARD_RPC_ERROR_CODE};
 use crate::api::http::error::HttpApiError;
 use crate::rpc_core::error::RpcError;
 
@@ -196,7 +196,7 @@ impl ApiError {
     }
 }
 
-pub type StrictRpcResult = Result<StarknetResponse, ApiError>;
+pub type StrictRpcResult = Result<JsonRpcResponse, ApiError>;
 
 #[cfg(test)]
 mod tests {

--- a/crates/starknet-devnet-server/src/api/json_rpc/error.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/error.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 use tracing::error;
 
 use super::{StarknetResponse, WILDCARD_RPC_ERROR_CODE};
+use crate::api::http::error::HttpApiError;
 use crate::rpc_core::error::RpcError;
 
 #[allow(unused)]
@@ -55,6 +56,8 @@ pub enum ApiError {
     NoTraceAvailable,
     #[error("{msg}")]
     NoStateAtBlock { msg: String },
+    #[error(transparent)]
+    HttpApiError(#[from] HttpApiError),
 }
 
 impl ApiError {
@@ -188,6 +191,7 @@ impl ApiError {
                 message: error_message.into(),
                 data: None,
             },
+            ApiError::HttpApiError(http_api_error) => http_api_error.http_api_error_to_rpc_error(),
         }
     }
 }

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -371,13 +371,13 @@ pub enum JsonRpcRequest {
     SetTime(SetTime),
     #[serde(rename = "devnet_increaseTime")]
     IncreaseTime(IncreaseTime),
-    #[serde(rename = "devnet_predeployedAccounts", with = "empty_params")]
+    #[serde(rename = "devnet_getPredeployedAccounts", with = "empty_params")]
     PredeployedAccounts,
-    #[serde(rename = "devnet_accountBalance")]
+    #[serde(rename = "devnet_getAccountBalance")]
     AccountBalance(BalanceQuery),
     #[serde(rename = "devnet_mint")]
     Mint(MintTokensRequest),
-    #[serde(rename = "devnet_config", with = "empty_params")]
+    #[serde(rename = "devnet_getConfig", with = "empty_params")]
     DevnetConfig,
 }
 

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -451,10 +451,10 @@ impl std::fmt::Display for JsonRpcRequest {
             JsonRpcRequest::Restart => write!(f, "devnet_restart"),
             JsonRpcRequest::SetTime(_) => write!(f, "devnet_setTime"),
             JsonRpcRequest::IncreaseTime(_) => write!(f, "devnet_increaseTime"),
-            JsonRpcRequest::PredeployedAccounts => write!(f, "devnet_predeployedAccounts"),
-            JsonRpcRequest::AccountBalance(_) => write!(f, "devnet_accountBalance"),
+            JsonRpcRequest::PredeployedAccounts => write!(f, "devnet_getPredeployedAccounts"),
+            JsonRpcRequest::AccountBalance(_) => write!(f, "devnet_getAccountBalance"),
             JsonRpcRequest::Mint(_) => write!(f, "devnet_mint"),
-            JsonRpcRequest::DevnetConfig => write!(f, "devnet_config"),
+            JsonRpcRequest::DevnetConfig => write!(f, "devnet_getConfig"),
         }
     }
 }

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -227,7 +227,6 @@ impl JsonRpcHandler {
             }
             JsonRpcRequest::AutoImpersonate => self.set_auto_impersonate(true).await,
             JsonRpcRequest::StopAutoImpersonate => self.set_auto_impersonate(false).await,
-            JsonRpcRequest::IsAlive => self.is_alive(),
             JsonRpcRequest::Dump(path) => self.dump(path).await,
             JsonRpcRequest::Load(path) => self.load(path).await,
             JsonRpcRequest::PostmanLoadL1MessagingContract(data) => self.postman_load(data).await,
@@ -345,8 +344,6 @@ pub enum JsonRpcRequest {
     AutoImpersonate,
     #[serde(rename = "devnet_stopAutoImpersonate", with = "empty_params")]
     StopAutoImpersonate,
-    #[serde(rename = "devnet_isAlive", with = "empty_params")]
-    IsAlive,
     #[serde(rename = "devnet_dump")]
     Dump(DumpPath),
     #[serde(rename = "devnet_load")]

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -510,6 +510,7 @@ pub enum StarknetResponse {
 }
 
 #[derive(Serialize)]
+#[serde(untagged)]
 pub enum DevnetResponse {
     MessagingContractAddress(MessagingLoadAddress),
     FlushedMessages(FlushedMessages),

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -430,7 +430,6 @@ impl std::fmt::Display for JsonRpcRequest {
             }
             JsonRpcRequest::AutoImpersonate => write!(f, "devnet_autoImpersonate"),
             JsonRpcRequest::StopAutoImpersonate => write!(f, "devnet_stopAutoImpersonate"),
-            JsonRpcRequest::IsAlive => write!(f, "devnet_isAlive"),
             JsonRpcRequest::Dump(_) => write!(f, "devnet_dump"),
             JsonRpcRequest::Load(_) => write!(f, "devnet_load"),
             JsonRpcRequest::PostmanLoadL1MessagingContract(_) => write!(f, "devnet_postmanLoad"),

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -345,14 +345,12 @@ pub enum JsonRpcRequest {
     AutoImpersonate,
     #[serde(rename = "devnet_stopAutoImpersonate", with = "empty_params")]
     StopAutoImpersonate,
-
     #[serde(rename = "devnet_isAlive", with = "empty_params")]
     IsAlive,
     #[serde(rename = "devnet_dump")]
     Dump(DumpPath),
     #[serde(rename = "devnet_load")]
     Load(LoadPath),
-
     #[serde(rename = "devnet_postmanLoad")]
     PostmanLoadL1MessagingContract(PostmanLoadL1MessagingContract),
     #[serde(rename = "devnet_postmanFlush")]

--- a/crates/starknet-devnet-server/src/api/json_rpc/models.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/models.rs
@@ -152,7 +152,7 @@ pub struct BroadcastedInvokeTransactionInput {
 #[derive(Debug, Clone, Serialize)]
 #[cfg_attr(test, derive(Deserialize))]
 #[serde(deny_unknown_fields)]
-pub struct InvokeTransactionOutput {
+pub struct TransactionHashOutput {
     pub transaction_hash: TransactionHash,
 }
 

--- a/crates/starknet-devnet-server/src/api/json_rpc/spec_reader/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/spec_reader/mod.rs
@@ -166,7 +166,7 @@ mod tests {
 
     use super::{generate_combined_schema, generate_json_rpc_response, Spec};
     use crate::api::json_rpc::spec_reader::generate_json_rpc_request;
-    use crate::api::json_rpc::{StarknetRequest, StarknetResponse, RPC_SPEC_VERSION};
+    use crate::api::json_rpc::{JsonRpcRequest, StarknetResponse, RPC_SPEC_VERSION};
 
     #[test]
     /// This test asserts that the spec files used in testing indeed match the expected version
@@ -208,7 +208,7 @@ mod tests {
                     let request = generate_json_rpc_request(method, &combined_schema)
                         .expect("Could not generate the JSON-RPC request");
 
-                    let sn_request = serde_json::from_value::<StarknetRequest>(request.clone());
+                    let sn_request = serde_json::from_value::<JsonRpcRequest>(request.clone());
 
                     if sn_request.is_err() {
                         serde_json::to_writer_pretty(
@@ -237,101 +237,100 @@ mod tests {
                     let sn_request = sn_request.unwrap();
 
                     match sn_request {
-                        StarknetRequest::TransactionReceiptByTransactionHash(_) => {
+                        JsonRpcRequest::TransactionReceiptByTransactionHash(_) => {
                             assert!(matches!(
                                 sn_response,
                                 StarknetResponse::TransactionReceiptByTransactionHash(_)
                             ));
                         }
-                        StarknetRequest::BlockWithTransactionHashes(_)
-                        | StarknetRequest::BlockWithFullTransactions(_)
-                        | StarknetRequest::BlockWithReceipts(_) => {
+                        JsonRpcRequest::BlockWithTransactionHashes(_)
+                        | JsonRpcRequest::BlockWithFullTransactions(_)
+                        | JsonRpcRequest::BlockWithReceipts(_) => {
                             assert!(matches!(
                                 sn_response,
                                 StarknetResponse::Block(_) | StarknetResponse::PendingBlock(_)
                             ));
                         }
-                        StarknetRequest::BlockHashAndNumber => {
+                        JsonRpcRequest::BlockHashAndNumber => {
                             assert!(matches!(sn_response, StarknetResponse::BlockHashAndNumber(_)));
                         }
-                        StarknetRequest::BlockTransactionCount(_)
-                        | StarknetRequest::BlockNumber => {
+                        JsonRpcRequest::BlockTransactionCount(_) | JsonRpcRequest::BlockNumber => {
                             assert!(matches!(
                                 sn_response,
                                 StarknetResponse::BlockTransactionCount(_)
                                     | StarknetResponse::BlockNumber(_)
                             ));
                         }
-                        StarknetRequest::Call(_) => {
+                        JsonRpcRequest::Call(_) => {
                             assert!(matches!(sn_response, StarknetResponse::Call(_)));
                         }
-                        StarknetRequest::ClassAtContractAddress(_)
-                        | StarknetRequest::ClassByHash(_) => {
+                        JsonRpcRequest::ClassAtContractAddress(_)
+                        | JsonRpcRequest::ClassByHash(_) => {
                             assert!(matches!(sn_response, StarknetResponse::ContractClass(_)));
                         }
-                        StarknetRequest::EstimateFee(_) => {
+                        JsonRpcRequest::EstimateFee(_) => {
                             assert!(matches!(sn_response, StarknetResponse::EstimateFee(_)));
                         }
-                        StarknetRequest::EstimateMessageFee(_) => {
+                        JsonRpcRequest::EstimateMessageFee(_) => {
                             assert!(matches!(sn_response, StarknetResponse::EstimateMessageFee(_)));
                         }
-                        StarknetRequest::Events(_) => {
+                        JsonRpcRequest::Events(_) => {
                             assert!(matches!(sn_response, StarknetResponse::Events(_)));
                         }
-                        StarknetRequest::SimulateTransactions(_) => {
+                        JsonRpcRequest::SimulateTransactions(_) => {
                             assert!(matches!(
                                 sn_response,
                                 StarknetResponse::SimulateTransactions(_)
                             ));
                         }
-                        StarknetRequest::StateUpdate(_) => {
+                        JsonRpcRequest::StateUpdate(_) => {
                             assert!(matches!(
                                 sn_response,
                                 StarknetResponse::StateUpdate(_)
                                     | StarknetResponse::PendingStateUpdate(_)
                             ));
                         }
-                        StarknetRequest::Syncing => {
+                        JsonRpcRequest::Syncing => {
                             assert!(matches!(sn_response, StarknetResponse::Syncing(_)));
                         }
-                        StarknetRequest::TransactionStatusByHash(_) => {
+                        JsonRpcRequest::TransactionStatusByHash(_) => {
                             assert!(matches!(
                                 sn_response,
                                 StarknetResponse::TransactionStatusByHash(_)
                             ));
                         }
-                        StarknetRequest::AddDeclareTransaction(_) => {
+                        JsonRpcRequest::AddDeclareTransaction(_) => {
                             assert!(matches!(
                                 sn_response,
                                 StarknetResponse::AddDeclareTransaction(_)
                             ));
                         }
-                        StarknetRequest::AddDeployAccountTransaction(_) => {
+                        JsonRpcRequest::AddDeployAccountTransaction(_) => {
                             assert!(matches!(
                                 sn_response,
                                 StarknetResponse::AddDeployAccountTransaction(_)
                             ));
                         }
-                        StarknetRequest::AddInvokeTransaction(_) => {
+                        JsonRpcRequest::AddInvokeTransaction(_) => {
                             assert!(matches!(sn_response, StarknetResponse::TransactionHash(_)));
                         }
-                        StarknetRequest::SpecVersion => {
+                        JsonRpcRequest::SpecVersion => {
                             assert!(matches!(sn_response, StarknetResponse::String(_)));
                         }
-                        StarknetRequest::TransactionByHash(_)
-                        | StarknetRequest::TransactionByBlockAndIndex(_) => {
+                        JsonRpcRequest::TransactionByHash(_)
+                        | JsonRpcRequest::TransactionByBlockAndIndex(_) => {
                             assert!(matches!(sn_response, StarknetResponse::Transaction(_)));
                         }
-                        StarknetRequest::ContractNonce(_)
-                        | StarknetRequest::ChainId
-                        | StarknetRequest::ClassHashAtContractAddress(_)
-                        | StarknetRequest::StorageAt(_) => {
+                        JsonRpcRequest::ContractNonce(_)
+                        | JsonRpcRequest::ChainId
+                        | JsonRpcRequest::ClassHashAtContractAddress(_)
+                        | JsonRpcRequest::StorageAt(_) => {
                             assert!(matches!(sn_response, StarknetResponse::Felt(_)));
                         }
-                        StarknetRequest::TraceTransaction(_) => {
+                        JsonRpcRequest::TraceTransaction(_) => {
                             assert!(matches!(sn_response, StarknetResponse::TraceTransaction(_)));
                         }
-                        StarknetRequest::BlockTransactionTraces(_) => {
+                        JsonRpcRequest::BlockTransactionTraces(_) => {
                             assert!(matches!(
                                 sn_response,
                                 StarknetResponse::BlockTransactionTraces(_)

--- a/crates/starknet-devnet-server/src/api/json_rpc/spec_reader/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/spec_reader/mod.rs
@@ -313,10 +313,7 @@ mod tests {
                             ));
                         }
                         StarknetRequest::AddInvokeTransaction(_) => {
-                            assert!(matches!(
-                                sn_response,
-                                StarknetResponse::AddInvokeTransaction(_)
-                            ));
+                            assert!(matches!(sn_response, StarknetResponse::TransactionHash(_)));
                         }
                         StarknetRequest::SpecVersion => {
                             assert!(matches!(sn_response, StarknetResponse::String(_)));

--- a/crates/starknet-devnet-server/src/api/json_rpc/write_endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/write_endpoints.rs
@@ -9,7 +9,7 @@ use super::error::{ApiError, StrictRpcResult};
 use super::models::{
     DeclareTransactionOutput, DeployAccountTransactionOutput, TransactionHashOutput,
 };
-use super::StarknetResponse;
+use super::{DevnetResponse, StarknetResponse};
 use crate::api::http::endpoints::blocks::{abort_blocks_impl, create_block_impl};
 use crate::api::http::endpoints::dump_load::{dump_impl, load_impl};
 use crate::api::http::endpoints::mint_token::mint_impl;
@@ -36,7 +36,8 @@ impl JsonRpcHandler {
         Ok(StarknetResponse::AddDeclareTransaction(DeclareTransactionOutput {
             transaction_hash,
             class_hash,
-        }))
+        })
+        .into())
     }
 
     pub async fn add_deploy_account_transaction(
@@ -56,7 +57,8 @@ impl JsonRpcHandler {
         Ok(StarknetResponse::AddDeployAccountTransaction(DeployAccountTransactionOutput {
             transaction_hash,
             contract_address,
-        }))
+        })
+        .into())
     }
 
     pub async fn add_invoke_transaction(
@@ -65,54 +67,56 @@ impl JsonRpcHandler {
     ) -> StrictRpcResult {
         let transaction_hash = self.api.starknet.write().await.add_invoke_transaction(request)?;
 
-        Ok(StarknetResponse::TransactionHash(TransactionHashOutput { transaction_hash }))
+        Ok(StarknetResponse::TransactionHash(TransactionHashOutput { transaction_hash }).into())
     }
 
     // devnet_impersonateAccount
     pub async fn impersonate_account(&self, address: ContractAddress) -> StrictRpcResult {
         let mut starknet = self.api.starknet.write().await;
         starknet.impersonate_account(address)?;
-        Ok(StarknetResponse::Empty)
+        Ok(super::JsonRpcResponse::Empty)
     }
 
     // devnet_stopImpersonatingAccount
     pub async fn stop_impersonating_account(&self, address: ContractAddress) -> StrictRpcResult {
         let mut starknet = self.api.starknet.write().await;
         starknet.stop_impersonating_account(&address);
-        Ok(StarknetResponse::Empty)
+        Ok(super::JsonRpcResponse::Empty)
     }
 
     // devnet_autoImpersonate | devnet_stopAutoImpersonate
     pub async fn set_auto_impersonate(&self, auto_impersonation: bool) -> StrictRpcResult {
         let mut starknet = self.api.starknet.write().await;
         starknet.set_auto_impersonate_account(auto_impersonation)?;
-        Ok(StarknetResponse::Empty)
+        Ok(super::JsonRpcResponse::Empty)
     }
 
     /// devnet_dump
     pub async fn dump(&self, path: DumpPath) -> StrictRpcResult {
         dump_impl(&self.api, path).await.map_err(ApiError::from)?;
-        Ok(StarknetResponse::Empty)
+        Ok(super::JsonRpcResponse::Empty)
     }
 
     /// devnet_load
     pub async fn load(&self, path: LoadPath) -> StrictRpcResult {
         load_impl(&self.api, path).await.map_err(ApiError::from)?;
-        Ok(StarknetResponse::Empty)
+        Ok(super::JsonRpcResponse::Empty)
     }
 
     /// devnet_postmanLoad
     pub async fn postman_load(&self, data: PostmanLoadL1MessagingContract) -> StrictRpcResult {
-        Ok(StarknetResponse::MessagingContractAddress(
+        Ok(DevnetResponse::MessagingContractAddress(
             postman_load_impl(&self.api, data).await.map_err(ApiError::from)?,
-        ))
+        )
+        .into())
     }
 
     /// devnet_postmanFlush
     pub async fn postman_flush(&self, data: FlushParameters) -> StrictRpcResult {
-        Ok(StarknetResponse::FlushedMessages(
+        Ok(DevnetResponse::FlushedMessages(
             postman_flush_impl(&self.api, data).await.map_err(ApiError::from)?,
-        ))
+        )
+        .into())
     }
 
     /// devnet_postmanSendMessageToL2
@@ -120,9 +124,10 @@ impl JsonRpcHandler {
         let transaction_hash =
             postman_send_message_to_l2_impl(&self.api, message).await.map_err(ApiError::from)?;
 
-        Ok(StarknetResponse::TransactionHash(TransactionHashOutput {
+        Ok(DevnetResponse::TransactionHash(TransactionHashOutput {
             transaction_hash: transaction_hash.transaction_hash,
-        }))
+        })
+        .into())
     }
 
     /// devnet_postmanConsumeMessageFromL2
@@ -131,33 +136,33 @@ impl JsonRpcHandler {
             .await
             .map_err(ApiError::from)?;
 
-        Ok(StarknetResponse::MessageHash(message_hash))
+        Ok(DevnetResponse::MessageHash(message_hash).into())
     }
 
     /// devnet_createBlock
     pub async fn create_block(&self) -> StrictRpcResult {
         let created_block = create_block_impl(&self.api).await.map_err(ApiError::from)?;
-        Ok(StarknetResponse::CreatedBlock(created_block))
+        Ok(DevnetResponse::CreatedBlock(created_block).into())
     }
 
     /// devnet_abortBlocks
     pub async fn abort_blocks(&self, data: AbortingBlocks) -> StrictRpcResult {
         let aborted_blocks = abort_blocks_impl(&self.api, data).await.map_err(ApiError::from)?;
 
-        Ok(StarknetResponse::AbortedBlocks(aborted_blocks))
+        Ok(DevnetResponse::AbortedBlocks(aborted_blocks).into())
     }
 
     /// devnet_restart
     pub async fn restart(&self) -> StrictRpcResult {
         restart_impl(&self.api).await.map_err(ApiError::from)?;
 
-        Ok(StarknetResponse::Empty)
+        Ok(super::JsonRpcResponse::Empty)
     }
 
     /// devnet_setTime
     pub async fn set_time(&self, data: SetTime) -> StrictRpcResult {
         let set_time_response = set_time_impl(&self.api, data).await.map_err(ApiError::from)?;
-        Ok(StarknetResponse::SetTime(set_time_response))
+        Ok(DevnetResponse::SetTime(set_time_response).into())
     }
 
     /// devnet_increaseTime
@@ -165,14 +170,14 @@ impl JsonRpcHandler {
         let increase_time_response =
             increase_time_impl(&self.api, data).await.map_err(ApiError::from)?;
 
-        Ok(StarknetResponse::IncreaseTime(increase_time_response))
+        Ok(DevnetResponse::IncreaseTime(increase_time_response).into())
     }
 
     /// devnet_mint
     pub async fn mint(&self, request: MintTokensRequest) -> StrictRpcResult {
         let mint_tokens_response = mint_impl(&self.api, request).await.map_err(ApiError::from)?;
 
-        Ok(StarknetResponse::MintTokens(mint_tokens_response))
+        Ok(DevnetResponse::MintTokens(mint_tokens_response).into())
     }
 }
 

--- a/crates/starknet-devnet-server/src/config.rs
+++ b/crates/starknet-devnet-server/src/config.rs
@@ -1,9 +1,8 @@
 use std::net::IpAddr;
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize)]
-#[cfg_attr(test, derive(Deserialize))]
 pub struct ServerConfig {
     pub host: IpAddr,
     pub port: u16,

--- a/crates/starknet-devnet-server/src/config.rs
+++ b/crates/starknet-devnet-server/src/config.rs
@@ -1,8 +1,9 @@
 use std::net::IpAddr;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize)]
+#[cfg_attr(test, derive(Deserialize))]
 pub struct ServerConfig {
     pub host: IpAddr,
     pub port: u16,

--- a/crates/starknet-devnet-server/src/rpc_handler.rs
+++ b/crates/starknet-devnet-server/src/rpc_handler.rs
@@ -15,7 +15,7 @@ use crate::rpc_core::response::{Response, ResponseResult, RpcResponse};
 #[async_trait::async_trait]
 pub trait RpcHandler: Clone + Send + Sync + 'static {
     /// The request type to expect
-    type Request: DeserializeOwned + Send + Sync + fmt::Debug;
+    type Request: DeserializeOwned + Send + Sync + fmt::Display;
 
     /// Invoked when the request was received
     async fn on_request(

--- a/crates/starknet-devnet-server/src/server.rs
+++ b/crates/starknet-devnet-server/src/server.rs
@@ -42,9 +42,12 @@ fn http_api_routes(http_api_handler: HttpApiHandler) -> Router {
             "/postman/consume_message_from_l2",
             post(http::postman::postman_consume_message_from_l2),
         )
+
         .route("/create_block", post(http::blocks::create_block))
         .route("/abort_blocks", post(http::blocks::abort_blocks))
+
         .route("/restart", post(http::restart))
+        // json-rpc
         .route("/set_time", post(http::time::set_time))
         .route("/increase_time", post(http::time::increase_time))
         .route("/predeployed_accounts", get(http::accounts::get_predeployed_accounts))
@@ -70,7 +73,8 @@ pub fn serve_http_api_json_rpc(
         None
     };
 
-    let json_rpc_handler = JsonRpcHandler { api, origin_caller };
+    let json_rpc_handler =
+        JsonRpcHandler { api, origin_caller, server_config: server_config.clone() };
     let json_rpc_routes = json_rpc_routes(json_rpc_handler);
     let http_api_routes = http_api_routes(http_handler);
 

--- a/crates/starknet-devnet-server/src/server.rs
+++ b/crates/starknet-devnet-server/src/server.rs
@@ -42,12 +42,9 @@ fn http_api_routes(http_api_handler: HttpApiHandler) -> Router {
             "/postman/consume_message_from_l2",
             post(http::postman::postman_consume_message_from_l2),
         )
-
         .route("/create_block", post(http::blocks::create_block))
         .route("/abort_blocks", post(http::blocks::abort_blocks))
-
         .route("/restart", post(http::restart))
-        // json-rpc
         .route("/set_time", post(http::time::set_time))
         .route("/increase_time", post(http::time::increase_time))
         .route("/predeployed_accounts", get(http::accounts::get_predeployed_accounts))

--- a/crates/starknet-devnet/benches/mint_bench.rs
+++ b/crates/starknet-devnet/benches/mint_bench.rs
@@ -25,7 +25,7 @@ fn bench_devnet(c: &mut Criterion) {
     let mut group = c.benchmark_group("Mint");
     group.significance_level(0.1).sample_size(10);
     for i in ["full", "none"].iter() {
-        group.bench_function(*i, |b| b.to_async(&rt).iter(|| black_box(mint_iter(*i))));
+        group.bench_function(*i, |b| b.to_async(&rt).iter(|| black_box(mint_iter(i))));
     }
 
     group.finish();

--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -28,10 +28,8 @@ use super::constants::{
     ACCOUNTS, CHAIN_ID_CLI_PARAM, HEALTHCHECK_PATH, HOST, MAX_PORT, MIN_PORT,
     PREDEPLOYED_ACCOUNT_INITIAL_BALANCE, RPC_PATH, SEED,
 };
-use super::errors::{ReqwestError, TestError};
-use super::reqwest_client::{
-    GetReqwestSender, HttpEmptyResponseBody, PostReqwestSender, ReqwestClient,
-};
+use super::errors::TestError;
+use super::reqwest_client::{PostReqwestSender, ReqwestClient};
 use super::utils::{to_hex_felt, ImpersonationAction};
 
 lazy_static! {
@@ -180,7 +178,7 @@ impl BackgroundDevnet {
             .reqwest_client()
             .post_json_async(RPC_PATH, body_json)
             .await
-            .map_err(|_| RpcError::internal_error())?;
+            .map_err(|err| RpcError::internal_error_with(err.error_message()))?;
 
         if let Some(result) = json_rpc_result.get("result") {
             Ok(result.clone())

--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -185,7 +185,7 @@ impl BackgroundDevnet {
         } else if let Some(error) = json_rpc_result.get("error") {
             Err(serde_json::from_value(error.clone()).unwrap())
         } else {
-            Err(RpcError::internal_error())
+            Err(RpcError::internal_error_with("Server responded with malformed response"))
         }
     }
 

--- a/crates/starknet-devnet/tests/general_integration_tests.rs
+++ b/crates/starknet-devnet/tests/general_integration_tests.rs
@@ -128,7 +128,7 @@ mod general_integration_tests {
 
         expected_config["server_config"]["port"] = devnet.port.into();
 
-        let fetched_config = devnet.get_config().await.unwrap();
+        let fetched_config = devnet.get_config().await;
         assert_eq!(fetched_config, expected_config);
     }
 }

--- a/crates/starknet-devnet/tests/get_transaction_receipt_by_hash.rs
+++ b/crates/starknet-devnet/tests/get_transaction_receipt_by_hash.rs
@@ -268,20 +268,17 @@ mod get_transaction_receipt_by_hash_integration_tests {
                 u32::from_str_radix(&offset_hex_string[2..], 16).unwrap().into();
         }
 
-        let resp = &devnet
+        let rpc_error = devnet
             .send_custom_rpc(
                 "starknet_addDeclareTransaction",
                 serde_json::json!({ "declare_transaction": declare_rpc_body }),
             )
-            .await;
+            .await
+            .unwrap_err();
 
-        match resp["error"]["code"].as_u64() {
-            Some(53) => {
-                // We got error code corresponding to insufficient balance, which is ok;
-                // it's important we didn't get failed JSON schema matching with error -32602
-            }
-            _ => panic!("Unexpected response: {resp}"),
-        }
+        // We got error code corresponding to insufficient balance, which is ok;
+        // it's important we didn't get failed JSON schema matching with error -32602
+        assert_eq!(rpc_error.code.code(), 53);
     }
 
     #[tokio::test]

--- a/crates/starknet-devnet/tests/test_abort_blocks.rs
+++ b/crates/starknet-devnet/tests/test_abort_blocks.rs
@@ -7,7 +7,6 @@ mod abort_blocks_tests {
     use starknet_types::rpc::transaction_receipt::FeeUnit;
 
     use crate::common::background_devnet::BackgroundDevnet;
-    use crate::common::reqwest_client::{HttpEmptyResponseBody, PostReqwestSender};
     use crate::common::utils::{assert_tx_reverted, to_hex_felt};
 
     static DUMMY_ADDRESS: u128 = 1;
@@ -17,10 +16,9 @@ mod abort_blocks_tests {
         devnet: &BackgroundDevnet,
         starting_block_hash: &FieldElement,
     ) -> Vec<FieldElement> {
-        let mut aborted_blocks: serde_json::Value = devnet
-            .reqwest_client()
-            .post_json_async(
-                "/abort_blocks",
+        let mut aborted_blocks = devnet
+            .send_custom_rpc(
+                "devnet_abortBlocks",
                 json!({ "starting_block_hash": to_hex_felt(starting_block_hash) }),
             )
             .await
@@ -36,16 +34,14 @@ mod abort_blocks_tests {
 
     async fn abort_blocks_error(devnet: &BackgroundDevnet, starting_block_hash: &FieldElement) {
         let aborted_blocks_error = devnet
-            .reqwest_client()
-            .post_json_async(
-                "/abort_blocks",
+            .send_custom_rpc(
+                "devnet_abortBlocks",
                 json!({ "starting_block_hash": to_hex_felt(starting_block_hash) }),
             )
             .await
-            .map(|_: HttpEmptyResponseBody| ())
             .unwrap_err();
 
-        assert!(aborted_blocks_error.error_message().contains("\"Block abortion failed"));
+        assert!(aborted_blocks_error.message.contains("Block abortion failed"));
     }
 
     async fn assert_block_rejected(devnet: &BackgroundDevnet, block_hash: &FieldElement) {

--- a/crates/starknet-devnet/tests/test_account_impersonation.rs
+++ b/crates/starknet-devnet/tests/test_account_impersonation.rs
@@ -233,7 +233,7 @@ mod impersonated_account_tests {
                 simulation_result.expect("Expected simulation to succeed");
             }
 
-            forked_devnet.restart().await.unwrap();
+            forked_devnet.restart().await;
         }
     }
 

--- a/crates/starknet-devnet/tests/test_account_selection.rs
+++ b/crates/starknet-devnet/tests/test_account_selection.rs
@@ -54,7 +54,7 @@ mod test_account_selection {
         let expected_hash = FieldElement::from_hex_be(expected_hash_hex).unwrap();
         assert_eq!(retrieved_class_hash, expected_hash);
 
-        let config = devnet.get_config().await.unwrap();
+        let config = devnet.get_config().await;
         let config_class_hash_hex = config["account_contract_class_hash"].as_str().unwrap();
         assert_eq!(FieldElement::from_hex_be(config_class_hash_hex).unwrap(), expected_hash);
     }

--- a/crates/starknet-devnet/tests/test_advancing_time.rs
+++ b/crates/starknet-devnet/tests/test_advancing_time.rs
@@ -12,11 +12,9 @@ mod advancing_time_tests {
     use starknet_rs_core::types::{BlockId, BlockTag, FieldElement, FunctionCall};
     use starknet_rs_core::utils::{get_selector_from_name, get_udc_deployed_address};
     use starknet_rs_providers::Provider;
-    use starknet_types::rpc;
 
     use crate::common::background_devnet::BackgroundDevnet;
     use crate::common::constants;
-    use crate::common::reqwest_client::{HttpEmptyResponseBody, PostReqwestSender};
     use crate::common::utils::{
         get_block_reader_contract_in_sierra_and_compiled_class_hash, get_unix_timestamp_as_seconds,
         send_ctrl_c_signal_and_wait, UniqueAutoDeletableFile,

--- a/crates/starknet-devnet/tests/test_balance.rs
+++ b/crates/starknet-devnet/tests/test_balance.rs
@@ -1,6 +1,7 @@
 pub mod common;
 
 mod balance_tests {
+    use serde_json::json;
     use starknet_rs_core::types::FieldElement;
     use starknet_types::rpc::transaction_receipt::FeeUnit;
 
@@ -33,10 +34,14 @@ mod balance_tests {
             (PREDEPLOYED_ACCOUNT_ADDRESS, PREDEPLOYED_ACCOUNT_INITIAL_BALANCE.to_string().as_str()),
         ] {
             for unit in ["WEI", "FRI"] {
-                let params = format!("address={}&unit={}", address, unit);
                 let json_resp: serde_json::Value = devnet
-                    .reqwest_client()
-                    .get_json_async("/account_balance", Some(params))
+                    .send_custom_rpc(
+                        "devnet_getAccountBalance",
+                        json!({
+                            "address": address,
+                            "unit": unit,
+                        }),
+                    )
                     .await
                     .unwrap();
 

--- a/crates/starknet-devnet/tests/test_balance.rs
+++ b/crates/starknet-devnet/tests/test_balance.rs
@@ -9,7 +9,6 @@ mod balance_tests {
     use crate::common::constants::{
         PREDEPLOYED_ACCOUNT_ADDRESS, PREDEPLOYED_ACCOUNT_INITIAL_BALANCE,
     };
-    use crate::common::reqwest_client::GetReqwestSender;
 
     #[tokio::test]
     async fn getting_balance_of_predeployed_contract() {

--- a/crates/starknet-devnet/tests/test_blocks_on_demand.rs
+++ b/crates/starknet-devnet/tests/test_blocks_on_demand.rs
@@ -105,7 +105,8 @@ mod blocks_on_demand_tests {
                     "block_id": "latest"
                 }),
             )
-            .await["result"];
+            .await
+            .unwrap();
 
         assert_eq!(latest_block["transactions"].as_array().unwrap().len(), tx_count);
         assert_eq!(latest_block["block_number"], block_number);
@@ -129,7 +130,8 @@ mod blocks_on_demand_tests {
                     "block_id": "pending"
                 }),
             )
-            .await["result"];
+            .await
+            .unwrap();
 
         assert!(pending_block["status"].is_null());
         assert_eq!(pending_block["transactions"].as_array().unwrap().len(), tx_count);

--- a/crates/starknet-devnet/tests/test_dump_and_load.rs
+++ b/crates/starknet-devnet/tests/test_dump_and_load.rs
@@ -372,8 +372,7 @@ mod dump_and_load_tests {
             )
             .await
             .unwrap_err();
-        println!("{:?}", rpc_error);
-        assert!(rpc_error.message.contains("File exists"));
+        assert!(rpc_error.message.contains("I/O error"));
     }
 
     #[tokio::test]

--- a/crates/starknet-devnet/tests/test_dump_and_load.rs
+++ b/crates/starknet-devnet/tests/test_dump_and_load.rs
@@ -5,12 +5,12 @@ mod dump_and_load_tests {
     use std::time;
 
     use serde_json::json;
+    use server::rpc_core::error::ErrorCode::InvalidParams;
     use starknet_rs_providers::Provider;
     use starknet_types::rpc::transaction_receipt::FeeUnit;
 
     use crate::common::background_devnet::BackgroundDevnet;
     use crate::common::constants;
-    use crate::common::reqwest_client::{HttpEmptyResponseBody, PostReqwestSender};
     use crate::common::utils::{send_ctrl_c_signal_and_wait, UniqueAutoDeletableFile};
 
     static DUMMY_ADDRESS: u128 = 1;
@@ -331,30 +331,23 @@ mod dump_and_load_tests {
     #[tokio::test]
     async fn dump_endpoint_fail_with_no_mode_set() {
         let devnet_dump = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
-        let result = devnet_dump
-            .reqwest_client()
-            .post_json_async("/dump", ())
-            .await
-            .map(|_: HttpEmptyResponseBody| ())
-            .unwrap_err();
-        assert_eq!(result.status(), 400);
+        let rpc_error = devnet_dump.send_custom_rpc("devnet_dump", json!({})).await.unwrap_err();
+        assert!(rpc_error.message.contains("Please provide --dump-on mode"));
     }
 
     #[tokio::test]
     async fn dump_endpoint_fail_with_wrong_request() {
         let devnet_dump = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
-        let result = devnet_dump
-            .reqwest_client()
-            .post_json_async(
-                "/dump",
+        let rpc_error = devnet_dump
+            .send_custom_rpc(
+                "devnet_dump",
                 json!({
                     "test": ""
                 }),
             )
             .await
-            .map(|_: HttpEmptyResponseBody| ())
             .unwrap_err();
-        assert_eq!(result.status(), 400);
+        assert_eq!(rpc_error.code, InvalidParams);
     }
 
     #[tokio::test]
@@ -370,37 +363,34 @@ mod dump_and_load_tests {
         .expect("Could not start Devnet");
 
         devnet_dump.mint(DUMMY_ADDRESS, DUMMY_AMOUNT).await;
-        let result = devnet_dump
-            .reqwest_client()
-            .post_json_async(
-                "/dump",
+        let rpc_error = devnet_dump
+            .send_custom_rpc(
+                "devnet_dump",
                 json!({
                     "path": "///"
                 }),
             )
             .await
-            .map(|_: HttpEmptyResponseBody| ())
             .unwrap_err();
-        assert_eq!(result.status(), 400);
+        println!("{:?}", rpc_error);
+        assert!(rpc_error.message.contains("File exists"));
     }
 
     #[tokio::test]
     async fn load_endpoint_fail_with_wrong_request() {
         let devnet_load = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
 
-        let result = devnet_load
-            .reqwest_client()
-            .post_json_async(
-                "/load",
+        let rpc_error = devnet_load
+            .send_custom_rpc(
+                "devnet_load",
                 json!({
                     "test": ""
                 }),
             )
             .await
-            .map(|_: HttpEmptyResponseBody| ())
             .unwrap_err();
 
-        assert_eq!(result.status(), 422);
+        assert_eq!(rpc_error.code, InvalidParams);
     }
 
     #[tokio::test]
@@ -408,12 +398,10 @@ mod dump_and_load_tests {
         let load_file_name = "load_file_name";
         let devnet_load = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
         let result = devnet_load
-            .reqwest_client()
-            .post_json_async("/load", json!({ "path": load_file_name }))
+            .send_custom_rpc("devnet_load", json!({ "path": load_file_name }))
             .await
-            .map(|_: HttpEmptyResponseBody| ())
             .unwrap_err();
-        assert_eq!(result.status(), 400);
+        assert!(result.message.contains("file does not exist"));
     }
 
     #[tokio::test]
@@ -432,20 +420,13 @@ mod dump_and_load_tests {
         .expect("Could not start Devnet");
 
         let mint_tx_hash = devnet_dump.mint(DUMMY_ADDRESS, DUMMY_AMOUNT).await;
-        devnet_dump
-            .reqwest_client()
-            .post_json_async("/dump", ())
-            .await
-            .map(|_: HttpEmptyResponseBody| ())
-            .unwrap();
+        devnet_dump.send_custom_rpc("devnet_dump", json!({})).await.unwrap();
         assert!(Path::new(&dump_file.path).exists());
 
         let dump_file_custom = UniqueAutoDeletableFile::new("dump_endpoint_custom_path");
         devnet_dump
-            .reqwest_client()
-            .post_json_async("/dump", json!({ "path": dump_file_custom.path }))
+            .send_custom_rpc("devnet_dump", json!({ "path": dump_file_custom.path }))
             .await
-            .map(|_: HttpEmptyResponseBody| ())
             .unwrap();
         assert!(Path::new(&dump_file_custom.path).exists());
 
@@ -453,10 +434,8 @@ mod dump_and_load_tests {
         // blockchain is valid
         let devnet_load = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
         devnet_load
-            .reqwest_client()
-            .post_json_async("/load", json!({ "path": dump_file.path }))
+            .send_custom_rpc("devnet_load", json!({ "path": dump_file.path }))
             .await
-            .map(|_: HttpEmptyResponseBody| ())
             .unwrap();
 
         let balance_result = devnet_load
@@ -492,10 +471,11 @@ mod dump_and_load_tests {
         // set time in past without block generation
         let past_time = 1;
         devnet_dump
-            .reqwest_client()
-            .post_json_async("/set_time", json!({ "time": past_time, "generate_block": false }))
+            .send_custom_rpc(
+                "devnet_setTime",
+                json!({ "time": past_time, "generate_block": false }),
+            )
             .await
-            .map(|_: HttpEmptyResponseBody| ())
             .unwrap();
 
         // wait 1 second

--- a/crates/starknet-devnet/tests/test_estimate_fee.rs
+++ b/crates/starknet-devnet/tests/test_estimate_fee.rs
@@ -426,10 +426,8 @@ mod estimate_fee_tests {
             ]
         });
 
-        let result = devnet.send_custom_rpc("starknet_estimateFee", params).await;
-        let revert_error = result["error"]["data"]["revert_error"].as_str().unwrap();
-
-        assert!(revert_error.contains(panic_reason));
+        let rpc_error = devnet.send_custom_rpc("starknet_estimateFee", params).await.unwrap_err();
+        assert!(rpc_error.data.unwrap()["revert_error"].as_str().unwrap().contains(panic_reason));
     }
 
     #[tokio::test]

--- a/crates/starknet-devnet/tests/test_fork.rs
+++ b/crates/starknet-devnet/tests/test_fork.rs
@@ -37,7 +37,7 @@ mod fork_tests {
     async fn test_fork_status() {
         let origin_devnet = BackgroundDevnet::spawn_forkable_devnet().await.unwrap();
 
-        let origin_devnet_config = origin_devnet.get_config().await.unwrap();
+        let origin_devnet_config = origin_devnet.get_config().await;
         assert_eq!(
             origin_devnet_config["fork_config"],
             serde_json::json!({ "url": null, "block_number": null })
@@ -45,7 +45,7 @@ mod fork_tests {
 
         let fork_devnet = origin_devnet.fork().await.unwrap();
 
-        let fork_devnet_config = fork_devnet.get_config().await.unwrap();
+        let fork_devnet_config = fork_devnet.get_config().await;
         let fork_devnet_fork_config = &fork_devnet_config["fork_config"];
         assert_eq!(
             url::Url::from_str(fork_devnet_fork_config["url"].as_str().unwrap()).unwrap(),

--- a/crates/starknet-devnet/tests/test_messaging.rs
+++ b/crates/starknet-devnet/tests/test_messaging.rs
@@ -507,7 +507,7 @@ mod test_messaging {
                 "starknet_traceTransaction",
                 json!({ "transaction_hash": flush_body.get("generated_l2_transactions").unwrap()[0] }),
             )
-            .await["result"];
+            .await.unwrap();
         assert_traces(l1_handler_tx_trace);
 
         send_ctrl_c_signal_and_wait(&devnet.process).await;
@@ -527,7 +527,7 @@ mod test_messaging {
             "starknet_traceTransaction",
             json!({ "transaction_hash": flush_body.get("generated_l2_transactions").unwrap()[0] }),
         )
-        .await["result"];
+        .await.unwrap();
         assert_traces(l1_handler_tx_trace_load);
     }
 

--- a/crates/starknet-devnet/tests/test_messaging.rs
+++ b/crates/starknet-devnet/tests/test_messaging.rs
@@ -37,7 +37,6 @@ mod test_messaging {
         CHAIN_ID, L1_HANDLER_SELECTOR, MESSAGING_L1_CONTRACT_ADDRESS,
         MESSAGING_L2_CONTRACT_ADDRESS, MESSAGING_WHITELISTED_L1_CONTRACT,
     };
-    use crate::common::reqwest_client::{HttpEmptyResponseBody, PostReqwestSender};
     use crate::common::utils::{
         assert_tx_successful, get_messaging_contract_in_sierra_and_compiled_class_hash,
         get_messaging_lib_in_sierra_and_compiled_class_hash, send_ctrl_c_signal_and_wait,

--- a/crates/starknet-devnet/tests/test_minting.rs
+++ b/crates/starknet-devnet/tests/test_minting.rs
@@ -11,9 +11,7 @@ mod minting_tests {
     use crate::common::constants::{
         PREDEPLOYED_ACCOUNT_ADDRESS, PREDEPLOYED_ACCOUNT_INITIAL_BALANCE,
     };
-    use crate::common::reqwest_client::{
-        GetReqwestSender, HttpEmptyResponseBody, PostReqwestSender,
-    };
+    use crate::common::reqwest_client::{GetReqwestSender, HttpEmptyResponseBody};
 
     static DUMMY_ADDRESS: &str = "0x42";
     static DUMMY_AMOUNT: u128 = 42;
@@ -27,9 +25,8 @@ mod minting_tests {
         let devnet = BackgroundDevnet::spawn().await.expect("Could not start Devnet");
 
         let mut resp_body: serde_json::Value = devnet
-            .reqwest_client()
-            .post_json_async(
-                "/mint",
+            .send_custom_rpc(
+                "devnet_mint",
                 json!({
                     "address": address,
                     "amount": mint_amount,
@@ -81,7 +78,7 @@ mod minting_tests {
         });
 
         let mut resp_body: serde_json::Value =
-            devnet.reqwest_client().post_json_async("/mint", unit_not_specified).await.unwrap();
+            devnet.send_custom_rpc("devnet_mint", unit_not_specified).await.unwrap();
 
         let tx_hash_value = resp_body["tx_hash"].take();
 
@@ -132,13 +129,12 @@ mod minting_tests {
 
     async fn reject_bad_minting_request(json_body: serde_json::Value) {
         let devnet = BackgroundDevnet::spawn().await.unwrap();
-        let resp = devnet
-            .reqwest_client()
-            .post_json_async("/mint", json_body)
-            .await
-            .map(|_: serde_json::Value| ())
-            .unwrap_err();
-        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY, "Checking status of {resp:?}");
+        let rpc_error = devnet.send_custom_rpc("devnet_mint", json_body).await.unwrap_err();
+        assert_eq!(
+            rpc_error.code,
+            server::rpc_core::error::ErrorCode::InvalidParams,
+            "Checking status of {rpc_error:?}"
+        );
     }
 
     #[tokio::test]
@@ -170,8 +166,7 @@ mod minting_tests {
         reject_bad_minting_request(json!({ "address": DUMMY_ADDRESS })).await;
     }
 
-    async fn reject_bad_balance_query(query: &str) {
-        let devnet = BackgroundDevnet::spawn().await.unwrap();
+    async fn reject_bad_balance_query(devnet: &BackgroundDevnet, query: &str) {
         let resp = devnet
             .reqwest_client()
             .get_json_async("/account_balance", Some(query.into()))
@@ -181,18 +176,29 @@ mod minting_tests {
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "Checking status of {resp:?}");
     }
 
+    async fn reject_bad_json_rpc_request(devnet: &BackgroundDevnet, body: serde_json::Value) {
+        let rpc_error = devnet.send_custom_rpc("devnet_getAccountBalance", body).await.unwrap_err();
+        assert_eq!(rpc_error.code, server::rpc_core::error::ErrorCode::InvalidParams);
+    }
+
     #[tokio::test]
     async fn reject_if_no_params_when_querying() {
-        reject_bad_balance_query("").await;
+        let devnet = BackgroundDevnet::spawn().await.unwrap();
+        reject_bad_balance_query(&devnet, "").await;
+        reject_bad_json_rpc_request(&devnet, json!({})).await;
     }
 
     #[tokio::test]
     async fn reject_missing_address_when_querying() {
-        reject_bad_balance_query("unit=FRI").await;
+        let devnet = BackgroundDevnet::spawn().await.unwrap();
+        reject_bad_balance_query(&devnet, "unit=FRI").await;
+        reject_bad_json_rpc_request(&devnet, json!({ "unit": "FRI" })).await;
     }
 
     #[tokio::test]
     async fn reject_invalid_unit_when_querying() {
-        reject_bad_balance_query("address=0x1&unit=INVALID").await;
+        let devnet = BackgroundDevnet::spawn().await.unwrap();
+        reject_bad_balance_query(&devnet, "address=0x1&unit=INVALID").await;
+        reject_bad_json_rpc_request(&devnet, json!({ "address": "0x1", "unit": "INVALID" })).await;
     }
 }

--- a/crates/starknet-devnet/tests/test_restart.rs
+++ b/crates/starknet-devnet/tests/test_restart.rs
@@ -25,7 +25,7 @@ mod test_restart {
     #[tokio::test]
     async fn assert_restartable() {
         let devnet = BackgroundDevnet::spawn().await.unwrap();
-        devnet.restart().await.unwrap();
+        devnet.restart().await;
     }
 
     #[tokio::test]
@@ -36,7 +36,7 @@ mod test_restart {
         let mint_hash = devnet.mint(FieldElement::ONE, 100).await;
         assert!(devnet.json_rpc_client.get_transaction_by_hash(mint_hash).await.is_ok());
 
-        devnet.restart().await.unwrap();
+        devnet.restart().await;
 
         match devnet.json_rpc_client.get_transaction_by_hash(mint_hash).await {
             Err(ProviderError::StarknetError(StarknetError::TransactionHashNotFound)) => (),
@@ -71,7 +71,7 @@ mod test_restart {
         let storage_value_before = get_storage().await.unwrap();
         assert_eq!(storage_value_before, FieldElement::from(mint_amount));
 
-        devnet.restart().await.unwrap();
+        devnet.restart().await;
 
         let storage_value_after = get_storage().await.unwrap();
         assert_eq!(storage_value_after, FieldElement::ZERO);
@@ -104,7 +104,7 @@ mod test_restart {
             .await
             .unwrap();
 
-        devnet.restart().await.unwrap();
+        devnet.restart().await;
 
         // expect ContractNotFound error since account not present anymore
         match devnet
@@ -150,7 +150,7 @@ mod test_restart {
             .unwrap();
         assert_eq!(estimate_before.gas_price, FieldElement::from(expected_gas_price));
 
-        devnet.restart().await.unwrap();
+        devnet.restart().await;
 
         let estimate_after =
             predeployed_account.declare_legacy(contract_artifact).estimate_fee().await.unwrap();
@@ -176,7 +176,7 @@ mod test_restart {
             devnet.get_balance_latest(&predeployed_account_address, FeeUnit::WEI).await.unwrap();
         assert_eq!(balance_before, FieldElement::from(initial_balance));
 
-        devnet.restart().await.unwrap();
+        devnet.restart().await;
 
         let balance_after =
             devnet.get_balance_latest(&predeployed_account_address, FeeUnit::WEI).await.unwrap();
@@ -195,7 +195,7 @@ mod test_restart {
         .await
         .unwrap();
 
-        devnet.restart().await.unwrap();
+        devnet.restart().await;
 
         // send a dummy tx; otherwise there's no dump
         devnet.mint(FieldElement::ONE, 1).await;
@@ -233,7 +233,7 @@ mod test_restart {
                 .await
                 .unwrap();
 
-        loaded_devnet.restart().await.unwrap();
+        loaded_devnet.restart().await;
 
         // asserting that restarting really clears the state, without re-executing txs from dump
         match loaded_devnet.json_rpc_client.get_transaction_by_hash(tx_hash).await {

--- a/crates/starknet-devnet/tests/test_simulate_transactions.rs
+++ b/crates/starknet-devnet/tests/test_simulate_transactions.rs
@@ -141,12 +141,14 @@ mod simulation_tests {
         let params_no_flags = get_params(&[]);
         let resp_no_flags = &devnet
             .send_custom_rpc("starknet_simulateTransactions", params_no_flags)
-            .await["result"][0];
+            .await
+            .unwrap()[0];
 
         let params_skip_validation = get_params(&["SKIP_VALIDATE"]);
         let resp_skip_validation = &devnet
             .send_custom_rpc("starknet_simulateTransactions", params_skip_validation)
-            .await["result"][0];
+            .await
+            .unwrap()[0];
 
         assert_difference_if_validation(
             resp_no_flags,
@@ -213,12 +215,14 @@ mod simulation_tests {
         let params_no_flags = get_params(&[]);
         let resp_no_flags = &devnet
             .send_custom_rpc("starknet_simulateTransactions", params_no_flags)
-            .await["result"][0];
+            .await
+            .unwrap()[0];
 
         let params_skip_validation = get_params(&["SKIP_VALIDATE"]);
         let resp_skip_validation = &devnet
             .send_custom_rpc("starknet_simulateTransactions", params_skip_validation)
-            .await["result"][0];
+            .await
+            .unwrap()[0];
 
         assert_difference_if_validation(
             resp_no_flags,
@@ -285,7 +289,8 @@ mod simulation_tests {
         let params_no_flags = get_params(&[]);
         let resp_no_flags = &devnet
             .send_custom_rpc("starknet_simulateTransactions", params_no_flags)
-            .await["result"][0];
+            .await
+            .unwrap()[0];
 
         let no_flags_trace = &resp_no_flags["transaction_trace"];
         assert_eq!(
@@ -305,7 +310,8 @@ mod simulation_tests {
         let params_skip_validation = get_params(&["SKIP_VALIDATE"]);
         let resp_skip_validation = &devnet
             .send_custom_rpc("starknet_simulateTransactions", params_skip_validation)
-            .await["result"][0];
+            .await
+            .unwrap()[0];
         let skip_validation_trace = &resp_skip_validation["transaction_trace"];
         assert!(skip_validation_trace["validate_invocation"].as_object().is_none());
         assert_eq!(
@@ -323,7 +329,8 @@ mod simulation_tests {
         let params_skip_everything = get_params(&["SKIP_VALIDATE", "SKIP_FEE_CHARGE"]);
         let resp_skip_everything = &devnet
             .send_custom_rpc("starknet_simulateTransactions", params_skip_everything)
-            .await["result"][0];
+            .await
+            .unwrap()[0];
         let skip_everything_trace = &resp_skip_everything["transaction_trace"];
         assert!(skip_everything_trace["validate_invocation"].as_object().is_none());
         assert!(skip_everything_trace["fee_transfer_invocation"].as_object().is_none());
@@ -422,7 +429,8 @@ mod simulation_tests {
 
         let resp_no_flags = &devnet
             .send_custom_rpc("starknet_simulateTransactions", params_no_flags)
-            .await["result"][0];
+            .await
+            .unwrap()[0];
         assert_eq!(
             resp_no_flags["transaction_trace"]["execute_invocation"]["contract_address"],
             sender_address_hex
@@ -431,7 +439,8 @@ mod simulation_tests {
         let params_skip_validation = get_params(&["SKIP_VALIDATE"]);
         let resp_skip_validation = &devnet
             .send_custom_rpc("starknet_simulateTransactions", params_skip_validation)
-            .await["result"][0];
+            .await
+            .unwrap()[0];
         assert_eq!(
             resp_skip_validation["transaction_trace"]["execute_invocation"]["contract_address"],
             sender_address_hex

--- a/crates/starknet-devnet/tests/test_trace.rs
+++ b/crates/starknet-devnet/tests/test_trace.rs
@@ -279,7 +279,8 @@ mod trace_tests {
         // this test also needs to be updated
         let block_traces = &devnet
             .send_custom_rpc("starknet_traceBlockTransactions", json!({ "block_id": "latest" }))
-            .await["result"];
+            .await
+            .unwrap();
         let traces = &block_traces[0];
 
         // assert if there is only one transaction trace

--- a/website/docs/api.md
+++ b/website/docs/api.md
@@ -12,7 +12,7 @@ Devnet has many other functional features which are available via their own endp
 
 ## Config API
 
-To retrieve the current configuration of Devnet, send a `GET` request to `/config` or `JSON-RPC` request with method name `devnet_config`. Example response is attached below. It can be interpreted as a JSON mapping of CLI input parameters, both specified and default ones, with some irrelevant parameters omitted. So use `starknet-devnet --help` to better understand the meaning of each value, though keep in mind that some of the parameters have slightly modified names.
+To retrieve the current configuration of Devnet, send a `GET` request to `/config` or `JSON-RPC` request with method name `devnet_getConfig`. Example response is attached below. It can be interpreted as a JSON mapping of CLI input parameters, both specified and default ones, with some irrelevant parameters omitted. So use `starknet-devnet --help` to better understand the meaning of each value, though keep in mind that some of the parameters have slightly modified names.
 
 ```json
 {

--- a/website/docs/api.md
+++ b/website/docs/api.md
@@ -8,11 +8,11 @@ The JSON-RPC API is reachable via `/rpc` and `/` (e.g. if spawning Devnet with d
 
 ## Devnet API
 
-Devnet has many other functional features which are available via their own endpoints, which are all mentioned throughout the documentation.
+Devnet has many other functional features which are available via their own endpoints and JSON-RPC, which are all mentioned throughout the documentation.
 
 ## Config API
 
-To retrieve the current configuration of Devnet, send a `GET` request to `/config`. Example response is attached below. It can be interpreted as a JSON mapping of CLI input parameters, both specified and default ones, with some irrelevant parameters omitted. So use `starknet-devnet --help` to better understand the meaning of each value, though keep in mind that some of the parameters have slightly modified names.
+To retrieve the current configuration of Devnet, send a `GET` request to `/config` or `JSON-RPC` request with method name `devnet_config`. Example response is attached below. It can be interpreted as a JSON mapping of CLI input parameters, both specified and default ones, with some irrelevant parameters omitted. So use `starknet-devnet --help` to better understand the meaning of each value, though keep in mind that some of the parameters have slightly modified names.
 
 ```json
 {

--- a/website/docs/balance.md
+++ b/website/docs/balance.md
@@ -9,7 +9,7 @@ Separate tokens use separate ERC20 contracts for minting and charging fees. Thes
 
 ## Mint token - Local faucet
 
-By sending a `POST` request to `/mint` for a token, you initiate a transaction on that token's ERC20 contract. The response contains the hash of this transaction, as well as the new balance after minting. The token is specified by providing the unit, and defaults to `WEI`.
+By sending a `POST` request to `/mint` or `JSON-RPC` request with method name `devnet_mint` for a token, you initiate a transaction on that token's ERC20 contract. The response contains the hash of this transaction, as well as the new balance after minting. The token is specified by providing the unit, and defaults to `WEI`.
 
 The value of `amount` is in WEI and needs to be an integer (or a float whose fractional part is 0, e.g. `1000.0` or `1e21`)
 
@@ -19,6 +19,20 @@ POST /mint
     "address": "0x6e3205f...",
     "amount": 500000,
     "unit": "WEI" | "FRI"
+}
+```
+
+```
+JSON-RPC
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "devnet_mint",
+    "params": {
+        "address": "0x6e3205f...",
+        "amount": 500000,
+        "unit": "WEI" | "FRI"
+    }
 }
 ```
 
@@ -38,4 +52,18 @@ Check the balance of an address by sending a `GET` request to `/account_balance`
 
 ```
 GET /account_balance?address=<ADDRESS>[&unit=<FRI|WEI>][&block_tag=<latest|pending>]
+```
+
+```
+JSON-RPC
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "devnet_accountBalance",
+    "params": {
+        "address": "0x6e3205f...",
+        "unit": "WEI" | "FRI",
+        "block_tag": "latest" | "pending"
+    }
+}
 ```

--- a/website/docs/balance.md
+++ b/website/docs/balance.md
@@ -59,7 +59,7 @@ JSON-RPC
 {
     "jsonrpc": "2.0",
     "id": "1",
-    "method": "devnet_accountBalance",
+    "method": "devnet_getAccountBalance",
     "params": {
         "address": "0x6e3205f...",
         "unit": "WEI" | "FRI",

--- a/website/docs/blocks.md
+++ b/website/docs/blocks.md
@@ -8,7 +8,7 @@ A new block is generated based on the pending block, once a new block is generat
 
 If you start Devnet with the `--blocks-on-demand` CLI option, you will enable the possibility to store more than one transaction in the pending block (targetable via block tag `"pending"`).
 
-Once you've added the desired transactions into the pending block, you can send a `POST` request to `/create_block`. This will convert the pending block to the latest block (targetable via block tag `"latest"`), giving it a block hash and a block number. All subsequent transactions will be stored in a new pending block.
+Once you've added the desired transactions into the pending block, you can send a `POST` request to `/create_block` or `JSON-RPC` request with method name `devnet_createBlock`. This will convert the pending block to the latest block (targetable via block tag `"latest"`), giving it a block hash and a block number. All subsequent transactions will be stored in a new pending block.
 
 In case of demanding block creation with no pending transactions, a new empty block will be generated.
 
@@ -16,6 +16,15 @@ The creation of the genesis block is not affected by this feature.
 
 ```
 POST /create_block
+```
+
+```
+JSON-RPC
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "devnet_createBlock"
+}
 ```
 
 Response:
@@ -30,6 +39,15 @@ To create an empty block without transactions, `POST` a request to `/create_bloc
 
 ```
 POST /create_block
+```
+
+```
+JSON-RPC
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "devnet_createBlock"
+}
 ```
 
 Response:
@@ -54,6 +72,18 @@ Aborted blocks can only be queried by block hash. Aborting the blocks in forking
 POST /abort_blocks
 {
     "starting_block_hash": BLOCK_HASH
+}
+```
+
+```
+JSON-RPC
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "devnet_abortBlocks",
+    "params": {
+        "starting_block_hash": BLOCK_HASH
+    }
 }
 ```
 

--- a/website/docs/dump-load-restart.md
+++ b/website/docs/dump-load-restart.md
@@ -23,6 +23,18 @@ $ starknet-devnet --dump-on exit --dump-path <PATH>
 $ curl -X POST http://<HOST>:<PORT>/dump -d '{ "path": <PATH> }' -H "Content-Type: application/json"
 ```
 
+```
+JSON-RPC
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "devnet_dump",
+    "params": {
+        "path": PATH
+    }
+}
+```
+
 ## Loading
 
 To load a preserved Devnet instance, the options are:
@@ -39,6 +51,18 @@ $ starknet-devnet --dump-path <PATH>
 curl -X POST http://<HOST>:<PORT>/load -d '{ "path": <PATH> }' -H "Content-Type: application/json"
 ```
 
+```
+JSON-RPC
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "devnet_load",
+    "params": {
+        "path": PATH
+    }
+}
+```
+
 Currently, dumping produces a list of received transactions that is stored on disk. Conversely, loading is implemented as the re-execution of transactions from a dump. This means that timestamps of `StarknetBlock` will be different on each load.
 
 ### Loading disclaimer
@@ -49,7 +73,7 @@ If you dumped a Devnet utilizing one class for account predeployment (e.g. `--ac
 
 ## Restarting
 
-Devnet can be restarted by making a `POST /restart` request (no body required). All of the deployed contracts (including predeployed), blocks and storage updates will be restarted to the original state, without the transactions and requests that may have been loaded from a dump file on startup.
+Devnet can be restarted by making a `POST /restart` request (no body required) or `JSON-RPC` request with method name `devnet_restart`. All of the deployed contracts (including predeployed), blocks and storage updates will be restarted to the original state, without the transactions and requests that may have been loaded from a dump file on startup.
 
 If you're using [**the Hardhat plugin**](https://github.com/0xSpaceShard/starknet-hardhat-plugin#restart), restart with `starknet.devnet.restart()`.
 

--- a/website/docs/postman.md
+++ b/website/docs/postman.md
@@ -8,10 +8,23 @@ Postman is a Starknet utility that allows testing L1-L2 interaction. Ensure you 
 POST /postman/load_l1_messaging_contract
 ```
 
-```js
+```json
 {
   "networkUrl": "http://localhost:8545",
   "address": "0x123...def"
+}
+```
+
+```
+JSON-RPC
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "devnet_postmanLoad",
+    "params": {
+      "networkUrl": "http://localhost:8545",
+      "address": "0x123...def"
+    }
 }
 ```
 
@@ -31,6 +44,15 @@ Loads a `MockStarknetMessaging` contract. The `address` parameter is optional; i
 POST /postman/flush
 ```
 
+```
+JSON-RPC
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "devnet_postmanFlush"
+}
+```
+
 Goes through the newly enqueued messages, sending them from L1 to L2 and from L2 to L1. Requires no body. Optionally, set the `dry_run` specifier to just see the result of flushing, without actually triggering it:
 
 ```
@@ -39,6 +61,18 @@ POST /postman/flush
 
 ```js
 { "dry_run": true }
+```
+
+```
+JSON-RPC
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "devnet_postmanFlush",
+    "params": {
+      "dry_run": true
+    }
+}
 ```
 
 A running L1 node is required if `dry_run` is not set.
@@ -91,6 +125,26 @@ Request:
 }
 ```
 
+```
+JSON-RPC
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "devnet_postmanSendMessageToL2",
+    "params": {
+      "l2_contract_address": "0x00285ddb7e5c777b310d806b9b2a0f7c7ba0a41f12b420219209d97a3b7f25b2",
+      "entry_point_selector": "0xC73F681176FC7B3F9693986FD7B14581E8D540519E27400E88B8713932BE01",
+      "l1_contract_address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+      "payload": [
+        "0x1",
+        "0x2"
+      ],
+      "paid_fee_on_l1": "0x123456abcdef"
+      "nonce":"0x0"
+  }
+}
+```
+
 Response:
 
 ```js
@@ -115,6 +169,20 @@ Request:
     "l2_contract_address": "0x00285ddb7e5c777b310d806b9b2a0f7c7ba0a41f12b420219209d97a3b7f25b2",
     "l1_contract_address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
     "payload": ["0x0", "0x1", "0x3e8"],
+}
+```
+
+```
+JSON-RPC
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "devnet_postmanConsumeMessageFromL2",
+    "params": {
+      "l2_contract_address": "0x00285ddb7e5c777b310d806b9b2a0f7c7ba0a41f12b420219209d97a3b7f25b2",
+      "l1_contract_address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+      "payload": ["0x0", "0x1", "0x3e8"],
+  }
 }
 ```
 

--- a/website/docs/predeployed.md
+++ b/website/docs/predeployed.md
@@ -24,4 +24,4 @@ If you want to deploy an instance of an account contract class not predeclared o
 
 ## How to get predeployment info?
 
-The predeployment information is logged on Devnet startup. Predeployed accounts can be retrieved in JSON format by sending a `GET` request to `/predeployed_accounts` of your Devnet.
+The predeployment information is logged on Devnet startup. Predeployed accounts can be retrieved in JSON format by sending a `GET` request to `/predeployed_accounts` of your Devnet or `JSON-RPC` request with method name `devnet_predeployedAccounts`.

--- a/website/docs/predeployed.md
+++ b/website/docs/predeployed.md
@@ -24,4 +24,4 @@ If you want to deploy an instance of an account contract class not predeclared o
 
 ## How to get predeployment info?
 
-The predeployment information is logged on Devnet startup. Predeployed accounts can be retrieved in JSON format by sending a `GET` request to `/predeployed_accounts` of your Devnet or `JSON-RPC` request with method name `devnet_predeployedAccounts`.
+The predeployment information is logged on Devnet startup. Predeployed accounts can be retrieved in JSON format by sending a `GET` request to `/predeployed_accounts` of your Devnet or `JSON-RPC` request with method name `devnet_getPredeployedAccounts`.

--- a/website/docs/server-config.md
+++ b/website/docs/server-config.md
@@ -61,7 +61,7 @@ $ starknet-devnet --request-body-size-limit <BYTES>
 
 ## API
 
-Retrieve the server config by sending a `GET` request to `/config` or `JSON-RPC` request with method name `devnet_config` and extracting its `server_config` property.
+Retrieve the server config by sending a `GET` request to `/config` or `JSON-RPC` request with method name `devnet_getConfig` and extracting its `server_config` property.
 
 ```
 $ curl localhost:5050/config | jq .server_config
@@ -72,6 +72,6 @@ JSON-RPC
 {
     "jsonrpc": "2.0",
     "id": "1",
-    "method": "devnet_config"
+    "method": "devnet_getConfig"
 }
 ```

--- a/website/docs/server-config.md
+++ b/website/docs/server-config.md
@@ -61,8 +61,17 @@ $ starknet-devnet --request-body-size-limit <BYTES>
 
 ## API
 
-Retrieve the server config by sending a `GET` request to `/config` and extracting its `server_config` property.
+Retrieve the server config by sending a `GET` request to `/config` or `JSON-RPC` request with method name `devnet_config` and extracting its `server_config` property.
 
 ```
 $ curl localhost:5050/config | jq .server_config
+```
+
+```
+JSON-RPC
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "devnet_config"
+}
 ```

--- a/website/docs/starknet-time.md
+++ b/website/docs/starknet-time.md
@@ -1,6 +1,6 @@
 # Starknet time
 
-Block and state timestamp can be manipulated by setting the exact time or setting the time offset. By default, timestamp methods `/set_time` and `/increase_time` generate a new block. This can be changed for `/set_time` by setting the optional parameter `generate_block` to `false`. This skips immediate new block generation, but will use the specified timestamp whenever the next block is supposed to be generated.
+Block and state timestamp can be manipulated by setting the exact time or setting the time offset. By default, timestamp methods `/set_time`, `/increase_time` and `JSON-RPC` methods `devnet_setTime`, `devnet_increaseTime` generate a new block. This can be changed for `/set_time` (`devnet_setTime`) by setting the optional parameter `generate_block` to `false`. This skips immediate new block generation, but will use the specified timestamp whenever the next block is supposed to be generated.
 
 All values should be set in [Unix time seconds](https://en.wikipedia.org/wiki/Unix_time).
 
@@ -15,6 +15,18 @@ POST /set_time
 }
 ```
 
+```
+JSON-RPC
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "devnet_setTime",
+    "params": {
+        "time": TIME_IN_SECONDS
+    }
+}
+```
+
 Doesn't generate a new block, but sets the exact time for the next generated block.
 
 ```
@@ -22,6 +34,19 @@ POST /set_time
 {
     "time": TIME_IN_SECONDS,
     "generate_block": false
+}
+```
+
+```
+JSON-RPC
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "devnet_setTime",
+    "params": {
+        "time": TIME_IN_SECONDS,
+        "generate_block": false
+    }
 }
 ```
 
@@ -35,6 +60,18 @@ Increases the block timestamp by the provided amount and generates a new block. 
 POST /increase_time
 {
     "time": TIME_IN_SECONDS
+}
+```
+
+```
+JSON-RPC
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "devnet_increaseTime",
+    "params": {
+        "time": TIME_IN_SECONDS
+    }
 }
 ```
 


### PR DESCRIPTION
## Usage related changes

Users can use http api endpoints via JSON-RPC api.

## Development related changes

- Endpoints accessible via HTTP endpoints can be invoked via JSON-RPC
- StarknetRequest -> JsonRpcRequest
- StarknetResponse -> JsonRpcResponse (StarknetResponse, DevnetResponse, Empty)
- Most of the http api methods logic is extracted into `<http api endpoint>_impl` function which is called from JSON-RPC counterpart
- Updated docs

## Checklist:

- [ ] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
- [ ] No spelling errors - `./scripts/check_spelling.sh`
- [ ] Performed code self-review
- [ ] Rebased to the latest commit of the target branch (or merged it into my branch)
- [ ] Updated the docs if needed - `./website/README.md`
- [ ] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#test-execution)
