### PR TITLE
Improve dumping UX

### DIFF
--- a/crates/starknet-devnet-core/src/starknet/dump.rs
+++ b/crates/starknet-devnet-core/src/starknet/dump.rs
@@ -62,7 +62,7 @@ impl Starknet {
                 self.dump_events.push(event);
 
                 Ok(())
-            },
+            }
             Some(DumpOn::Exit) => {
                 self.dump_events.push(event);
 

--- a/crates/starknet-devnet-core/src/starknet/dump.rs
+++ b/crates/starknet-devnet-core/src/starknet/dump.rs
@@ -58,6 +58,11 @@ impl Starknet {
     pub fn handle_dump_event(&mut self, event: DumpEvent) -> DevnetResult<()> {
         match self.config.dump_on {
             Some(DumpOn::Block) => self.dump_event(event),
+            Some(DumpOn::Request) => {
+                self.dump_events.push(event);
+
+                Ok(())
+            },
             Some(DumpOn::Exit) => {
                 self.dump_events.push(event);
 
@@ -131,6 +136,10 @@ impl Starknet {
             }
             None => Err(Error::FormatError),
         }
+    }
+
+    pub fn dump_events_vec(&self) -> DevnetResult<Vec<DumpEvent>> {
+        Ok(self.dump_events.clone())
     }
 
     pub fn load_events(&self) -> DevnetResult<Vec<DumpEvent>> {

--- a/crates/starknet-devnet-core/src/starknet/dump.rs
+++ b/crates/starknet-devnet-core/src/starknet/dump.rs
@@ -58,12 +58,7 @@ impl Starknet {
     pub fn handle_dump_event(&mut self, event: DumpEvent) -> DevnetResult<()> {
         match self.config.dump_on {
             Some(DumpOn::Block) => self.dump_event(event),
-            Some(DumpOn::Request) => {
-                self.dump_events.push(event);
-
-                Ok(())
-            }
-            Some(DumpOn::Exit) => {
+            Some(DumpOn::Request | DumpOn::Exit) => {
                 self.dump_events.push(event);
 
                 Ok(())

--- a/crates/starknet-devnet-core/src/starknet/dump.rs
+++ b/crates/starknet-devnet-core/src/starknet/dump.rs
@@ -133,8 +133,8 @@ impl Starknet {
         }
     }
 
-    pub fn dump_events_vec(&self) -> DevnetResult<Vec<DumpEvent>> {
-        Ok(self.dump_events.clone())
+    pub fn read_dump_events(&self) -> &Vec<DumpEvent> {
+        &self.dump_events
     }
 
     pub fn load_events(&self) -> DevnetResult<Vec<DumpEvent>> {

--- a/crates/starknet-devnet-core/src/starknet/starknet_config.rs
+++ b/crates/starknet-devnet-core/src/starknet/starknet_config.rs
@@ -20,6 +20,7 @@ use crate::constants::{
 pub enum DumpOn {
     Exit,
     Block,
+    Request,
 }
 
 #[derive(Default, Copy, Clone, Debug, Eq, PartialEq, clap::ValueEnum, Serialize)]

--- a/crates/starknet-devnet-server/src/api/http/endpoints/dump_load.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/dump_load.rs
@@ -14,7 +14,7 @@ pub async fn dump(
 }
 
 pub(crate) async fn dump_impl(api: &Api, path: DumpPath) -> HttpApiResult<DumpResponseBody> {
-    let starknet = api.starknet.write().await;
+    let starknet = api.starknet.read().await;
 
     if starknet.config.dump_on.is_none() {
         return Err(HttpApiError::DumpError {

--- a/crates/starknet-devnet-server/src/api/http/endpoints/dump_load.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/dump_load.rs
@@ -11,10 +11,9 @@ pub async fn dump(
     Json(path): Json<DumpPath>,
 ) -> HttpApiResult<Json<Dump>> {
     dump_impl(&state.api, path).await.map(Json::from)
-
 }
 
-pub(crate) async fn dump_impl(api: &Api, path: DumpPath) -> HttpApiResult<Dump>{
+pub(crate) async fn dump_impl(api: &Api, path: DumpPath) -> HttpApiResult<Dump> {
     let starknet = api.starknet.write().await;
 
     if starknet.config.dump_on.is_none() {

--- a/crates/starknet-devnet-server/src/api/http/models.rs
+++ b/crates/starknet-devnet-server/src/api/http/models.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use starknet_core::starknet::dump::DumpEvent;
 use starknet_rs_core::types::{Hash256, MsgToL1};
 use starknet_types::contract_address::ContractAddress;
 use starknet_types::felt::{BlockHash, Calldata, EntryPointSelector, Felt, Nonce, TransactionHash};
@@ -41,6 +42,8 @@ pub struct MessageHash {
 pub struct TxHash {
     pub transaction_hash: TransactionHash,
 }
+// Implemented as type alias so JSON returned doesn't have extra key
+pub type Dump = Option<Vec<DumpEvent>>;
 
 #[derive(Serialize)]
 pub struct CreatedBlock {

--- a/crates/starknet-devnet-server/src/api/http/models.rs
+++ b/crates/starknet-devnet-server/src/api/http/models.rs
@@ -43,7 +43,7 @@ pub struct TxHash {
     pub transaction_hash: TransactionHash,
 }
 // Implemented as type alias so JSON returned doesn't have extra key
-pub type Dump = Option<Vec<DumpEvent>>;
+pub type DumpResponseBody = Option<Vec<DumpEvent>>;
 
 #[derive(Serialize)]
 pub struct CreatedBlock {

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -40,10 +40,7 @@ use self::origin_forwarder::OriginForwarder;
 use super::http::endpoints::accounts::{BalanceQuery, PredeployedAccountsQuery};
 use super::http::endpoints::DevnetConfig;
 use super::http::models::{
-    AbortedBlocks, AbortingBlocks, AccountBalanceResponse, CreatedBlock, DumpPath, FlushParameters,
-    FlushedMessages, IncreaseTime, IncreaseTimeResponse, LoadPath, MessageHash,
-    MessagingLoadAddress, MintTokensRequest, MintTokensResponse, PostmanLoadL1MessagingContract,
-    SerializableAccount, SetTime, SetTimeResponse,
+    AbortedBlocks, AbortingBlocks, AccountBalanceResponse, CreatedBlock, Dump, DumpPath, FlushParameters, FlushedMessages, IncreaseTime, IncreaseTimeResponse, LoadPath, MessageHash, MessagingLoadAddress, MintTokensRequest, MintTokensResponse, PostmanLoadL1MessagingContract, SerializableAccount, SetTime, SetTimeResponse
 };
 use super::Api;
 use crate::api::json_rpc::models::{
@@ -518,6 +515,7 @@ pub enum DevnetResponse {
     AccountBalance(AccountBalanceResponse),
     MintTokens(MintTokensResponse),
     DevnetConfig(DevnetConfig),
+    DevnetDump(Dump)
 }
 
 #[cfg(test)]

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -40,7 +40,10 @@ use self::origin_forwarder::OriginForwarder;
 use super::http::endpoints::accounts::{BalanceQuery, PredeployedAccountsQuery};
 use super::http::endpoints::DevnetConfig;
 use super::http::models::{
-    AbortedBlocks, AbortingBlocks, AccountBalanceResponse, CreatedBlock, Dump, DumpPath, FlushParameters, FlushedMessages, IncreaseTime, IncreaseTimeResponse, LoadPath, MessageHash, MessagingLoadAddress, MintTokensRequest, MintTokensResponse, PostmanLoadL1MessagingContract, SerializableAccount, SetTime, SetTimeResponse
+    AbortedBlocks, AbortingBlocks, AccountBalanceResponse, CreatedBlock, Dump, DumpPath,
+    FlushParameters, FlushedMessages, IncreaseTime, IncreaseTimeResponse, LoadPath, MessageHash,
+    MessagingLoadAddress, MintTokensRequest, MintTokensResponse, PostmanLoadL1MessagingContract,
+    SerializableAccount, SetTime, SetTimeResponse,
 };
 use super::Api;
 use crate::api::json_rpc::models::{
@@ -515,7 +518,7 @@ pub enum DevnetResponse {
     AccountBalance(AccountBalanceResponse),
     MintTokens(MintTokensResponse),
     DevnetConfig(DevnetConfig),
-    DevnetDump(Dump)
+    DevnetDump(Dump),
 }
 
 #[cfg(test)]

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -40,10 +40,10 @@ use self::origin_forwarder::OriginForwarder;
 use super::http::endpoints::accounts::{BalanceQuery, PredeployedAccountsQuery};
 use super::http::endpoints::DevnetConfig;
 use super::http::models::{
-    AbortedBlocks, AbortingBlocks, AccountBalanceResponse, CreatedBlock, Dump, DumpPath,
-    FlushParameters, FlushedMessages, IncreaseTime, IncreaseTimeResponse, LoadPath, MessageHash,
-    MessagingLoadAddress, MintTokensRequest, MintTokensResponse, PostmanLoadL1MessagingContract,
-    SerializableAccount, SetTime, SetTimeResponse,
+    AbortedBlocks, AbortingBlocks, AccountBalanceResponse, CreatedBlock, DumpPath,
+    DumpResponseBody, FlushParameters, FlushedMessages, IncreaseTime, IncreaseTimeResponse,
+    LoadPath, MessageHash, MessagingLoadAddress, MintTokensRequest, MintTokensResponse,
+    PostmanLoadL1MessagingContract, SerializableAccount, SetTime, SetTimeResponse,
 };
 use super::Api;
 use crate::api::json_rpc::models::{
@@ -518,7 +518,7 @@ pub enum DevnetResponse {
     AccountBalance(AccountBalanceResponse),
     MintTokens(MintTokensResponse),
     DevnetConfig(DevnetConfig),
-    DevnetDump(Dump),
+    DevnetDump(DumpResponseBody),
 }
 
 #[cfg(test)]

--- a/crates/starknet-devnet-server/src/api/json_rpc/write_endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/write_endpoints.rs
@@ -93,8 +93,8 @@ impl JsonRpcHandler {
 
     /// devnet_dump
     pub async fn dump(&self, path: DumpPath) -> StrictRpcResult {
-        dump_impl(&self.api, path).await.map_err(ApiError::from)?;
-        Ok(super::JsonRpcResponse::Empty)
+        let dump = dump_impl(&self.api, path).await.map_err(ApiError::from)?;
+        Ok(DevnetResponse::DevnetDump(dump).into())
     }
 
     /// devnet_load

--- a/crates/starknet-devnet/src/cli.rs
+++ b/crates/starknet-devnet/src/cli.rs
@@ -142,7 +142,6 @@ pub(crate) struct Args {
     #[arg(env = "DUMP_ON")]
     #[arg(value_name = "EVENT")]
     #[arg(help = "Specify when to dump the state of Devnet;")]
-    #[arg(requires = "dump_path")]
     dump_on: Option<DumpOn>,
 
     #[arg(long = "lite-mode")]
@@ -155,6 +154,7 @@ pub(crate) struct Args {
     #[arg(env = "DUMP_PATH")]
     #[arg(value_name = "DUMP_PATH")]
     #[arg(help = "Specify the path to dump to;")]
+    #[arg(required_if_eq_any([("dump_on", "exit"), ("dump_on", "block")]))]
     dump_path: Option<String>,
 
     #[arg(long = "block-generation-on")]

--- a/crates/starknet-devnet/src/cli.rs
+++ b/crates/starknet-devnet/src/cli.rs
@@ -274,7 +274,9 @@ mod tests {
     use starknet_core::constants::{
         CAIRO_0_ERC20_CONTRACT_PATH, CAIRO_1_ACCOUNT_CONTRACT_SIERRA_PATH,
     };
-    use starknet_core::starknet::starknet_config::{BlockGenerationOn, StateArchiveCapacity};
+    use starknet_core::starknet::starknet_config::{
+        BlockGenerationOn, DumpOn, StateArchiveCapacity,
+    };
     use tracing_subscriber::EnvFilter;
 
     use super::{Args, RequestResponseLogging};
@@ -622,13 +624,19 @@ mod tests {
     }
 
     #[test]
-    fn disallow_dump_on_if_no_dump_path_provided() {
-        match Args::try_parse_from(["--", "--dump-on", "exit"]) {
-            Ok(args) => panic!("Should have failed; got: {args:?}"),
-            Err(e) => assert_eq!(
-                get_first_line(&e.to_string()),
-                "error: the following required arguments were not provided:"
-            ),
+    fn test_when_dump_path_flag_required() {
+        for event in ["exit", "block"] {
+            match Args::try_parse_from(["--", "--dump-on", event]) {
+                Ok(args) => panic!("Should have failed; got: {args:?}"),
+                Err(e) => assert_eq!(
+                    get_first_line(&e.to_string()),
+                    "error: the following required arguments were not provided:"
+                ),
+            }
+        }
+        match Args::try_parse_from(["--", "--dump-on", "request"]) {
+            Ok(args) => assert_eq!(args.dump_on, Some(DumpOn::Request)),
+            Err(e) => panic!("Should have passed; got: {e}"),
         }
     }
 

--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -362,10 +362,6 @@ impl BackgroundDevnet {
         self.send_custom_rpc("devnet_getConfig", json!({})).await.unwrap()
     }
 
-    pub async fn get_dump(&self) -> serde_json::Value {
-        self.send_custom_rpc("devnet_dump", json!({})).await.unwrap()
-    }
-
     pub async fn execute_impersonation_action(
         &self,
         action: &ImpersonationAction,

--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -362,6 +362,10 @@ impl BackgroundDevnet {
         self.send_custom_rpc("devnet_getConfig", json!({})).await.unwrap()
     }
 
+    pub async fn get_dump(&self) -> serde_json::Value {
+        self.send_custom_rpc("devnet_dump", json!({})).await.unwrap()
+    }
+
     pub async fn execute_impersonation_action(
         &self,
         action: &ImpersonationAction,

--- a/crates/starknet-devnet/tests/test_dump_and_load.rs
+++ b/crates/starknet-devnet/tests/test_dump_and_load.rs
@@ -67,7 +67,8 @@ mod dump_and_load_tests {
             devnet_dump.create_block().await.unwrap();
             devnet_dump.mint(DUMMY_ADDRESS, DUMMY_AMOUNT).await;
         }
-        let dump_rpc = devnet_dump.get_dump().await.to_string();
+        let dump_rpc =
+            devnet_dump.send_custom_rpc("devnet_dump", json!({})).await.unwrap().to_string();
         let dump_file = UniqueAutoDeletableFile::new("dump_load_dump_load_on_request_nofile");
         std::fs::write(&dump_file.path, dump_rpc).expect("Failed to write dump file");
 
@@ -82,6 +83,12 @@ mod dump_and_load_tests {
 
         let last_block = devnet_load.get_latest_block_with_tx_hashes().await.unwrap();
         assert_eq!(last_block.block_number, 4);
+
+        let loaded_balance = devnet_load
+            .get_balance_latest(&FieldElement::from(DUMMY_ADDRESS), FeeUnit::WEI)
+            .await
+            .unwrap();
+        assert_eq!(loaded_balance, FieldElement::from(DUMMY_AMOUNT * 2));
     }
 
     #[tokio::test]

--- a/crates/starknet-devnet/tests/test_dump_and_load.rs
+++ b/crates/starknet-devnet/tests/test_dump_and_load.rs
@@ -95,11 +95,6 @@ mod dump_and_load_tests {
     }
 
     #[tokio::test]
-    async fn dump_load_dump_load_on_request() {
-        dump_load_dump_load("request").await;
-    }
-
-    #[tokio::test]
     async fn dump_wrong_cli_parameters_path() {
         let devnet_dump = BackgroundDevnet::spawn_with_additional_args(&[
             "--dump-path",
@@ -114,7 +109,7 @@ mod dump_and_load_tests {
 
     #[tokio::test]
     async fn dump_and_load_blocks_generation_on_demand() {
-        let modes = vec!["exit", "block", "request"];
+        let modes = vec!["exit", "block"];
 
         for mode in modes {
             let dump_file = UniqueAutoDeletableFile::new(

--- a/website/docs/dump-load-restart.md
+++ b/website/docs/dump-load-restart.md
@@ -16,7 +16,7 @@ $ starknet-devnet --dump-on exit --dump-path <PATH>
 $ starknet-devnet --dump-on block --dump-path <PATH>
 ```
 
-- Dumping on request, which requires providing `--dump-on` on startup. E.g. if you run Devnet in `exit` mode, you can request dumping by sending `POST` to `/dump` or via JSON-RPC:
+- Dumping on request, which requires providing `--dump-on request` on startup. You can request dumping by sending `POST` to `/dump` or via JSON-RPC:
 
 ```
 $ starknet-devnet --dump-on exit --dump-path <DEFAULT_PATH>
@@ -25,7 +25,7 @@ $ starknet-devnet --dump-on exit --dump-path <DEFAULT_PATH>
 ```
 POST /dump
 {
-  // optional; defaults to the path specified via CLI
+  // optional; defaults to the path specified via CLI if defined
   "path": <PATH>
 }
 ```
@@ -37,11 +37,12 @@ JSON-RPC
     "id": "1",
     "method": "devnet_dump",
     "params": {
-        // optional; defaults to the path specified via CLI
+        // optional; defaults to the path specified via CLI if defined
         "path": <PATH>
     }
 }
 ```
+If dump path is not provided either via `--dump-path` flag or in dump request, dump is redirected to STDOUT.
 
 ## Loading
 

--- a/website/docs/dump-load-restart.md
+++ b/website/docs/dump-load-restart.md
@@ -42,7 +42,7 @@ JSON-RPC
     }
 }
 ```
-If dump path is not provided either via `--dump-path` flag or in dump request, dump is redirected to STDOUT.
+If a dump path is not provided either via `--dump-path` or in the request, the dump is included in the response body. This means that if you request dumping via curl, it will be printed to STDOUT, which you can then redirect to a destination of your choice.
 
 ## Loading
 


### PR DESCRIPTION
## Usage related changes

Improves ux when using `/dump` endpoint. When dump path not provided, it dumps to STDOUT.
## Development related changes

Resolves #529 

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please prefer merging over rebasing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
