### PR TITLE
Move CI build and test step to self-hosted runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
       - run:
           name: Integration tests
           # fails if jobs not limited; read more in https://github.com/0xSpaceShard/starknet-devnet-rs/issues/378
-          command: cargo test --jobs 6 --test '*' --no-fail-fast
+          command: cargo test --jobs 9 --test '*' --no-fail-fast
 
   binary-build:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,9 +46,8 @@ jobs:
     parameters:
       cargo_cache_key:
         type: string
-    docker:
-      - image: cimg/rust:1.74.0
-    resource_class: xlarge
+    machine: true
+    resource_class: spaceshard/ax41
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,11 +88,11 @@ jobs:
           key: << parameters.cargo_cache_key >>
       - run:
           name: Unit tests
-          command: cargo test --jobs 7 --lib --bins --no-fail-fast
+          command: cargo test --lib --bins --no-fail-fast
       - run:
           name: Integration tests
           # fails if jobs not limited; read more in https://github.com/0xSpaceShard/starknet-devnet-rs/issues/378
-          command: cargo test --jobs 3 --test '*' --no-fail-fast
+          command: cargo test --jobs 6 --test '*' --no-fail-fast
 
   binary-build:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,9 +50,6 @@ jobs:
     resource_class: spaceshard/ax41
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - << parameters.cargo_cache_key >>
       - run:
           name: Install nightly-2024-07-08
           command: rustup install nightly-2024-07-08
@@ -71,21 +68,6 @@ jobs:
       - run:
           name: Code spell check
           command: ./scripts/check_spelling.sh
-      - save_cache:
-          # Caching dependencies for future use
-          # Build and Clippy steps generate their own target artifacts
-          # Test also generates, but significantly more
-          # Compromise: saving before Test
-          paths:
-            - /home/circleci/.rustup/toolchains
-            - /home/circleci/.cargo/registry
-            - target/debug/.fingerprint
-            - target/debug/build
-            - target/debug/deps
-            - target/release/.fingerprint
-            - target/release/build
-            - target/release/deps
-          key: << parameters.cargo_cache_key >>
       - run:
           name: Unit tests
           command: cargo test --lib --bins --no-fail-fast


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

## Development related changes

This PR speeds up workflow and reduces incurred costs. Changes made:
 - Changed resource class to our self-hosted runner
 - Deleted cache - benefit is marginal (2 mins), but it spends credits
 - Increased test concurrency - new machine has more resources so it can support more jobs at once

TLDR: CI runtime for building is now around 16 minutes.

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x]  No unused dependencies - `./scripts/check_unused_deps.sh`
- [x]  No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please prefer merging over rebasing
- [x]  Updated the docs if needed - `./website/README.md`
- [x]  Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x]  Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
