### PR TITLE
Fix L1-L2 documentation mistakes

### DIFF
--- a/website/docs/postman.md
+++ b/website/docs/postman.md
@@ -10,7 +10,7 @@ POST /postman/load_l1_messaging_contract
 
 ```json
 {
-  "networkUrl": "http://localhost:8545",
+  "network_url": "http://localhost:8545",
   "address": "0x123...def"
 }
 ```
@@ -22,7 +22,7 @@ JSON-RPC
     "id": "1",
     "method": "devnet_postmanLoad",
     "params": {
-      "networkUrl": "http://localhost:8545",
+      "network_url": "http://localhost:8545",
       "address": "0x123...def"
     }
 }
@@ -120,7 +120,7 @@ Request:
       "0x1",
       "0x2"
     ],
-    "paid_fee_on_l1": "0x123456abcdef"
+    "paid_fee_on_l1": "0x123456abcdef",
     "nonce":"0x0"
 }
 ```
@@ -139,7 +139,7 @@ JSON-RPC
         "0x1",
         "0x2"
       ],
-      "paid_fee_on_l1": "0x123456abcdef"
+      "paid_fee_on_l1": "0x123456abcdef",
       "nonce":"0x0"
   }
 }
@@ -166,8 +166,8 @@ Request:
 
 ```js
 {
-    "l2_contract_address": "0x00285ddb7e5c777b310d806b9b2a0f7c7ba0a41f12b420219209d97a3b7f25b2",
-    "l1_contract_address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+    "from_address": "0x00285ddb7e5c777b310d806b9b2a0f7c7ba0a41f12b420219209d97a3b7f25b2",
+    "to_address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
     "payload": ["0x0", "0x1", "0x3e8"],
 }
 ```
@@ -179,8 +179,8 @@ JSON-RPC
     "id": "1",
     "method": "devnet_postmanConsumeMessageFromL2",
     "params": {
-      "l2_contract_address": "0x00285ddb7e5c777b310d806b9b2a0f7c7ba0a41f12b420219209d97a3b7f25b2",
-      "l1_contract_address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+      "from_address": "0x00285ddb7e5c777b310d806b9b2a0f7c7ba0a41f12b420219209d97a3b7f25b2",
+      "to_address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
       "payload": ["0x0", "0x1", "0x3e8"],
   }
 }

--- a/website/docs/postman.md
+++ b/website/docs/postman.md
@@ -30,7 +30,7 @@ JSON-RPC
 
 Loads a `MockStarknetMessaging` contract. The `address` parameter is optional; if provided, the `MockStarknetMessaging` contract will be fetched from that address, otherwise a new one will be deployed.
 
-`networkUrl` is the URL of the JSON-RPC API of the L1 node you've run locally or that already exists; possibilities include, and are not limited to:
+`network_url` is the URL of the JSON-RPC API of the L1 node you've run locally or that already exists; possibilities include, and are not limited to:
 
 - [**Anvil**](https://github.com/foundry-rs/foundry/tree/master/crates/anvil)
 - [**Sepolia testnet**](https://sepolia.etherscan.io/)
@@ -154,7 +154,7 @@ Response:
 ### L2->L1
 
 Sending mock transactions from L2 to L1.
-Deployed L2 contract address `l2_contract_address` and `l1_contract_address` must be valid.
+Deployed L2 contract address `from_address` and `to_address` must be valid.
 
 A running L1 node is required for this operation.
 


### PR DESCRIPTION
## Usage related changes

## Development related changes

from_address

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please prefer merging over rebasing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
