### PR TITLE
Fix naming: Replace stopImpersonating with stopImpersonate

### DIFF
--- a/crates/starknet-devnet-server/src/api/json_rpc/write_endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/write_endpoints.rs
@@ -77,7 +77,7 @@ impl JsonRpcHandler {
         Ok(super::JsonRpcResponse::Empty)
     }
 
-    /// devnet_stopImpersonatingAccount
+    /// devnet_stopImpersonateAccount
     pub async fn stop_impersonating_account(&self, address: ContractAddress) -> StrictRpcResult {
         let mut starknet = self.api.starknet.write().await;
         starknet.stop_impersonating_account(&address);

--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -373,7 +373,7 @@ impl BackgroundDevnet {
                     "account_address": to_hex_felt(account)
                 }),
             ),
-            ImpersonationAction::StopImpersonatingAccount(account) => (
+            ImpersonationAction::StopImpersonateAccount(account) => (
                 "devnet_stopImpersonateAccount",
                 json!({
                     "account_address": to_hex_felt(account)

--- a/crates/starknet-devnet/tests/common/utils.rs
+++ b/crates/starknet-devnet/tests/common/utils.rs
@@ -27,7 +27,7 @@ use super::constants::{ARGENT_ACCOUNT_CLASS_HASH, CAIRO_1_CONTRACT_PATH, CHAIN_I
 
 pub enum ImpersonationAction {
     ImpersonateAccount(FieldElement),
-    StopImpersonatingAccount(FieldElement),
+    StopImpersonateAccount(FieldElement),
     AutoImpersonate,
     StopAutoImpersonate,
 }

--- a/crates/starknet-devnet/tests/test_account_impersonation.rs
+++ b/crates/starknet-devnet/tests/test_account_impersonation.rs
@@ -156,7 +156,7 @@ mod impersonated_account_tests {
             origin_devnet,
             &[
                 ImpersonationAction::ImpersonateAccount(account_address),
-                ImpersonationAction::StopImpersonatingAccount(account_address),
+                ImpersonationAction::StopImpersonateAccount(account_address),
             ],
         )
         .await
@@ -168,7 +168,7 @@ mod impersonated_account_tests {
             origin_devnet,
             &[
                 ImpersonationAction::ImpersonateAccount(account_address),
-                ImpersonationAction::StopImpersonatingAccount(account_address),
+                ImpersonationAction::StopImpersonateAccount(account_address),
             ],
         )
         .await


### PR DESCRIPTION
## Usage related changes

- None

## Development related changes

- In some places we refer to the action with `stopImpersonatingAccount`, when it's actually `stopImpersonateAccount`. This is only in comments and tests.

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please prefer merging over rebasing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
