### PR TITLE
Fix nightly version in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,6 @@ jobs:
           keys:
             - << parameters.cargo_cache_key >>
       - run:
-          # this step doesn't need to be cached, it's relatively fast (15s on Docker/X-Large)
           name: Install nightly-2024-07-08
           command: rustup install nightly-2024-07-08
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ jobs:
           # Test also generates, but significantly more
           # Compromise: saving before Test
           paths:
+            - /home/circleci/.rustup/toolchains
             - /home/circleci/.cargo/registry
             - target/debug/.fingerprint
             - target/debug/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
       - run:
           # this step doesn't need to be cached, it's relatively fast (15s on Docker/X-Large)
           name: Install nightly
-          command: rustup install nightly
+          command: rustup install nightly-2024-07-08
       - run:
           name: Install foundry
           command: ./scripts/install_foundry.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
             - << parameters.cargo_cache_key >>
       - run:
           # this step doesn't need to be cached, it's relatively fast (15s on Docker/X-Large)
-          name: Install nightly
+          name: Install nightly-2024-07-08
           command: rustup install nightly-2024-07-08
       - run:
           name: Install foundry
@@ -69,7 +69,7 @@ jobs:
           command: ./scripts/clippy_check.sh
       - run:
           name: Format check
-          command: cargo +nightly fmt --all --check
+          command: cargo +nightly-2024-07-08 fmt --all --check
       - run:
           name: Code spell check
           command: ./scripts/check_spelling.sh

--- a/scripts/check_spelling.sh
+++ b/scripts/check_spelling.sh
@@ -3,6 +3,6 @@
 set -eu
 
 # should skip if already installed
-cargo +nightly install typos-cli
+cargo +nightly-2024-07-08 install typos-cli
 
 typos

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-cargo +nightly fmt --all
+cargo +nightly-2024-07-08 fmt --all
 
 # Format documentation code
 cd website


### PR DESCRIPTION
## Development related changes

CI pipeline uses fixed version of nightly toolchain. The reason for it is that in the CI nightly channel is downloaded, which is the latest one. There were cases where the devs nightly channel on their computer was different from the downloaded during CI pipeline and it broke the workflow

## Checklist:

- [ ] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
- [ ] No spelling errors - `./scripts/check_spelling.sh`
- [ ] Performed code self-review
- [ ] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please prefer merging over rebasing
- [ ] Updated the docs if needed - `./website/README.md`
- [ ] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
