### PR TITLE
Improve UX by allowing no params for JSON-RPC requests

### DIFF
--- a/crates/starknet-devnet-core/src/messaging/ethereum.rs
+++ b/crates/starknet-devnet-core/src/messaging/ethereum.rs
@@ -219,7 +219,8 @@ impl EthereumMessaging {
                 Some(receipt) => {
                     trace!(
                         "Message {:064x} sent on L1 with transaction hash {:#x}",
-                        message_hash, receipt.transaction_hash,
+                        message_hash,
+                        receipt.transaction_hash,
                     );
                 }
                 None => {

--- a/crates/starknet-devnet-server/src/api/http/endpoints/accounts.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/accounts.rs
@@ -22,9 +22,14 @@ pub struct PredeployedAccountsQuery {
 
 pub async fn get_predeployed_accounts(
     State(state): State<HttpApiHandler>,
-    Query(params): Query<Option<PredeployedAccountsQuery>>,
+    optional_params: Option<Query<PredeployedAccountsQuery>>,
 ) -> HttpApiResult<Json<Vec<SerializableAccount>>> {
-    get_predeployed_accounts_impl(&state.api, params).await.map(Json::from)
+    get_predeployed_accounts_impl(
+        &state.api,
+        optional_params.map(|query| Some(query.0)).unwrap_or(Option::None),
+    )
+    .await
+    .map(Json::from)
 }
 
 pub(crate) async fn get_balance_unit(

--- a/crates/starknet-devnet-server/src/api/http/endpoints/dump_load.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/dump_load.rs
@@ -8,12 +8,12 @@ use crate::api::Api;
 
 pub async fn dump(
     State(state): State<HttpApiHandler>,
-    Json(path): Json<DumpPath>,
+    Json(path): Json<Option<DumpPath>>,
 ) -> HttpApiResult<()> {
     dump_impl(&state.api, path).await
 }
 
-pub(crate) async fn dump_impl(api: &Api, path: DumpPath) -> HttpApiResult<()> {
+pub(crate) async fn dump_impl(api: &Api, path: Option<DumpPath>) -> HttpApiResult<()> {
     let starknet = api.starknet.write().await;
 
     if starknet.config.dump_on.is_none() {
@@ -22,7 +22,7 @@ pub(crate) async fn dump_impl(api: &Api, path: DumpPath) -> HttpApiResult<()> {
         });
     }
 
-    match path.path {
+    match path {
         None => {
             // path not present
             starknet
@@ -30,7 +30,7 @@ pub(crate) async fn dump_impl(api: &Api, path: DumpPath) -> HttpApiResult<()> {
                 .map_err(|err| HttpApiError::DumpError { msg: err.to_string() })?;
             Ok(())
         }
-        Some(path) => {
+        Some(DumpPath { path }) => {
             if !path.is_empty() {
                 // path is present and it's not empty
                 starknet

--- a/crates/starknet-devnet-server/src/api/http/endpoints/dump_load.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/dump_load.rs
@@ -1,6 +1,7 @@
 use axum::extract::State;
 use axum::Json;
 
+use super::extract_optional_json_from_request;
 use crate::api::http::error::HttpApiError;
 use crate::api::http::models::{DumpPath, LoadPath};
 use crate::api::http::{HttpApiHandler, HttpApiResult};
@@ -8,9 +9,9 @@ use crate::api::Api;
 
 pub async fn dump(
     State(state): State<HttpApiHandler>,
-    Json(path): Json<Option<DumpPath>>,
+    optional_path: Option<Json<DumpPath>>,
 ) -> HttpApiResult<()> {
-    dump_impl(&state.api, path).await
+    dump_impl(&state.api, extract_optional_json_from_request(optional_path)).await
 }
 
 pub(crate) async fn dump_impl(api: &Api, path: Option<DumpPath>) -> HttpApiResult<()> {

--- a/crates/starknet-devnet-server/src/api/http/endpoints/dump_load.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/dump_load.rs
@@ -22,30 +22,16 @@ pub(crate) async fn dump_impl(api: &Api, path: Option<DumpPath>) -> HttpApiResul
             msg: "Please provide --dump-on mode on startup.".to_string(),
         });
     }
-
-    match path {
-        None => {
-            // path not present
-            starknet
-                .dump_events()
-                .map_err(|err| HttpApiError::DumpError { msg: err.to_string() })?;
-            Ok(())
-        }
-        Some(DumpPath { path }) => {
-            if !path.is_empty() {
-                // path is present and it's not empty
-                starknet
-                    .dump_events_custom_path(Some(path))
-                    .map_err(|err| HttpApiError::DumpError { msg: err.to_string() })?;
-                Ok(())
-            } else {
-                // path is present but it's empty
-                starknet
-                    .dump_events()
-                    .map_err(|err| HttpApiError::DumpError { msg: err.to_string() })?;
-                Ok(())
-            }
-        }
+    let path = path.map_or(String::new(), |s| s.path.clone());
+    // path not present
+    if path.is_empty() {
+        starknet.dump_events().map_err(|err| HttpApiError::DumpError { msg: err.to_string() })?;
+        Ok(())
+    } else {
+        starknet
+            .dump_events_custom_path(Some(path))
+            .map_err(|err| HttpApiError::DumpError { msg: err.to_string() })?;
+        Ok(())
     }
 }
 

--- a/crates/starknet-devnet-server/src/api/http/endpoints/mod.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/mod.rs
@@ -62,3 +62,7 @@ pub async fn get_devnet_config(
         server_config: state.server_config.clone(),
     }))
 }
+
+pub(crate) fn extract_optional_json_from_request<T>(optional_json: Option<Json<T>>) -> Option<T> {
+    optional_json.map(|json| Some(json.0)).unwrap_or(Option::None)
+}

--- a/crates/starknet-devnet-server/src/api/http/endpoints/postman.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/postman.rs
@@ -20,7 +20,7 @@ pub async fn postman_load(
 
 pub async fn postman_flush(
     State(state): State<HttpApiHandler>,
-    Json(data): Json<FlushParameters>,
+    Json(data): Json<Option<FlushParameters>>,
 ) -> HttpApiResult<Json<FlushedMessages>> {
     postman_flush_impl(&state.api, data).await.map(Json::from)
 }
@@ -55,13 +55,13 @@ pub(crate) async fn postman_load_impl(
 
 pub(crate) async fn postman_flush_impl(
     api: &Api,
-    data: FlushParameters,
+    data: Option<FlushParameters>,
 ) -> HttpApiResult<FlushedMessages> {
     // Need to handle L1 to L2 first in case that those messages
     // will create L2 to L1 messages.
     let mut starknet = api.starknet.write().await;
 
-    let is_dry_run = data.dry_run.unwrap_or(false);
+    let is_dry_run = if let Some(params) = data { params.dry_run } else { false };
 
     // Fetch and execute messages to l2.
     let (messages_to_l2, generated_l2_transactions) = if is_dry_run {

--- a/crates/starknet-devnet-server/src/api/http/endpoints/postman.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/postman.rs
@@ -3,6 +3,7 @@ use axum::Json;
 use starknet_types::rpc::messaging::{MessageToL1, MessageToL2};
 use starknet_types::rpc::transactions::l1_handler_transaction::L1HandlerTransaction;
 
+use super::extract_optional_json_from_request;
 use crate::api::http::error::HttpApiError;
 use crate::api::http::models::{
     FlushParameters, FlushedMessages, MessageHash, MessagingLoadAddress,
@@ -20,9 +21,11 @@ pub async fn postman_load(
 
 pub async fn postman_flush(
     State(state): State<HttpApiHandler>,
-    Json(data): Json<Option<FlushParameters>>,
+    optional_data: Option<Json<FlushParameters>>,
 ) -> HttpApiResult<Json<FlushedMessages>> {
-    postman_flush_impl(&state.api, data).await.map(Json::from)
+    postman_flush_impl(&state.api, extract_optional_json_from_request(optional_data))
+        .await
+        .map(Json::from)
 }
 
 pub async fn postman_send_message_to_l2(

--- a/crates/starknet-devnet-server/src/api/http/models.rs
+++ b/crates/starknet-devnet-server/src/api/http/models.rs
@@ -14,7 +14,7 @@ use crate::api::http::error::HttpApiError;
 #[serde(deny_unknown_fields)]
 #[cfg_attr(test, derive(Debug))]
 pub struct DumpPath {
-    pub path: Option<String>,
+    pub path: String,
 }
 
 #[derive(Deserialize)]
@@ -152,7 +152,7 @@ pub struct FlushedMessages {
 #[serde(deny_unknown_fields)]
 #[cfg_attr(test, derive(Debug))]
 pub struct FlushParameters {
-    pub dry_run: Option<bool>,
+    pub dry_run: bool,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
@@ -468,8 +468,12 @@ impl JsonRpcHandler {
         &self,
         params: Option<PredeployedAccountsQuery>,
     ) -> StrictRpcResult {
-        let predeployed_accounts =
-            get_predeployed_accounts_impl(&self.api, params).await.map_err(ApiError::from)?;
+        let predeployed_accounts = get_predeployed_accounts_impl(
+            &self.api,
+            params.map_or(PredeployedAccountsQuery { with_balance: Option::None }, |val| val),
+        )
+        .await
+        .map_err(ApiError::from)?;
 
         Ok(DevnetResponse::PredeployedAccounts(predeployed_accounts).into())
     }

--- a/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
@@ -466,7 +466,7 @@ impl JsonRpcHandler {
     /// devnet_getPredeployedAccounts
     pub async fn get_predeployed_accounts(
         &self,
-        params: PredeployedAccountsQuery,
+        params: Option<PredeployedAccountsQuery>,
     ) -> StrictRpcResult {
         let predeployed_accounts =
             get_predeployed_accounts_impl(&self.api, params).await.map_err(ApiError::from)?;

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -1074,6 +1074,17 @@ mod requests_tests {
             json!({
                 "method":"devnet_dump",
             }),
+            json!({
+                "method":"devnet_getPredeployedAccounts",
+                "params": {"with_balance": true}
+            }),
+            json!({
+                "method":"devnet_getPredeployedAccounts",
+            }),
+            json!({
+                "method":"devnet_getPredeployedAccounts",
+                "params": {}
+            }),
         ] {
             let mut json_rpc_object = json!({
                 "jsonrpc": "2.0",

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -1075,6 +1075,10 @@ mod requests_tests {
                 "method":"devnet_dump",
             }),
             json!({
+                "method":"devnet_dump",
+                "params": {"path": "path"}
+            }),
+            json!({
                 "method":"devnet_getPredeployedAccounts",
                 "params": {"with_balance": true}
             }),
@@ -1085,6 +1089,17 @@ mod requests_tests {
                 "method":"devnet_getPredeployedAccounts",
                 "params": {}
             }),
+            json!({
+                "method":"devnet_postmanFlush",
+                "params": {"dry_run": true}
+            }),
+            json!({
+                "method":"devnet_postmanFlush",
+            }),
+            json!({
+                "method":"devnet_postmanFlush",
+                "params": {}
+            }),
         ] {
             let mut json_rpc_object = json!({
                 "jsonrpc": "2.0",
@@ -1093,7 +1108,7 @@ mod requests_tests {
 
             json_rpc_object.as_object_mut().unwrap().append(body.as_object_mut().unwrap());
 
-            let RpcMethodCall { method, params, id, .. } =
+            let RpcMethodCall { method, params, .. } =
                 serde_json::from_value(json_rpc_object).unwrap();
             let params: serde_json::Value = params.into();
             let deserializable_call = serde_json::json!({

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -50,7 +50,7 @@ use crate::api::json_rpc::models::{
     BroadcastedDeclareTransactionEnumWrapper, BroadcastedDeployAccountTransactionEnumWrapper,
     BroadcastedInvokeTransactionEnumWrapper, SimulateTransactionsInput,
 };
-use crate::api::serde_helpers::empty_params;
+use crate::api::serde_helpers::{empty_params, possible_empty_params};
 use crate::rpc_core::error::RpcError;
 use crate::rpc_core::request::RpcMethodCall;
 use crate::rpc_core::response::ResponseResult;
@@ -344,14 +344,14 @@ pub enum JsonRpcRequest {
     AutoImpersonate,
     #[serde(rename = "devnet_stopAutoImpersonate", with = "empty_params")]
     StopAutoImpersonate,
-    #[serde(rename = "devnet_dump")]
-    Dump(DumpPath),
+    #[serde(rename = "devnet_dump", with = "possible_empty_params")]
+    Dump(Option<DumpPath>),
     #[serde(rename = "devnet_load")]
     Load(LoadPath),
     #[serde(rename = "devnet_postmanLoad")]
     PostmanLoadL1MessagingContract(PostmanLoadL1MessagingContract),
-    #[serde(rename = "devnet_postmanFlush")]
-    PostmanFlush(FlushParameters),
+    #[serde(rename = "devnet_postmanFlush", with = "possible_empty_params")]
+    PostmanFlush(Option<FlushParameters>),
     #[serde(rename = "devnet_postmanSendMessageToL2")]
     PostmanSendMessageToL2(MessageToL2),
     #[serde(rename = "devnet_postmanConsumeMessageFromL2")]
@@ -366,8 +366,8 @@ pub enum JsonRpcRequest {
     SetTime(SetTime),
     #[serde(rename = "devnet_increaseTime")]
     IncreaseTime(IncreaseTime),
-    #[serde(rename = "devnet_getPredeployedAccounts")]
-    PredeployedAccounts(PredeployedAccountsQuery),
+    #[serde(rename = "devnet_getPredeployedAccounts", with = "possible_empty_params")]
+    PredeployedAccounts(Option<PredeployedAccountsQuery>),
     #[serde(rename = "devnet_getAccountBalance")]
     AccountBalance(BalanceQuery),
     #[serde(rename = "devnet_mint")]
@@ -1059,6 +1059,15 @@ mod requests_tests {
                 "method": "starknet_specVersion",
             }),
         ] {
+            assert_deserialization_succeeds(body.to_string().as_str())
+        }
+    }
+
+    #[test]
+    fn deserialize_devnet_methods_with_optional_body() {
+        for body in [json!({
+            "method": "devnet_dump"
+        })] {
             assert_deserialization_succeeds(body.to_string().as_str())
         }
     }

--- a/crates/starknet-devnet-server/src/api/json_rpc/write_endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/write_endpoints.rs
@@ -92,7 +92,7 @@ impl JsonRpcHandler {
     }
 
     /// devnet_dump
-    pub async fn dump(&self, path: DumpPath) -> StrictRpcResult {
+    pub async fn dump(&self, path: Option<DumpPath>) -> StrictRpcResult {
         dump_impl(&self.api, path).await.map_err(ApiError::from)?;
         Ok(super::JsonRpcResponse::Empty)
     }
@@ -112,7 +112,7 @@ impl JsonRpcHandler {
     }
 
     /// devnet_postmanFlush
-    pub async fn postman_flush(&self, data: FlushParameters) -> StrictRpcResult {
+    pub async fn postman_flush(&self, data: Option<FlushParameters>) -> StrictRpcResult {
         Ok(DevnetResponse::FlushedMessages(
             postman_flush_impl(&self.api, data).await.map_err(ApiError::from)?,
         )

--- a/crates/starknet-devnet-server/src/api/serde_helpers.rs
+++ b/crates/starknet-devnet-server/src/api/serde_helpers.rs
@@ -31,7 +31,6 @@ pub mod possible_empty_params {
         D: Deserializer<'de>,
         T: DeserializeOwned,
     {
-        println!("deserialize");
         let value: Value = Deserialize::deserialize(d)?;
 
         match value {
@@ -98,10 +97,10 @@ mod tests {
         let json_str = "[1, 2, 3]";
         let value: Value = serde_json::from_str(json_str).unwrap();
         let deserializer = value.into_deserializer();
-        let x: Option<Vec<u32>> = possible_empty_params::deserialize(deserializer).unwrap();
-        println!("{}", x.unwrap().len());
-        let a: Option<()> =
+        let arr: Option<Vec<u32>> = possible_empty_params::deserialize(deserializer).unwrap();
+        assert_eq!(arr, Some(vec![1, 2, 3]));
+        let empty_field: Option<()> =
             possible_empty_params::deserialize(Value::Null.into_deserializer()).unwrap();
-        assert!(a.is_none());
+        assert!(empty_field.is_none());
     }
 }

--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -167,12 +167,20 @@ impl BackgroundDevnet {
         method: &str,
         params: serde_json::Value,
     ) -> Result<serde_json::Value, RpcError> {
-        let body_json = json!({
-            "jsonrpc": "2.0",
-            "id": 0,
-            "method": method,
-            "params": params
-        });
+        let body_json = if params.is_null() {
+            json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": method
+            })
+        } else {
+            json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": method,
+                "params": params
+            })
+        };
 
         let json_rpc_result: serde_json::Value = self
             .reqwest_client()

--- a/crates/starknet-devnet/tests/test_account_selection.rs
+++ b/crates/starknet-devnet/tests/test_account_selection.rs
@@ -372,7 +372,7 @@ mod test_account_selection {
         ] {
             let http_response: serde_json::Value = devnet
                 .reqwest_client()
-                .get_json_async(&http_endpoint_path, http_query.map(|s| s.to_string()))
+                .get_json_async(http_endpoint_path, http_query.map(|s| s.to_string()))
                 .await
                 .unwrap();
 

--- a/crates/starknet-devnet/tests/test_account_selection.rs
+++ b/crates/starknet-devnet/tests/test_account_selection.rs
@@ -22,6 +22,7 @@ mod test_account_selection {
 
     use crate::common::background_devnet::BackgroundDevnet;
     use crate::common::constants::{CHAIN_ID, MAINNET_URL};
+    use crate::common::reqwest_client::GetReqwestSender;
     use crate::common::utils::{
         assert_tx_successful, deploy_argent_account, deploy_oz_account,
         get_simple_contract_in_sierra_and_compiled_class_hash,
@@ -348,6 +349,37 @@ mod test_account_selection {
                     }
                 )
             );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_http_and_json_rpc_variants_behave_the_same() {
+        let devnet = BackgroundDevnet::spawn_with_additional_args(&[
+            "--accounts",
+            "10",
+            "--initial-balance",
+            "1",
+        ])
+        .await
+        .unwrap();
+
+        let http_endpoint_path = "/predeployed_accounts";
+        for (json_rpc_params, http_query) in [
+            (json!({}), Some("")),
+            (serde_json::Value::Null, None),
+            (json!({"with_balance": false}), Some("with_balance=false")),
+            (json!({"with_balance": true}), Some("with_balance=true")),
+        ] {
+            let http_response: serde_json::Value = devnet
+                .reqwest_client()
+                .get_json_async(&http_endpoint_path, http_query.map(|s| s.to_string()))
+                .await
+                .unwrap();
+
+            let json_rpc_response: serde_json::Value =
+                get_predeployed_accounts(&devnet, json_rpc_params).await;
+
+            assert_eq!(http_response, json_rpc_response);
         }
     }
 }


### PR DESCRIPTION
## Usage related changes
devnet_dump, devnet_getPredeployedAccounts, devnet_postmanFlush take optional parameters, therefore the params property of the JSON-RPC request can be omitted. The same applies to the HTTP endpoint.

## Development related changes

Fixed utility methods
Added new deserialization helper for constructing Optional types during deserialization

## Checklist:

- [ ] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
- [ ] No spelling errors - `./scripts/check_spelling.sh`
- [ ] Performed code self-review
- [ ] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please prefer merging over rebasing
- [ ] Updated the docs if needed - `./website/README.md`
- [ ] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
