### PR TITLE
Fix predeployed ERC20 storage

### DIFF
--- a/crates/starknet-devnet-core/src/starknet/predeployed.rs
+++ b/crates/starknet-devnet-core/src/starknet/predeployed.rs
@@ -1,5 +1,5 @@
 use blockifier::state::state_api::State;
-use starknet_rs_core::utils::get_selector_from_name;
+use starknet_rs_core::utils::cairo_short_string_to_felt;
 use starknet_types::contract_address::ContractAddress;
 use starknet_types::felt::Felt;
 
@@ -33,13 +33,13 @@ pub(crate) fn initialize_erc20_at_address(
     for (storage_var_name, storage_value) in [
         (
             "ERC20_name",
-            get_selector_from_name(erc20_name)
+            cairo_short_string_to_felt(erc20_name)
                 .map_err(|err| Error::UnexpectedInternalError { msg: err.to_string() })?
                 .into(),
         ),
         (
             "ERC20_symbol",
-            get_selector_from_name(erc20_symbol)
+            cairo_short_string_to_felt(erc20_symbol)
                 .map_err(|err| Error::UnexpectedInternalError { msg: err.to_string() })?
                 .into(),
         ),


### PR DESCRIPTION
## Usage related changes

- Close #544 

## Development related changes

- For storage values, use short cairo string parsing instead of selector or storage var address (those should be used for keys, not values)

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please prefer merging over rebasing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
