### PR TITLE
Upgraded USC and Cairo-related dependencies to latest versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ rand_mt = "4.2.2"
 regex_generate = "0.2.3"
 reqwest = { version = "0.12", features = ["blocking", "json"] }
 url = "2.4"
-usc = { version = "2.2.0-rc.1", package = "universal-sierra-compiler" }
+usc = { version = "2.2.0", package = "universal-sierra-compiler" }
 num-bigint = { version = "0.4" }
 bigdecimal = { version = "0.4.5" }
 
@@ -80,19 +80,19 @@ starknet-rs-crypto = { version = "0.7.0", package = "starknet-crypto" }
 cairo-vm = "=1.0.0-rc5"
 
 # Cairo-lang dependencies
-cairo-lang-starknet-classes = "=2.7.0-rc.3"
-cairo-lang-compiler = "=2.7.0-rc.3"
-cairo-lang-casm = "=2.7.0-rc.3"
-cairo-lang-defs = "=2.7.0-rc.3"
-cairo-lang-diagnostics = "=2.7.0-rc.3"
-cairo-lang-filesystem = "=2.7.0-rc.3"
-cairo-lang-lowering = "=2.7.0-rc.3"
-cairo-lang-semantic = "=2.7.0-rc.3"
-cairo-lang-sierra = "=2.7.0-rc.3"
-cairo-lang-sierra-generator = "=2.7.0-rc.3"
-cairo-lang-sierra-to-casm = "=2.7.0-rc.3"
-cairo-lang-syntax = "=2.7.0-rc.3"
-cairo-lang-utils = "=2.7.0-rc.3"
+cairo-lang-starknet-classes = "=2.7.0"
+cairo-lang-compiler = "=2.7.0"
+cairo-lang-casm = "=2.7.0"
+cairo-lang-defs = "=2.7.0"
+cairo-lang-diagnostics = "=2.7.0"
+cairo-lang-filesystem = "=2.7.0"
+cairo-lang-lowering = "=2.7.0"
+cairo-lang-semantic = "=2.7.0"
+cairo-lang-sierra = "=2.7.0"
+cairo-lang-sierra-generator = "=2.7.0"
+cairo-lang-sierra-to-casm = "=2.7.0"
+cairo-lang-syntax = "=2.7.0"
+cairo-lang-utils = "=2.7.0"
 
 # Inner dependencies
 starknet-types = { version = "0.2.0-rc.1", path = "crates/starknet-devnet-types", package = "starknet-devnet-types" }


### PR DESCRIPTION
closes [#575](https://github.com/0xSpaceShard/starknet-devnet-rs/issues/575#issue-2458349709)

## Usage related changes:
Devnet's USC is going to compile Sierra 1.6.0 and work with Scarb 2.7.0.

<!-- How the changes from this PR affect users. -->

## Development related changes
Upgraded Cairo-related project dependecies

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [ ] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [ ] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
