### PR TITLE
Support minting with amount using scientific notation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "bigdecimal"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d712318a27c7150326677b321a5fa91b55f6d9034ffd67f20319e147d40cee"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits 0.2.18",
+]
+
+[[package]]
 name = "bincode"
 version = "2.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5666,6 +5679,7 @@ name = "starknet-devnet-types"
 version = "0.1.2"
 dependencies = [
  "base64 0.22.1",
+ "bigdecimal 0.4.5",
  "blockifier",
  "cairo-lang-casm 2.6.0",
  "cairo-lang-compiler 2.6.0",
@@ -5700,7 +5714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abf1b44ec5b18d87c1ae5f54590ca9d0699ef4dd5b2ffa66fc97f24613ec585"
 dependencies = [
  "ark-ff",
- "bigdecimal",
+ "bigdecimal 0.3.1",
  "crypto-bigint",
  "getrandom",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ reqwest = { version = "0.12", features = ["blocking", "json"] }
 url = "2.4"
 usc = { version = "2.1.0", package = "universal-sierra-compiler" }
 num-bigint = { version = "0.4" }
+bigdecimal = { version = "0.4.5" }
 
 # Starknet dependencies
 starknet_api = { version = "0.10.0", features = ["testing"] }

--- a/crates/starknet-devnet-types/Cargo.toml
+++ b/crates/starknet-devnet-types/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = { workspace = true, features = [
 ] }
 starknet-rs-ff = { workspace = true }
 num-bigint = { workspace = true }
+bigdecimal = { workspace = true }
 usc = { workspace = true }
 
 # Cairo-lang dependencies

--- a/website/docs/balance.md
+++ b/website/docs/balance.md
@@ -11,7 +11,7 @@ Separate tokens use separate ERC20 contracts for minting and charging fees. Thes
 
 By sending a `POST` request to `/mint` or `JSON-RPC` request with method name `devnet_mint` for a token, you initiate a transaction on that token's ERC20 contract. The response contains the hash of this transaction, as well as the new balance after minting. The token is specified by providing the unit, and defaults to `WEI`.
 
-The value of `amount` is in WEI and needs to be an integer (or a float whose fractional part is 0, e.g. `1000.0` or `1e21`)
+The value of `amount` is in WEI or FRI. The precision is preserved if specifying an integer or a float whose fractional part is zero (e.g. `1000.0`, `1e21`). If the fractional part is non-zero, the amount is truncated to the nearest integer (e.g. `3.9` becomes `3` and `1.23e1` becomes `12`).
 
 ```
 POST /mint


### PR DESCRIPTION
## Usage related changes

- Close #533
- In docs it is actually claimed that scientific notation is supported, as long as the value is actually an integer. The docs are edited and aligned with the implementation.

## Development related changes

- Add new dependency: bigdecimal 0.4.5

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please prefer merging over rebasing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
