### PR TITLE
Add documentation formatting check to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
           command: ./scripts/clippy_check.sh
       - run:
           name: Format check
-          command: cargo +nightly-2024-07-08 fmt --all --check
+          command: ./scripts/format_check.sh
       - run:
           name: Code spell check
           command: ./scripts/check_spelling.sh

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,8 +7,7 @@ To release a new Devnet version, follow these steps:
 2. Add a documentation entry for the incoming version by running:
 
    ```
-   $ cd website
-   $ npm run docusaurus docs:version <VERSION>
+   $ npm --prefix website run docusaurus docs:version <VERSION>
    ```
 
 3. Create a PR styled after [this one](https://github.com/0xSpaceShard/starknet-devnet-rs/pull/473).

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -4,7 +4,5 @@ set -eu
 
 cargo +nightly-2024-07-08 fmt --all
 
-# Format documentation code
-cd website
-npm run format
-cd ..
+# Format documentation
+npm --prefix website run format

--- a/scripts/format_check.sh
+++ b/scripts/format_check.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cargo +nightly-2024-07-08 fmt --all --check
+cd website
+npm run format-check
+cd ..

--- a/scripts/format_check.sh
+++ b/scripts/format_check.sh
@@ -3,6 +3,6 @@
 set -euo pipefail
 
 cargo +nightly-2024-07-08 fmt --all --check
-cd website
-npm run format-check
-cd ..
+
+# Format documentation
+npm --prefix website run format-check


### PR DESCRIPTION
## Usage related changes

None

## Development related changes

- What the title says
- Instead of doing `cd website` and `cd ..`, rely on `npm --prefix`.

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please prefer merging over rebasing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
