### PR TITLE
Remove calling commit_with_diff from generate_new_block_and_state

### DIFF
--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -329,11 +329,6 @@ impl Starknet {
         // insert pending block in the blocks collection and connect it to the state diff
         self.blocks.insert(new_block, state_diff);
 
-        // clone_historic() requires self.historic_state, self.historic_state is set in
-        // expand_historic(), expand_historic() can be executed from commit_with_diff() - this
-        // is why self.commit_with_diff()? is here
-        self.commit_with_diff()?;
-
         // save into blocks state archive
         if self.config.state_archive == StateArchiveCapacity::Full {
             let clone = self.pending_state.clone_historic();


### PR DESCRIPTION
## Usage related changes

- remove of self.commit_with_diff

## Development related changes

- additional test for remove of self.commit_with_diff is not needed since`blocks_on_demand_states_and_blocks()` test is checking that scenario

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/?tab=readme-ov-file#test-execution)
