### PR TITLE
Check casm hash on declaration

### DIFF
--- a/crates/starknet-devnet-core/src/error.rs
+++ b/crates/starknet-devnet-core/src/error.rs
@@ -67,6 +67,8 @@ pub enum Error {
     MessagingError(#[from] MessagingError),
     #[error("Transaction has no trace")]
     NoTransactionTrace,
+    #[error("the compiled class hash did not match the one supplied in the transaction")]
+    CompiledClassHashMismatch,
 }
 
 #[derive(Debug, Error)]

--- a/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
@@ -1,5 +1,6 @@
 use blockifier::transaction::transactions::ExecutableTransaction;
-use starknet_types::felt::{ClassHash, TransactionHash};
+use starknet_types::contract_class::ContractClass;
+use starknet_types::felt::{ClassHash, CompiledClassHash, Felt, TransactionHash};
 use starknet_types::rpc::transactions::declare_transaction_v0v1::DeclareTransactionV0V1;
 use starknet_types::rpc::transactions::declare_transaction_v2::DeclareTransactionV2;
 use starknet_types::rpc::transactions::declare_transaction_v3::DeclareTransactionV3;
@@ -11,6 +12,7 @@ use super::dump::DumpEvent;
 use crate::error::{DevnetResult, Error};
 use crate::starknet::Starknet;
 use crate::state::CustomState;
+use crate::utils::calculate_casm_hash;
 
 pub fn add_declare_transaction(
     starknet: &mut Starknet,
@@ -34,7 +36,7 @@ pub fn add_declare_transaction(
     let transaction_hash = blockifier_declare_transaction.tx_hash().0.into();
     let class_hash = blockifier_declare_transaction.class_hash().0.into();
 
-    let (declare_transaction, contract_class, sender_address) =
+    let (declare_transaction, contract_class, casm_hash, sender_address) =
         match broadcasted_declare_transaction {
             BroadcastedDeclareTransaction::V1(ref v1) => {
                 let declare_transaction = Transaction::Declare(DeclareTransaction::V1(
@@ -42,23 +44,35 @@ pub fn add_declare_transaction(
                 ));
 
                 // TODO cloning necessary?
-                (declare_transaction, v1.contract_class.clone().into(), &v1.sender_address)
+                (declare_transaction, v1.contract_class.clone().into(), None, &v1.sender_address)
             }
             BroadcastedDeclareTransaction::V2(ref v2) => {
                 let declare_transaction = Transaction::Declare(DeclareTransaction::V2(
                     DeclareTransactionV2::new(v2, class_hash),
                 ));
 
-                (declare_transaction, v2.contract_class.clone().into(), &v2.sender_address)
+                (
+                    declare_transaction,
+                    v2.contract_class.clone().into(),
+                    Some(v2.compiled_class_hash),
+                    &v2.sender_address,
+                )
             }
             BroadcastedDeclareTransaction::V3(ref v3) => {
                 let declare_transaction = Transaction::Declare(DeclareTransaction::V3(
                     DeclareTransactionV3::new(v3, class_hash),
                 ));
 
-                (declare_transaction, v3.contract_class.clone().into(), &v3.sender_address)
+                (
+                    declare_transaction,
+                    v3.contract_class.clone().into(),
+                    Some(v3.compiled_class_hash),
+                    &v3.sender_address,
+                )
             }
         };
+
+    assert_casm_hash_is_valid(&contract_class, casm_hash)?;
 
     let validate = !(Starknet::is_account_impersonated(
         &mut starknet.pending_state,
@@ -81,7 +95,7 @@ pub fn add_declare_transaction(
     // if tx successful, store the class
     if blockifier_execution_result.as_ref().is_ok_and(|res| !res.is_reverted()) {
         let state = starknet.get_state();
-        state.declare_contract_class(class_hash, contract_class)?;
+        state.declare_contract_class(class_hash, casm_hash, contract_class)?;
     }
 
     // do the steps required in all transactions
@@ -92,6 +106,39 @@ pub fn add_declare_transaction(
 
     Ok((transaction_hash, class_hash))
 }
+
+/// Convert `contract_class` to casm, calculate its hash and assert it's equal to
+/// `received_casm_hash`
+fn assert_casm_hash_is_valid(
+    contract_class: &ContractClass,
+    received_casm_hash: Option<CompiledClassHash>,
+) -> DevnetResult<()> {
+    match (contract_class, received_casm_hash) {
+        (ContractClass::Cairo0(_), None) => Ok(()), // if cairo0, casm_hash expected to be None
+        (ContractClass::Cairo1(cairo_lang_contract_class), Some(received_casm_hash)) => {
+            let casm_json = usc::compile_contract(
+                serde_json::to_value(cairo_lang_contract_class)
+                    .map_err(|err| Error::SerializationError { origin: err.to_string() })?,
+            )
+            .map_err(|err| {
+                Error::TypesError(starknet_types::error::Error::SierraCompilationError {
+                    reason: err.to_string(),
+                })
+            })?;
+
+            let calculated_casm_hash = Felt::from(calculate_casm_hash(casm_json)?);
+            if calculated_casm_hash == received_casm_hash {
+                Ok(())
+            } else {
+                Err(Error::CompiledClassHashMismatch)
+            }
+        }
+        unexpected => Err(Error::UnexpectedInternalError {
+            msg: format!("Unexpected class and casm combination: {unexpected:?}"),
+        }),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use blockifier::state::state_api::StateReader;

--- a/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
@@ -43,7 +43,6 @@ pub fn add_declare_transaction(
                     DeclareTransactionV0V1::new(v1, class_hash),
                 ));
 
-                // TODO cloning necessary?
                 (declare_transaction, v1.contract_class.clone().into(), None, &v1.sender_address)
             }
             BroadcastedDeclareTransaction::V2(ref v2) => {

--- a/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
@@ -106,8 +106,8 @@ pub fn add_declare_transaction(
     Ok((transaction_hash, class_hash))
 }
 
-/// Convert `contract_class` to casm, calculate its hash and assert it's equal to
-/// `received_casm_hash`
+/// If cairo1, convert `contract_class` to casm, calculate its hash and assert it's equal to
+/// `received_casm_hash`. If cairo0, assert no `received_casm_hash`.
 fn assert_casm_hash_is_valid(
     contract_class: &ContractClass,
     received_casm_hash: Option<CompiledClassHash>,
@@ -120,9 +120,8 @@ fn assert_casm_hash_is_valid(
                     .map_err(|err| Error::SerializationError { origin: err.to_string() })?,
             )
             .map_err(|err| {
-                Error::TypesError(starknet_types::error::Error::SierraCompilationError {
-                    reason: err.to_string(),
-                })
+                let reason = err.to_string();
+                Error::TypesError(starknet_types::error::Error::SierraCompilationError { reason })
             })?;
 
             let calculated_casm_hash = Felt::from(calculate_casm_hash(casm_json)?);

--- a/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
@@ -409,7 +409,10 @@ mod tests {
         let contract_class = cairo_0_account_without_validations();
         let class_hash = contract_class.generate_hash().unwrap();
 
-        starknet.pending_state.declare_contract_class(class_hash, contract_class.into()).unwrap();
+        starknet
+            .pending_state
+            .declare_contract_class(class_hash, None, contract_class.into())
+            .unwrap();
         starknet.block_context = Starknet::init_block_context(
             nonzero!(1u128),
             nonzero!(1u128),

--- a/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
@@ -63,7 +63,7 @@ pub fn add_deploy_account_transaction(
         )
         .execute(&mut starknet.pending_state.state, &starknet.block_context, true, true);
 
-    starknet.handle_transaction_result(transaction, None, blockifier_execution_result)?;
+    starknet.handle_transaction_result(transaction, blockifier_execution_result)?;
     starknet.handle_dump_event(DumpEvent::AddDeployAccountTransaction(
         broadcasted_deploy_account_transaction,
     ))?;

--- a/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
@@ -534,7 +534,7 @@ mod tests {
         // declare dummy contract
         starknet
             .pending_state
-            .declare_contract_class(dummy_contract_class_hash, dummy_contract.into())
+            .declare_contract_class(dummy_contract_class_hash, None, dummy_contract.into())
             .unwrap();
 
         // deploy dummy contract

--- a/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
@@ -57,7 +57,7 @@ pub fn add_invoke_transaction(
 
     let transaction = TransactionWithHash::new(transaction_hash, invoke_transaction);
 
-    starknet.handle_transaction_result(transaction, None, blockifier_execution_result)?;
+    starknet.handle_transaction_result(transaction, blockifier_execution_result)?;
     starknet.handle_dump_event(DumpEvent::AddInvokeTransaction(broadcasted_invoke_transaction))?;
 
     Ok(transaction_hash)

--- a/crates/starknet-devnet-core/src/starknet/add_l1_handler_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_l1_handler_transaction.rs
@@ -32,7 +32,6 @@ pub fn add_l1_handler_transaction(
 
     starknet.handle_transaction_result(
         TransactionWithHash::new(transaction_hash, Transaction::L1Handler(transaction.clone())),
-        None,
         blockifier_execution_result,
     )?;
     starknet.handle_dump_event(DumpEvent::AddL1HandlerTransaction(transaction))?;

--- a/crates/starknet-devnet-core/src/starknet/add_l1_handler_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_l1_handler_transaction.rs
@@ -250,7 +250,7 @@ mod tests {
         // declare dummy contract
         starknet
             .pending_state
-            .declare_contract_class(dummy_contract_class_hash, dummy_contract.into())
+            .declare_contract_class(dummy_contract_class_hash, None, dummy_contract.into())
             .unwrap();
 
         // deploy dummy contract

--- a/crates/starknet-devnet-core/src/starknet/state_update.rs
+++ b/crates/starknet-devnet-core/src/starknet/state_update.rs
@@ -29,7 +29,7 @@ mod tests {
     use crate::starknet::tests::setup_starknet_with_no_signature_check_account;
     use crate::state::state_diff::StateDiff;
     use crate::traits::HashIdentifiedMut;
-    use crate::utils::casm_hash;
+    use crate::utils::calculate_casm_hash;
     use crate::utils::test_utils::dummy_cairo_1_contract_class;
 
     #[test]
@@ -44,7 +44,7 @@ mod tests {
         let casm_contract_class_json =
             usc::compile_contract(serde_json::to_value(contract_class.clone()).unwrap()).unwrap();
 
-        let compiled_class_hash = casm_hash(casm_contract_class_json).unwrap().into();
+        let compiled_class_hash = calculate_casm_hash(casm_contract_class_json).unwrap().into();
 
         let declare_txn = BroadcastedDeclareTransactionV2::new(
             &contract_class,

--- a/crates/starknet-devnet-core/src/state/mod.rs
+++ b/crates/starknet-devnet-core/src/state/mod.rs
@@ -40,11 +40,14 @@ pub trait CustomStateReader {
 }
 
 pub trait CustomState {
+    /// Link class with its hash; if cairo1 class: calculate casm hash, link class hash with it
     fn predeclare_contract_class(
         &mut self,
         class_hash: ClassHash,
         contract_class: ContractClass,
     ) -> DevnetResult<()>;
+
+    /// Link class with its hash; if cairo1 class: link class hash with casm hash
     fn declare_contract_class(
         &mut self,
         class_hash: ClassHash,
@@ -405,7 +408,6 @@ impl CustomState for StarknetState {
         casm_hash: Option<starknet_types::felt::CompiledClassHash>,
         contract_class: ContractClass,
     ) -> DevnetResult<()> {
-        // TODO can the cloned+converted class be received as method param
         let compiled_class = contract_class.clone().try_into()?;
 
         if let Some(casm_hash) = casm_hash {

--- a/crates/starknet-devnet-core/src/state/mod.rs
+++ b/crates/starknet-devnet-core/src/state/mod.rs
@@ -16,7 +16,7 @@ use self::state_diff::StateDiff;
 use self::state_readers::DictState;
 use crate::error::{DevnetResult, Error};
 use crate::starknet::defaulter::StarknetDefaulter;
-use crate::utils::casm_hash;
+use crate::utils::calculate_casm_hash;
 
 pub(crate) mod state_diff;
 pub(crate) mod state_readers;
@@ -48,6 +48,7 @@ pub trait CustomState {
     fn declare_contract_class(
         &mut self,
         class_hash: ClassHash,
+        casm_hash: Option<starknet_types::felt::CompiledClassHash>,
         contract_class: ContractClass,
     ) -> DevnetResult<()>;
 
@@ -387,7 +388,7 @@ impl CustomState for StarknetState {
                 })
             })?;
 
-            let casm_hash = Felt::from(casm_hash(casm_json)?);
+            let casm_hash = Felt::from(calculate_casm_hash(casm_json)?);
 
             self.state.state.set_compiled_class_hash(class_hash.into(), casm_hash.into())?;
         };
@@ -401,22 +402,13 @@ impl CustomState for StarknetState {
     fn declare_contract_class(
         &mut self,
         class_hash: ClassHash,
+        casm_hash: Option<starknet_types::felt::CompiledClassHash>,
         contract_class: ContractClass,
     ) -> DevnetResult<()> {
+        // TODO can the cloned+converted class be received as method param
         let compiled_class = contract_class.clone().try_into()?;
 
-        if let ContractClass::Cairo1(cairo_lang_contract_class) = &contract_class {
-            let casm_json = usc::compile_contract(
-                serde_json::to_value(cairo_lang_contract_class)
-                    .map_err(|err| Error::SerializationError { origin: err.to_string() })?,
-            )
-            .map_err(|err| {
-                Error::TypesError(starknet_types::error::Error::SierraCompilationError {
-                    reason: err.to_string(),
-                })
-            })?;
-
-            let casm_hash = Felt::from(casm_hash(casm_json)?);
+        if let Some(casm_hash) = casm_hash {
             self.set_compiled_class_hash(class_hash.into(), casm_hash.into())?;
         };
 
@@ -464,9 +456,10 @@ mod tests {
         let mut state = StarknetState::default();
 
         let class_hash = dummy_felt();
+        let casm_hash = Some(dummy_felt());
         let contract_class = ContractClass::Cairo0(dummy_cairo_0_contract_class().into());
 
-        state.declare_contract_class(class_hash, contract_class).unwrap();
+        state.declare_contract_class(class_hash, casm_hash, contract_class).unwrap();
         assert!(state.is_contract_declared(dummy_felt()));
     }
 
@@ -511,6 +504,7 @@ mod tests {
     fn declare_cairo_0_contract_class_successfully() {
         let mut state = StarknetState::default();
         let class_hash = Felt::from_prefixed_hex_str("0xFE").unwrap();
+        let casm_hash = Some(dummy_felt());
 
         match state.get_compiled_contract_class(class_hash.into()) {
             Err(StateError::UndeclaredClassHash(reported_hash)) => {
@@ -521,7 +515,11 @@ mod tests {
 
         let contract_class: Cairo0ContractClass = dummy_cairo_0_contract_class().into();
         state
-            .declare_contract_class(class_hash, contract_class.clone().try_into().unwrap())
+            .declare_contract_class(
+                class_hash,
+                casm_hash,
+                contract_class.clone().try_into().unwrap(),
+            )
             .unwrap();
 
         let block_number = 1;
@@ -613,8 +611,9 @@ mod tests {
         let address = dummy_contract_address();
         let contract_class = dummy_cairo_0_contract_class();
         let class_hash = dummy_felt();
+        let casm_hash = Some(dummy_felt());
 
-        state.declare_contract_class(class_hash, contract_class.into()).unwrap();
+        state.declare_contract_class(class_hash, casm_hash, contract_class.into()).unwrap();
         state.predeploy_contract(address, class_hash).unwrap();
 
         (state, address)

--- a/crates/starknet-devnet-core/src/state/state_diff.rs
+++ b/crates/starknet-devnet-core/src/state/state_diff.rs
@@ -292,7 +292,7 @@ mod tests {
         // declare cairo1
         {
             let class_hash = Felt::from(1);
-            let casm_hash: Felt = Felt::from(2);
+            let casm_hash = Felt::from_prefixed_hex_str(DUMMY_CAIRO_1_COMPILED_CLASS_HASH).unwrap();
             let contract_class = ContractClass::Cairo1(dummy_cairo_1_contract_class());
             state.declare_contract_class(class_hash, Some(casm_hash), contract_class).unwrap();
 

--- a/crates/starknet-devnet-core/src/state/state_diff.rs
+++ b/crates/starknet-devnet-core/src/state/state_diff.rs
@@ -207,9 +207,10 @@ mod tests {
         let mut state = setup();
 
         let class_hash = StarkFelt::from(1u8);
+        let casm_hash = Some(StarkFelt::from(1u8).into());
 
         let contract_class = ContractClass::Cairo1(dummy_cairo_1_contract_class());
-        state.declare_contract_class(class_hash.into(), contract_class).unwrap();
+        state.declare_contract_class(class_hash.into(), casm_hash, contract_class).unwrap();
 
         let block_number = 1;
         let new_classes = state.rpc_contract_classes.write().commit(block_number);
@@ -231,8 +232,9 @@ mod tests {
         let mut state = setup();
 
         let class_hash = Felt::from(1);
+        let casm_hash = Some(Felt::from(1));
         let contract_class = ContractClass::Cairo1(dummy_cairo_1_contract_class());
-        state.declare_contract_class(class_hash, contract_class).unwrap();
+        state.declare_contract_class(class_hash, casm_hash, contract_class).unwrap();
 
         let block_number = 1;
         let new_classes = state.rpc_contract_classes.write().commit(block_number);
@@ -253,7 +255,7 @@ mod tests {
         let class_hash = Felt::from(1);
         let contract_class = ContractClass::Cairo0(dummy_cairo_0_contract_class().into());
 
-        state.declare_contract_class(class_hash, contract_class).unwrap();
+        state.declare_contract_class(class_hash, None, contract_class).unwrap();
 
         let block_number = 1;
         let new_classes = state.rpc_contract_classes.write().commit(block_number);
@@ -276,7 +278,7 @@ mod tests {
             let class_hash = Felt::from(1);
             let contract_class = ContractClass::Cairo0(dummy_cairo_0_contract_class().into());
 
-            state.declare_contract_class(class_hash, contract_class).unwrap();
+            state.declare_contract_class(class_hash, None, contract_class).unwrap();
 
             let block_number = 1;
             let new_classes = state.rpc_contract_classes.write().commit(block_number);
@@ -293,8 +295,9 @@ mod tests {
         // declare cairo1
         {
             let class_hash = Felt::from(2);
+            let casm_hash = Some(Felt::from(2));
             let contract_class = ContractClass::Cairo1(dummy_cairo_1_contract_class());
-            state.declare_contract_class(class_hash, contract_class).unwrap();
+            state.declare_contract_class(class_hash, casm_hash, contract_class).unwrap();
 
             let block_number = 1;
             let new_classes = state.rpc_contract_classes.write().commit(block_number);

--- a/crates/starknet-devnet-core/src/utils.rs
+++ b/crates/starknet-devnet-core/src/utils.rs
@@ -48,7 +48,7 @@ pub(crate) fn get_versioned_constants() -> VersionedConstants {
 /// Returns the hash of a compiled class.
 /// # Arguments
 /// * `casm_json` - The compiled class in JSON format.
-pub fn casm_hash(casm_json: Value) -> DevnetResult<FieldElement> {
+pub fn calculate_casm_hash(casm_json: Value) -> DevnetResult<FieldElement> {
     serde_json::from_value::<CompiledClass>(casm_json)
         .map_err(|err| Error::DeserializationError { origin: err.to_string() })?
         .class_hash()
@@ -72,7 +72,7 @@ pub(crate) mod test_utils {
     };
     use starknet_types::traits::HashProducer;
 
-    use super::casm_hash;
+    use super::calculate_casm_hash;
     use crate::constants::DEVNET_DEFAULT_CHAIN_ID;
     use crate::utils::exported_test_utils::dummy_cairo_0_contract_class;
 
@@ -130,7 +130,7 @@ pub(crate) mod test_utils {
         let casm_contract_class_json =
             usc::compile_contract(serde_json::to_value(contract_class.clone()).unwrap()).unwrap();
 
-        let compiled_class_hash = casm_hash(casm_contract_class_json).unwrap().into();
+        let compiled_class_hash = calculate_casm_hash(casm_contract_class_json).unwrap().into();
 
         BroadcastedDeclareTransactionV2::new(
             &contract_class,

--- a/crates/starknet-devnet-server/src/api/json_rpc/error.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/error.rs
@@ -58,6 +58,8 @@ pub enum ApiError {
     NoStateAtBlock { msg: String },
     #[error(transparent)]
     HttpApiError(#[from] HttpApiError),
+    #[error("the compiled class hash did not match the one supplied in the transaction")]
+    CompiledClassHashMismatch,
 }
 
 impl ApiError {
@@ -163,6 +165,11 @@ impl ApiError {
                 code: crate::rpc_core::error::ErrorCode::ServerError(55),
                 message: error_message.into(),
                 data: Some(serde_json::Value::String(reason)),
+            },
+            ApiError::CompiledClassHashMismatch => RpcError {
+                code: crate::rpc_core::error::ErrorCode::ServerError(60),
+                message: error_message.into(),
+                data: None,
             },
             ApiError::StarknetDevnetError(
                 starknet_core::error::Error::TransactionValidationError(validation_error),

--- a/crates/starknet-devnet-server/src/api/json_rpc/write_endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/write_endpoints.rs
@@ -31,7 +31,14 @@ impl JsonRpcHandler {
         request: BroadcastedDeclareTransaction,
     ) -> StrictRpcResult {
         let (transaction_hash, class_hash) =
-            self.api.starknet.write().await.add_declare_transaction(request)?;
+            self.api.starknet.write().await.add_declare_transaction(request).map_err(|err| {
+                match err {
+                    starknet_core::error::Error::CompiledClassHashMismatch => {
+                        ApiError::CompiledClassHashMismatch
+                    }
+                    unknown_error => ApiError::StarknetDevnetError(unknown_error),
+                }
+            })?;
 
         Ok(StarknetResponse::AddDeclareTransaction(DeclareTransactionOutput {
             transaction_hash,

--- a/crates/starknet-devnet/tests/common/utils.rs
+++ b/crates/starknet-devnet/tests/common/utils.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use server::test_utils::exported_test_utils::assert_contains;
 use starknet_core::constants::CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH;
 use starknet_core::random_number_generator::generate_u32_random_number;
-use starknet_core::utils::casm_hash;
+use starknet_core::utils::calculate_casm_hash;
 use starknet_rs_accounts::{
     Account, AccountFactory, ArgentAccountFactory, OpenZeppelinAccountFactory, SingleOwnerAccount,
 };
@@ -65,7 +65,7 @@ pub fn get_flattened_sierra_contract_and_casm_hash(sierra_path: &str) -> SierraW
     let sierra_string = std::fs::read_to_string(sierra_path).unwrap();
     let sierra_class: SierraClass = serde_json::from_str(&sierra_string).unwrap();
     let casm_json = usc::compile_contract(serde_json::from_str(&sierra_string).unwrap()).unwrap();
-    (sierra_class.flatten().unwrap(), casm_hash(casm_json).unwrap())
+    (sierra_class.flatten().unwrap(), calculate_casm_hash(casm_json).unwrap())
 }
 
 pub fn get_messaging_contract_in_sierra_and_compiled_class_hash() -> SierraWithCasmHash {

--- a/crates/starknet-devnet/tests/get_transaction_by_hash.rs
+++ b/crates/starknet-devnet/tests/get_transaction_by_hash.rs
@@ -70,7 +70,6 @@ mod get_transaction_by_hash_integration_tests {
         );
         account.set_block_id(BlockId::Tag(BlockTag::Latest));
 
-        // We need to flatten the ABI into a string first
         let declare_result = account
             .declare(Arc::new(contract_class), casm_hash)
             .nonce(FieldElement::ZERO)


### PR DESCRIPTION
## Usage related changes

- Close #540
- Return `COMPILED_CLASS_HASH_MISMATCH` error (code 60) when appropriate
  - [Starknet JSON-RPC API docs](https://github.com/starkware-libs/starknet-specs/blob/76bdde23c7dae370a3340e40f7ca2ef2520e75b9/api/starknet_write_api.json#L280-L283)

## Development related changes

- Casm hash calculation and checking added just before declaration tx execution.
- Refactor declaration:
  - Class storing done in `add_declare_transaction` instead of in `handle_transction_result`
    - No more need for the optional parameter as the second argument used by all tx types (though just needed for declaration transactions)
    - Optionality moved to `declare_contract_class` as `casm_hash` - used only when declaring a cairo1 class
- Rename `fn casm_hash` to `fn calculate_casm_hash`.
- Improve doc comments of `CustomState`.
- Simplify expected state diff construction in state diff tests.

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please prefer merging over rebasing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
