### PR TITLE
Execution on the latest block should be specifiable by number

### DIFF
--- a/crates/starknet-devnet-core/src/starknet/get_class_impls.rs
+++ b/crates/starknet-devnet-core/src/starknet/get_class_impls.rs
@@ -118,6 +118,7 @@ mod tests {
 
         let block_number = starknet.get_latest_block().unwrap().block_number();
         let block_id = BlockId::Number(block_number.0);
+        starknet.create_block().unwrap();
 
         let class_hash = starknet.get_class_hash_at(&block_id, account.account_address);
         match class_hash.err().unwrap() {

--- a/crates/starknet-devnet-core/src/starknet/get_class_impls.rs
+++ b/crates/starknet-devnet-core/src/starknet/get_class_impls.rs
@@ -118,7 +118,7 @@ mod tests {
 
         let block_number = starknet.get_latest_block().unwrap().block_number();
         let block_id = BlockId::Number(block_number.0);
-        starknet.create_block().unwrap();
+        starknet.create_block().unwrap(); // makes the queried block non-latest (and unsupported)
 
         let class_hash = starknet.get_class_hash_at(&block_id, account.account_address);
         match class_hash.err().unwrap() {

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -1644,8 +1644,10 @@ mod tests {
         let config =
             StarknetConfig { state_archive: StateArchiveCapacity::Full, ..Default::default() };
         let mut starknet = Starknet::new(&config).unwrap();
+        let genesis_block_hash = starknet.get_latest_block().unwrap();
         let block_hash = starknet.generate_new_block_and_state().unwrap();
         starknet.blocks.hash_to_state.remove(&block_hash);
+        starknet.blocks.last_block_hash = Some(genesis_block_hash.block_hash());
 
         match starknet.get_mut_state_at(&BlockId::Number(1)) {
             Err(Error::NoStateAtBlock { block_id: _ }) => (),

--- a/crates/starknet-devnet/tests/test_blocks_generation.rs
+++ b/crates/starknet-devnet/tests/test_blocks_generation.rs
@@ -12,12 +12,14 @@ mod blocks_generation_tests {
         BlockId, BlockStatus, BlockTag, DeclaredClassItem, FieldElement, FunctionCall,
         MaybePendingStateUpdate, NonceUpdate, StateUpdate, TransactionTrace,
     };
-    use starknet_rs_core::utils::{get_selector_from_name, get_udc_deployed_address};
+    use starknet_rs_core::utils::{
+        get_selector_from_name, get_storage_var_address, get_udc_deployed_address,
+    };
     use starknet_rs_providers::Provider;
     use starknet_types::rpc::transaction_receipt::FeeUnit;
 
     use crate::common::background_devnet::BackgroundDevnet;
-    use crate::common::constants;
+    use crate::common::constants::{self, PREDEPLOYED_ACCOUNT_PUBLIC_KEY};
     use crate::common::utils::{
         assert_equal_elements, assert_tx_successful, get_contract_balance,
         get_contract_balance_by_block_id, get_events_contract_in_sierra_and_compiled_class_hash,
@@ -652,13 +654,13 @@ mod blocks_generation_tests {
                 FieldElement::from_hex_be(CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH).unwrap()
             );
 
-            let key = FieldElement::ZERO;
+            let key = get_storage_var_address("Account_public_key", &[]).unwrap();
             let storage = devnet
                 .json_rpc_client
                 .get_storage_at(account_address, key, block_id)
                 .await
                 .unwrap();
-            assert_eq!(storage, FieldElement::ZERO);
+            assert_eq!(storage, FieldElement::from_hex_be(PREDEPLOYED_ACCOUNT_PUBLIC_KEY).unwrap());
         }
     }
 }

--- a/crates/starknet-devnet/tests/test_blocks_generation.rs
+++ b/crates/starknet-devnet/tests/test_blocks_generation.rs
@@ -642,24 +642,24 @@ mod blocks_generation_tests {
             [BlockId::Hash(latest_block.block_hash), BlockId::Number(latest_block.block_number)];
 
         for block_id in &block_ids {
-            let latest_block_nonce =
+            let nonce =
                 devnet.json_rpc_client.get_nonce(block_id, account_address).await.unwrap();
-            assert_eq!(latest_block_nonce, FieldElement::ZERO);
+            assert_eq!(nonce, FieldElement::ZERO);
 
-            let latest_block_class_hash =
+            let class_hash =
                 devnet.json_rpc_client.get_class_hash_at(block_id, account_address).await.unwrap();
             assert_eq!(
-                latest_block_class_hash,
+                class_hash,
                 FieldElement::from_hex_be(CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH).unwrap()
             );
 
             let key = FieldElement::ZERO;
-            let latest_block_storage = devnet
+            let storage = devnet
                 .json_rpc_client
                 .get_storage_at(account_address, key, block_id)
                 .await
                 .unwrap();
-            assert_eq!(latest_block_storage, FieldElement::ZERO);
+            assert_eq!(storage, FieldElement::ZERO);
         }
     }
 }

--- a/crates/starknet-devnet/tests/test_blocks_generation.rs
+++ b/crates/starknet-devnet/tests/test_blocks_generation.rs
@@ -16,10 +16,11 @@ mod blocks_generation_tests {
         get_selector_from_name, get_storage_var_address, get_udc_deployed_address,
     };
     use starknet_rs_providers::Provider;
+    use starknet_rs_signers::Signer;
     use starknet_types::rpc::transaction_receipt::FeeUnit;
 
     use crate::common::background_devnet::BackgroundDevnet;
-    use crate::common::constants::{self, PREDEPLOYED_ACCOUNT_PUBLIC_KEY};
+    use crate::common::constants;
     use crate::common::utils::{
         assert_equal_elements, assert_tx_successful, get_contract_balance,
         get_contract_balance_by_block_id, get_events_contract_in_sierra_and_compiled_class_hash,
@@ -638,7 +639,7 @@ mod blocks_generation_tests {
     #[tokio::test]
     async fn get_data_by_specifying_latest_block_hash_and_number() {
         let devnet = BackgroundDevnet::spawn().await.unwrap();
-        let (_, account_address) = devnet.get_first_predeployed_account().await;
+        let (signer, account_address) = devnet.get_first_predeployed_account().await;
         let latest_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
         let block_ids =
             [BlockId::Hash(latest_block.block_hash), BlockId::Number(latest_block.block_number)];
@@ -660,7 +661,7 @@ mod blocks_generation_tests {
                 .get_storage_at(account_address, key, block_id)
                 .await
                 .unwrap();
-            assert_eq!(storage, FieldElement::from_hex_be(PREDEPLOYED_ACCOUNT_PUBLIC_KEY).unwrap());
+            assert_eq!(storage, signer.get_public_key().await.unwrap().scalar());
         }
     }
 }

--- a/crates/starknet-devnet/tests/test_blocks_generation.rs
+++ b/crates/starknet-devnet/tests/test_blocks_generation.rs
@@ -642,8 +642,7 @@ mod blocks_generation_tests {
             [BlockId::Hash(latest_block.block_hash), BlockId::Number(latest_block.block_number)];
 
         for block_id in &block_ids {
-            let nonce =
-                devnet.json_rpc_client.get_nonce(block_id, account_address).await.unwrap();
+            let nonce = devnet.json_rpc_client.get_nonce(block_id, account_address).await.unwrap();
             assert_eq!(nonce, FieldElement::ZERO);
 
             let class_hash =


### PR DESCRIPTION
## Usage related changes

- `--state-archive-capacity none` mode from now on, allows calling the latest state by its number and hash

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please prefer merging over rebasing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
