### PR TITLE
Refactor loading

### DIFF
--- a/crates/starknet-devnet-core/src/starknet/dump.rs
+++ b/crates/starknet-devnet-core/src/starknet/dump.rs
@@ -29,7 +29,9 @@ impl Starknet {
     pub fn load(config: &StarknetConfig, path: &str) -> DevnetResult<Self> {
         let mut this = Self::new(config)?;
 
-        // Try to load transactions from dump_path, if there is no file skip this step
+        // Try to load events from the path. Since the same CLI parameter is used for dump and load
+        // path, it may be the case that there is no file at the path. This means that the file will
+        // be created during Devnet's lifetime via dumping, so its non-existence is here ignored.
         match this.load_events(path) {
             Ok(events) => this.re_execute(events)?,
             Err(Error::FileNotFound) => {}

--- a/crates/starknet-devnet-core/src/starknet/dump.rs
+++ b/crates/starknet-devnet-core/src/starknet/dump.rs
@@ -9,6 +9,7 @@ use starknet_types::rpc::transactions::{
     BroadcastedInvokeTransaction,
 };
 
+use super::starknet_config::StarknetConfig;
 use super::{DumpOn, Starknet};
 use crate::error::{DevnetResult, Error};
 
@@ -24,6 +25,19 @@ pub enum DumpEvent {
 }
 
 impl Starknet {
+    pub fn load(config: &StarknetConfig, path: &str) -> DevnetResult<Self> {
+        let mut this = Self::new(config)?;
+
+        // Try to load transactions from dump_path, if there is no file skip this step
+        match this.load_events_custom_path(path) {
+            Ok(events) => this.re_execute(events)?,
+            Err(Error::FileNotFound) => {}
+            Err(err) => return Err(err),
+        };
+
+        Ok(this)
+    }
+
     pub fn re_execute(&mut self, events: Vec<DumpEvent>) -> DevnetResult<()> {
         for event in events.into_iter() {
             match event {
@@ -137,40 +151,27 @@ impl Starknet {
         &self.dump_events
     }
 
-    pub fn load_events(&self) -> DevnetResult<Vec<DumpEvent>> {
-        self.load_events_custom_path(None)
-    }
-
     // load starknet events from file
-    pub fn load_events_custom_path(
-        &self,
-        custom_path: Option<String>,
-    ) -> DevnetResult<Vec<DumpEvent>> {
-        let dump_path = if custom_path.is_some() { &custom_path } else { &self.config.dump_path };
-        match dump_path {
-            Some(path) => {
-                let file_path = Path::new(path);
+    pub fn load_events_custom_path(&self, path: &str) -> DevnetResult<Vec<DumpEvent>> {
+        let file_path = Path::new(path);
 
-                // load only if the file exists, if config.dump_path is set but the file doesn't
-                // exist it means that it's first execution and in that case return an empty vector,
-                // in case of load from HTTP endpoint return FileNotFound error
-                if file_path.exists() {
-                    let file = File::open(file_path).map_err(Error::IoError)?;
-                    let events: Vec<DumpEvent> = serde_json::from_reader(file)
-                        .map_err(|e| Error::DeserializationError { origin: e.to_string() })?;
+        // load only if the file exists, if config.dump_path is set but the file doesn't
+        // exist it means that it's first execution and in that case return an empty vector,
+        // in case of load from HTTP endpoint return FileNotFound error
+        if file_path.exists() {
+            let file = File::open(file_path).map_err(Error::IoError)?;
+            let events: Vec<DumpEvent> = serde_json::from_reader(file)
+                .map_err(|e| Error::DeserializationError { origin: e.to_string() })?;
 
-                    // to avoid doublets in block mode during load, we need to remove the file
-                    // because they will be re-executed and saved again
-                    if self.config.dump_on == Some(DumpOn::Block) {
-                        fs::remove_file(file_path).map_err(Error::IoError)?;
-                    }
-
-                    Ok(events)
-                } else {
-                    Err(Error::FileNotFound)
-                }
+            // to avoid doublets in block mode during load, we need to remove the file
+            // because they will be re-executed and saved again
+            if self.config.dump_on == Some(DumpOn::Block) {
+                fs::remove_file(file_path).map_err(Error::IoError)?;
             }
-            None => Err(Error::FormatError),
+
+            Ok(events)
+        } else {
+            Err(Error::FileNotFound)
         }
     }
 }

--- a/crates/starknet-devnet-core/src/starknet/dump.rs
+++ b/crates/starknet-devnet-core/src/starknet/dump.rs
@@ -29,7 +29,7 @@ impl Starknet {
         let mut this = Self::new(config)?;
 
         // Try to load transactions from dump_path, if there is no file skip this step
-        match this.load_events_custom_path(path) {
+        match this.load_events(path) {
             Ok(events) => this.re_execute(events)?,
             Err(Error::FileNotFound) => {}
             Err(err) => return Err(err),
@@ -151,8 +151,8 @@ impl Starknet {
         &self.dump_events
     }
 
-    // load starknet events from file
-    pub fn load_events_custom_path(&self, path: &str) -> DevnetResult<Vec<DumpEvent>> {
+    /// Load starknet events from the provided `path`
+    pub fn load_events(&self, path: &str) -> DevnetResult<Vec<DumpEvent>> {
         let file_path = Path::new(path);
 
         // load only if the file exists, if config.dump_path is set but the file doesn't

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -261,16 +261,6 @@ impl Starknet {
         };
         this.create_block()?;
 
-        // Load starknet transactions
-        if this.config.dump_path.is_some() && this.config.re_execute_on_init {
-            // Try to load transactions from dump_path, if there is no file skip this step
-            match this.load_events() {
-                Ok(events) => this.re_execute(events)?,
-                Err(Error::FileNotFound) => {}
-                Err(err) => return Err(err),
-            };
-        }
-
         Ok(this)
     }
 
@@ -279,7 +269,6 @@ impl Starknet {
     }
 
     pub fn restart(&mut self) -> DevnetResult<()> {
-        self.config.re_execute_on_init = false;
         *self = Starknet::new(&self.config)?;
         info!("Starknet Devnet restarted");
 

--- a/crates/starknet-devnet-core/src/starknet/starknet_config.rs
+++ b/crates/starknet-devnet-core/src/starknet/starknet_config.rs
@@ -113,9 +113,6 @@ pub struct StarknetConfig {
     pub dump_path: Option<String>,
     pub block_generation_on: BlockGenerationOn,
     pub lite_mode: bool,
-    /// on initialization, re-execute loaded txs (if any)
-    #[serde(skip_serializing)]
-    pub re_execute_on_init: bool,
     pub state_archive: StateArchiveCapacity,
     pub fork_config: ForkConfig,
     pub disable_account_impersonation: bool,
@@ -143,7 +140,6 @@ impl Default for StarknetConfig {
             dump_path: None,
             block_generation_on: BlockGenerationOn::Transaction,
             lite_mode: false,
-            re_execute_on_init: true,
             state_archive: StateArchiveCapacity::default(),
             fork_config: ForkConfig::default(),
             disable_account_impersonation: false,

--- a/crates/starknet-devnet-server/src/api/http/endpoints/dump_load.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/dump_load.rs
@@ -53,9 +53,9 @@ pub(crate) async fn dump_impl(
 
 pub async fn load(
     State(state): State<HttpApiHandler>,
-    Json(path): Json<LoadPath>,
+    Json(path_wrapper): Json<LoadPath>,
 ) -> HttpApiResult<()> {
-    load_impl(&state.api, path).await
+    load_impl(&state.api, path_wrapper).await
 }
 
 pub(crate) async fn load_impl(api: &Api, path_wrapper: LoadPath) -> HttpApiResult<()> {
@@ -67,7 +67,7 @@ pub(crate) async fn load_impl(api: &Api, path_wrapper: LoadPath) -> HttpApiResul
     let mut starknet = api.starknet.lock().await;
     starknet.restart().map_err(|e| HttpApiError::RestartError { msg: e.to_string() })?;
     let events = starknet
-        .load_events_custom_path(&path_wrapper.path)
+        .load_events(&path_wrapper.path)
         .map_err(|e| HttpApiError::LoadError(e.to_string()))?;
     starknet.re_execute(events).map_err(|e| HttpApiError::ReExecutionError(e.to_string()))?;
 

--- a/crates/starknet-devnet-server/src/api/http/endpoints/dump_load.rs
+++ b/crates/starknet-devnet-server/src/api/http/endpoints/dump_load.rs
@@ -58,16 +58,16 @@ pub async fn load(
     load_impl(&state.api, path).await
 }
 
-pub(crate) async fn load_impl(api: &Api, path: LoadPath) -> HttpApiResult<()> {
-    let file_path = std::path::Path::new(&path.path);
-    if path.path.is_empty() || !file_path.exists() {
+pub(crate) async fn load_impl(api: &Api, path_wrapper: LoadPath) -> HttpApiResult<()> {
+    let file_path = std::path::Path::new(&path_wrapper.path);
+    if path_wrapper.path.is_empty() || !file_path.exists() {
         return Err(HttpApiError::FileNotFound);
     }
 
     let mut starknet = api.starknet.lock().await;
     starknet.restart().map_err(|e| HttpApiError::RestartError { msg: e.to_string() })?;
     let events = starknet
-        .load_events_custom_path(Some(path.path))
+        .load_events_custom_path(&path_wrapper.path)
         .map_err(|e| HttpApiError::LoadError(e.to_string()))?;
     starknet.re_execute(events).map_err(|e| HttpApiError::ReExecutionError(e.to_string()))?;
 

--- a/crates/starknet-devnet/src/cli.rs
+++ b/crates/starknet-devnet/src/cli.rs
@@ -231,7 +231,6 @@ impl Args {
             dump_path: self.dump_path.clone(),
             block_generation_on: self.block_generation_on,
             lite_mode: self.lite_mode,
-            re_execute_on_init: true,
             state_archive: self.state_archive,
             fork_config: ForkConfig {
                 url: self.fork_network.clone(),

--- a/crates/starknet-devnet/src/main.rs
+++ b/crates/starknet-devnet/src/main.rs
@@ -171,7 +171,12 @@ async fn main() -> Result<(), anyhow::Error> {
     let address = format!("{}:{}", server_config.host, server_config.port);
     let listener = TcpListener::bind(address.clone()).await?;
 
-    let api = Api::new(Starknet::new(&starknet_config)?);
+    let starknet = if let Some(dump_path) = &starknet_config.dump_path {
+        Starknet::load(&starknet_config, dump_path)?
+    } else {
+        Starknet::new(&starknet_config)?
+    };
+    let api = Api::new(starknet);
 
     // set block timestamp shift during startup if start time is set
     if let Some(start_time) = starknet_config.start_time {


### PR DESCRIPTION
## Usage related changes

None

## Development related changes

- Simplify loading
- Avoid needing the `re_execute_on_init` flag
- Unify `load_events` and `load_events_custom_path`
- Remove loading logic from `Starknet::new`. Create a new method `Starknet::load` which uses `Starknet::new` and loads.

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
