### PR TITLE
Block interval improvment

### DIFF
--- a/crates/starknet-devnet/src/main.rs
+++ b/crates/starknet-devnet/src/main.rs
@@ -24,7 +24,7 @@ use starknet_types::traits::ToHexString;
 use tokio::net::TcpListener;
 use tokio::signal::unix::{signal, SignalKind};
 use tokio::task::{self};
-use tokio::time::interval;
+use tokio::time::{interval, sleep};
 use tracing::{info, warn};
 use tracing_subscriber::EnvFilter;
 
@@ -233,11 +233,14 @@ async fn main() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-async fn create_block_interval(api: Api, block_interval: u64) -> Result<(), std::io::Error> {
-    let mut interval = interval(Duration::from_secs(block_interval));
+async fn create_block_interval(api: Api, block_interval_sec: u64) -> Result<(), std::io::Error> {
+    let mut interval = interval(Duration::from_secs(block_interval_sec));
     let mut sigint = signal(SignalKind::interrupt()).expect("Failed to setup SIGINT handler");
 
     loop {
+        // avoid creating block instantly after startup
+        sleep(Duration::from_secs(block_interval_sec)).await;
+
         tokio::select! {
             _ = interval.tick() => {
                 let mut starknet = api.starknet.write().await;

--- a/crates/starknet-devnet/src/main.rs
+++ b/crates/starknet-devnet/src/main.rs
@@ -233,13 +233,13 @@ async fn main() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-async fn create_block_interval(api: Api, block_interval_sec: u64) -> Result<(), std::io::Error> {
-    let mut interval = interval(Duration::from_secs(block_interval_sec));
+async fn create_block_interval(api: Api, block_interval_seconds: u64) -> Result<(), std::io::Error> {
+    let mut interval = interval(Duration::from_secs(block_interval_seconds));
     let mut sigint = signal(SignalKind::interrupt()).expect("Failed to setup SIGINT handler");
 
     loop {
         // avoid creating block instantly after startup
-        sleep(Duration::from_secs(block_interval_sec)).await;
+        sleep(Duration::from_secs(block_interval_seconds)).await;
 
         tokio::select! {
             _ = interval.tick() => {

--- a/crates/starknet-devnet/src/main.rs
+++ b/crates/starknet-devnet/src/main.rs
@@ -233,7 +233,10 @@ async fn main() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-async fn create_block_interval(api: Api, block_interval_seconds: u64) -> Result<(), std::io::Error> {
+async fn create_block_interval(
+    api: Api,
+    block_interval_seconds: u64,
+) -> Result<(), std::io::Error> {
     let mut interval = interval(Duration::from_secs(block_interval_seconds));
     let mut sigint = signal(SignalKind::interrupt()).expect("Failed to setup SIGINT handler");
 

--- a/crates/starknet-devnet/tests/test_blocks_generation.rs
+++ b/crates/starknet-devnet/tests/test_blocks_generation.rs
@@ -511,34 +511,24 @@ mod blocks_generation_tests {
 
     #[tokio::test]
     async fn blocks_on_interval() {
-        let devnet = BackgroundDevnet::spawn_with_additional_args(&["--block-generation-on", "1"])
+        let devnet = BackgroundDevnet::spawn_with_additional_args(&["--block-generation-on", "2"])
             .await
             .expect("Could not start Devnet");
 
-        // wait 1 second
-        tokio::time::sleep(time::Duration::from_secs(1)).await;
+        // wait for one and a half interval
+        tokio::time::sleep(time::Duration::from_secs(3)).await;
 
         let last_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
 
-        // first is genesis block, second block is generated instantly, third is generated after 1
-        // second
-        assert_eq!(last_block.block_number, 2);
+        // first is genesis block, second block is generated after 1 second
+        assert_eq!(last_block.block_number, 1);
     }
 
     #[tokio::test]
-    /// In the following sketch, above are seconds, B means block:
-    ///
-    /// 0     1     2     3     4     5     6     7     8     9
-    /// |--|--|-----|-----|-----|--|--|-----|--|--|-----|--|--|
-    /// |  |  |                    |           |           |
-    /// B0 B1 txs                  B2          check       B3
     async fn blocks_on_interval_transactions() {
-        let devnet = BackgroundDevnet::spawn_with_additional_args(&["--block-generation-on", "4"])
+        let devnet = BackgroundDevnet::spawn_with_additional_args(&["--block-generation-on", "2"])
             .await
             .expect("Could not start Devnet");
-
-        // sleep a bit to allow the genesis and the first automatic block to be generated
-        tokio::time::sleep(time::Duration::from_secs(1)).await;
 
         let tx_count = 3;
         let mut tx_hashes = Vec::new();
@@ -548,11 +538,10 @@ mod blocks_generation_tests {
         }
 
         // wait for one and a half interval
-        tokio::time::sleep(time::Duration::from_secs(6)).await;
+        tokio::time::sleep(time::Duration::from_secs(3)).await;
 
-        // first is genesis block, second block is generated instantly, third is generated after the
-        // first interval
-        assert_latest_block_with_tx_hashes(&devnet, 2, tx_hashes).await;
+        // first is genesis block, second block is generated after transactions
+        assert_latest_block_with_tx_hashes(&devnet, 1, tx_hashes).await;
     }
 
     #[tokio::test]
@@ -565,19 +554,18 @@ mod blocks_generation_tests {
             "--dump-on",
             mode,
             "--block-generation-on",
-            "1",
+            "2",
         ])
         .await
         .expect("Could not start Devnet");
 
-        // wait 1 second
-        tokio::time::sleep(time::Duration::from_secs(1)).await;
+        // wait for one and a half interval
+        tokio::time::sleep(time::Duration::from_secs(3)).await;
 
         let last_block = devnet_dump.get_latest_block_with_tx_hashes().await.unwrap();
 
-        // first is genesis block, second block is generated instantly, third is generated after 1
-        // second
-        assert_eq!(last_block.block_number, 2);
+        // first is genesis block, second block is generated after 1 second
+        assert_eq!(last_block.block_number, 1);
 
         send_ctrl_c_signal_and_wait(&devnet_dump.process).await;
 


### PR DESCRIPTION
## Usage related changes

- In `--block-generation-on` interval mode, the first block is generated after time interval, rather than being generated instantly as it was before.

## Development related changes

- use longer time periods in block on interval tests to avoid failed ci/cd

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please prefer merging over rebasing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
