### PR TITLE
Fix dump loading on request

### DIFF
--- a/crates/starknet-devnet-server/src/api/http/endpoints/dump_load.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/dump_load.rs
@@ -62,9 +62,10 @@ pub(crate) async fn load_impl(api: &Api, path: LoadPath) -> HttpApiResult<()> {
     }
 
     let mut starknet = api.starknet.write().await;
-    let events =
-        starknet.load_events_custom_path(Some(path.path)).map_err(|_| HttpApiError::LoadError)?;
-    starknet.re_execute(events).map_err(|_| HttpApiError::ReExecutionError)?;
+    let events = starknet
+        .load_events_custom_path(Some(path.path))
+        .map_err(|e| HttpApiError::LoadError(e.to_string()))?;
+    starknet.re_execute(events).map_err(|e| HttpApiError::ReExecutionError(e.to_string()))?;
 
     Ok(())
 }

--- a/crates/starknet-devnet-server/src/api/http/endpoints/dump_load.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/dump_load.rs
@@ -62,6 +62,7 @@ pub(crate) async fn load_impl(api: &Api, path: LoadPath) -> HttpApiResult<()> {
     }
 
     let mut starknet = api.starknet.write().await;
+    starknet.restart().map_err(|e| HttpApiError::RestartError { msg: e.to_string() })?;
     let events = starknet
         .load_events_custom_path(Some(path.path))
         .map_err(|e| HttpApiError::LoadError(e.to_string()))?;

--- a/crates/starknet-devnet-server/src/api/http/error.rs
+++ b/crates/starknet-devnet-server/src/api/http/error.rs
@@ -17,10 +17,10 @@ pub enum HttpApiError {
     FileNotFound,
     #[error("The dump operation failed: {msg}")]
     DumpError { msg: String },
-    #[error("The load operation failed")]
-    LoadError,
-    #[error("The re-execution operation failed")]
-    ReExecutionError,
+    #[error("The load operation failed: {0}")]
+    LoadError(String),
+    #[error("The re-execution operation failed: {0}")]
+    ReExecutionError(String),
     #[error("The creation of empty block failed: {msg}")]
     CreateEmptyBlockError { msg: String },
     #[error("The set time operation failed: {msg}")]
@@ -52,11 +52,11 @@ impl IntoResponse for HttpApiError {
             HttpApiError::GeneralError(err) => (StatusCode::BAD_REQUEST, err.to_string()),
             err @ HttpApiError::FileNotFound => (StatusCode::BAD_REQUEST, err.to_string()),
             err @ HttpApiError::DumpError { msg: _ } => (StatusCode::BAD_REQUEST, err.to_string()),
-            err @ HttpApiError::LoadError => (StatusCode::BAD_REQUEST, err.to_string()),
+            err @ HttpApiError::LoadError(_) => (StatusCode::BAD_REQUEST, err.to_string()),
             err @ HttpApiError::BlockAbortError { msg: _ } => {
                 (StatusCode::BAD_REQUEST, err.to_string())
             }
-            err @ HttpApiError::ReExecutionError => (StatusCode::BAD_REQUEST, err.to_string()),
+            err @ HttpApiError::ReExecutionError(_) => (StatusCode::BAD_REQUEST, err.to_string()),
             err @ HttpApiError::CreateEmptyBlockError { msg: _ } => {
                 (StatusCode::BAD_REQUEST, err.to_string())
             }

--- a/crates/starknet-devnet-types/src/rpc/transaction_receipt.rs
+++ b/crates/starknet-devnet-types/src/rpc/transaction_receipt.rs
@@ -278,7 +278,7 @@ pub enum FeeInUnits {
     FRI(FeeAmount),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 pub enum FeeUnit {
     WEI,
     FRI,

--- a/crates/starknet-devnet/src/cli.rs
+++ b/crates/starknet-devnet/src/cli.rs
@@ -620,4 +620,26 @@ mod tests {
             Err(e) => panic!("Should have passed; got: {e}"),
         }
     }
+
+    #[test]
+    fn disallow_dump_on_if_no_dump_path_provided() {
+        match Args::try_parse_from(["--", "--dump-on", "exit"]) {
+            Ok(args) => panic!("Should have failed; got: {args:?}"),
+            Err(e) => assert_eq!(
+                get_first_line(&e.to_string()),
+                "error: the following required arguments were not provided:"
+            ),
+        }
+    }
+
+    #[test]
+    fn invalid_dump_path_not_allowed() {
+        match Args::try_parse_from(["--", "--dump-path", "dump_wrong_cli_mode", "--dump-on", "e"]) {
+            Ok(args) => panic!("Should have failed; got: {args:?}"),
+            Err(e) => assert_eq!(
+                get_first_line(&e.to_string()),
+                "error: invalid value 'e' for '--dump-on <EVENT>'"
+            ),
+        }
+    }
 }

--- a/crates/starknet-devnet/tests/test_dump_and_load.rs
+++ b/crates/starknet-devnet/tests/test_dump_and_load.rs
@@ -68,32 +68,12 @@ mod dump_and_load_tests {
     }
 
     #[tokio::test]
-    async fn dump_wrong_cli_parameters_no_path() {
-        let devnet_dump =
-            BackgroundDevnet::spawn_with_additional_args(&["--dump-on", "exit"]).await;
-        assert!(devnet_dump.is_err());
-    }
-
-    #[tokio::test]
     async fn dump_wrong_cli_parameters_path() {
         let devnet_dump = BackgroundDevnet::spawn_with_additional_args(&[
             "--dump-path",
             "///",
             "--dump-on",
             "block",
-        ])
-        .await;
-
-        assert!(devnet_dump.is_err());
-    }
-
-    #[tokio::test]
-    async fn dump_wrong_cli_parameters_mode() {
-        let devnet_dump = BackgroundDevnet::spawn_with_additional_args(&[
-            "--dump-path",
-            "dump_wrong_cli_mode",
-            "--dump-on",
-            "e",
         ])
         .await;
 

--- a/crates/starknet-devnet/tests/test_dump_and_load.rs
+++ b/crates/starknet-devnet/tests/test_dump_and_load.rs
@@ -438,6 +438,44 @@ mod dump_and_load_tests {
     }
 
     #[tokio::test]
+    async fn mint_and_dump_and_load_on_same_devnet() {
+        let dump_file = UniqueAutoDeletableFile::new("dump_set_time");
+        let devnet = BackgroundDevnet::spawn_with_additional_args(&[
+            "--dump-on",
+            "exit",
+            "--dump-path",
+            &dump_file.path,
+        ])
+        .await
+        .unwrap();
+
+        let unit = FeeUnit::WEI;
+
+        devnet.mint_unit(DUMMY_ADDRESS, DUMMY_AMOUNT, unit).await;
+        let balance_before_dump =
+            devnet.get_balance_latest(&DUMMY_ADDRESS.into(), unit).await.unwrap();
+        assert_eq!(balance_before_dump, DUMMY_AMOUNT.into());
+
+        devnet.send_custom_rpc("devnet_dump", json!({ "path": dump_file.path })).await.unwrap();
+
+        devnet.mint_unit(DUMMY_ADDRESS, DUMMY_AMOUNT, unit).await;
+        let balance_after_dump =
+            devnet.get_balance_latest(&DUMMY_ADDRESS.into(), unit).await.unwrap();
+        assert_eq!(balance_after_dump, balance_before_dump + DUMMY_AMOUNT.into());
+
+        devnet.send_custom_rpc("devnet_load", json!({ "path": dump_file.path })).await.unwrap();
+
+        let balance_after_load =
+            devnet.get_balance_latest(&DUMMY_ADDRESS.into(), unit).await.unwrap();
+        assert_eq!(balance_after_load, balance_before_dump);
+
+        devnet.mint_unit(DUMMY_ADDRESS, DUMMY_AMOUNT, unit).await;
+        let balance_after_mint_on_loaded =
+            devnet.get_balance_latest(&DUMMY_ADDRESS.into(), unit).await.unwrap();
+        assert_eq!(balance_after_mint_on_loaded, balance_after_load + DUMMY_AMOUNT.into());
+    }
+
+    #[tokio::test]
     async fn set_time_with_later_block_generation_dump_and_load() {
         let dump_file = UniqueAutoDeletableFile::new("dump_set_time");
         let devnet_dump = BackgroundDevnet::spawn_with_additional_args(&[

--- a/website/docs/dump-load-restart.md
+++ b/website/docs/dump-load-restart.md
@@ -16,11 +16,18 @@ $ starknet-devnet --dump-on exit --dump-path <PATH>
 $ starknet-devnet --dump-on block --dump-path <PATH>
 ```
 
-- Dumping on request requires providing --dump-on mode on the startup. Example usage in `exit` mode (replace `<HOST>`, `<PORT>` and `<PATH>` with your own):
+- Dumping on request, which requires providing `--dump-on` on startup. E.g. if you run Devnet in `exit` mode, you can request dumping by sending `POST` to `/dump` or via JSON-RPC:
 
 ```
-$ starknet-devnet --dump-on exit --dump-path <PATH>
-$ curl -X POST http://<HOST>:<PORT>/dump -d '{ "path": <PATH> }' -H "Content-Type: application/json"
+$ starknet-devnet --dump-on exit --dump-path <DEFAULT_PATH>
+```
+
+```
+POST /dump
+{
+  // optional; defaults to the path specified via CLI
+  "path": <PATH>
+}
 ```
 
 ```
@@ -30,7 +37,8 @@ JSON-RPC
     "id": "1",
     "method": "devnet_dump",
     "params": {
-        "path": PATH
+        // optional; defaults to the path specified via CLI
+        "path": <PATH>
     }
 }
 ```
@@ -45,7 +53,7 @@ To load a preserved Devnet instance, the options are:
 $ starknet-devnet --dump-path <PATH>
 ```
 
-- Loading on request, which replaces the current state with the one in the provided file. It can be done by making `POST` to `/load` or by sending a JSON-RPC request:
+- Loading on request, which replaces the current state with the one in the provided file. It can be done by sending `POST` to `/load` or via JSON-RPC:
 
 ```
 POST /load

--- a/website/docs/dump-load-restart.md
+++ b/website/docs/dump-load-restart.md
@@ -45,10 +45,11 @@ To load a preserved Devnet instance, the options are:
 $ starknet-devnet --dump-path <PATH>
 ```
 
-- Loading on request:
+- Loading on request, which replaces the current state with the one in the provided file. It can be done by making `POST` to `/load` or by sending a JSON-RPC request:
 
 ```
-curl -X POST http://<HOST>:<PORT>/load -d '{ "path": <PATH> }' -H "Content-Type: application/json"
+POST /load
+{ "path": <PATH> }
 ```
 
 ```
@@ -58,14 +59,14 @@ JSON-RPC
     "id": "1",
     "method": "devnet_load",
     "params": {
-        "path": PATH
+        "path": <PATH>
     }
 }
 ```
 
-Currently, dumping produces a list of received transactions that is stored on disk. Conversely, loading is implemented as the re-execution of transactions from a dump. This means that timestamps of `StarknetBlock` will be different on each load.
-
 ### Loading disclaimer
+
+Currently, dumping produces a list of received transactions that is stored on disk. Conversely, loading is implemented as the re-execution of transactions from a dump. This means that timestamps of `StarknetBlock` will be different on each load.
 
 Dumping and loading are not guaranteed to work across versions. I.e. if you dumped one version of Devnet, do not expect it to be loadable with a different version.
 


### PR DESCRIPTION
## Usage related changes

- Fix the bug that made loading via request impossible due to nonce invalidation.
- Make load and re-execution errors more transparent.
- Improve docs:
  - Improve wording.
  - Replace `curl` mentions with the more agnostic `POST`.

## Development related changes

- Add `Copy` to `FeeUnit` to reduce the need for cloning in test.
- Move CLI arg parsing tests from e2e to unit tests `cli.rs`.

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please prefer merging over rebasing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
