### PR TITLE
Prerelease v0.2.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-devnet"
-version = "0.1.2"
+version = "0.2.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5774,7 +5774,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-devnet-core"
-version = "0.1.2"
+version = "0.2.0-rc.0"
 dependencies = [
  "blockifier",
  "cairo-lang-starknet-classes",
@@ -5803,7 +5803,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-devnet-server"
-version = "0.1.2"
+version = "0.2.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5828,7 +5828,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-devnet-types"
-version = "0.1.2"
+version = "0.2.0-rc.0"
 dependencies = [
  "base64 0.22.1",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,9 +95,9 @@ cairo-lang-syntax = "=2.7.0-rc.1"
 cairo-lang-utils = "=2.7.0-rc.1"
 
 # Inner dependencies
-starknet-types = { version = "0.1.2", path = "crates/starknet-devnet-types", package = "starknet-devnet-types" }
-starknet-core = { version = "0.1.2", path = "crates/starknet-devnet-core", package = "starknet-devnet-core" }
-server = { version = "0.1.2", path = "crates/starknet-devnet-server", package = "starknet-devnet-server" }
+starknet-types = { version = "0.2.0-rc.0", path = "crates/starknet-devnet-types", package = "starknet-devnet-types" }
+starknet-core = { version = "0.2.0-rc.0", path = "crates/starknet-devnet-core", package = "starknet-devnet-core" }
+server = { version = "0.2.0-rc.0", path = "crates/starknet-devnet-server", package = "starknet-devnet-server" }
 
 # Dependabot alerts
 zerocopy = "0.7.31"

--- a/crates/starknet-devnet-core/Cargo.toml
+++ b/crates/starknet-devnet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-devnet-core"
-version = "0.1.2"
+version = "0.2.0-rc.0"
 edition.workspace = true
 repository.workspace = true
 license-file.workspace = true

--- a/crates/starknet-devnet-server/Cargo.toml
+++ b/crates/starknet-devnet-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-devnet-server"
-version = "0.1.2"
+version = "0.2.0-rc.0"
 edition = "2021"
 repository.workspace = true
 license-file.workspace = true

--- a/crates/starknet-devnet-types/Cargo.toml
+++ b/crates/starknet-devnet-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-devnet-types"
-version = "0.1.2"
+version = "0.2.0-rc.0"
 edition = "2021"
 description = "Starknet types for the devnet"
 repository.workspace = true

--- a/crates/starknet-devnet/Cargo.toml
+++ b/crates/starknet-devnet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-devnet"
-version = "0.1.2"
+version = "0.2.0-rc.0"
 edition = "2021"
 repository.workspace = true
 license-file.workspace = true


### PR DESCRIPTION
## Usage related changes

- Upped all starknet-devnet crates to 0.2.0-rc.0.
- No documentation entry added - will be addressed when a stable v0.2.0 is released.

## Development related changes

<!-- How these changes affect the developers of this project. E.g. changes in dev tools, testing, CI/CD... -->

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
