### PR TITLE
Fix Cargo.lock; verify in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,9 @@ jobs:
           name: Install foundry
           command: ./scripts/install_foundry.sh
       - run:
+          name: Verify lockfile
+          command: cargo update -w --locked
+      - run:
           name: Build
           command: cargo build --release
       - run:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,10 +563,10 @@ dependencies = [
  "ark-secp256k1",
  "ark-secp256r1",
  "cached",
- "cairo-lang-casm 2.7.0-rc.3",
+ "cairo-lang-casm 2.7.0",
  "cairo-lang-runner",
  "cairo-lang-starknet-classes",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-utils 2.7.0",
  "cairo-vm",
  "derive_more",
  "indexmap 2.2.6",
@@ -746,11 +746,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5abf875e93f696e783412d3f2a7c6f66e94e07c30b01559380b4d0707dc0050e"
+checksum = "4a43421bf72645b3a562d264747166d6f093e960a69dfa38b67bb3209e370366"
 dependencies = [
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-utils 2.7.0",
  "indoc",
  "num-bigint",
  "num-traits 0.2.19",
@@ -786,22 +786,22 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f135e1768e199e88b04f824e34b9411ff49fc31970e77cbf5c6f448170441d18"
+checksum = "24242af537265add372896d9ab0678c86a68d3484281fbeb6d8a9d4d5bacf7c8"
 dependencies = [
  "anyhow",
- "cairo-lang-defs 2.7.0-rc.3",
- "cairo-lang-diagnostics 2.7.0-rc.3",
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-lowering 2.7.0-rc.3",
- "cairo-lang-parser 2.7.0-rc.3",
- "cairo-lang-project 2.7.0-rc.3",
- "cairo-lang-semantic 2.7.0-rc.3",
- "cairo-lang-sierra 2.7.0-rc.3",
- "cairo-lang-sierra-generator 2.7.0-rc.3",
- "cairo-lang-syntax 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-defs 2.7.0",
+ "cairo-lang-diagnostics 2.7.0",
+ "cairo-lang-filesystem 2.7.0",
+ "cairo-lang-lowering 2.7.0",
+ "cairo-lang-parser 2.7.0",
+ "cairo-lang-project 2.7.0",
+ "cairo-lang-semantic 2.7.0",
+ "cairo-lang-sierra 2.7.0",
+ "cairo-lang-sierra-generator 2.7.0",
+ "cairo-lang-syntax 2.7.0",
+ "cairo-lang-utils 2.7.0",
  "indoc",
  "salsa",
  "smol_str",
@@ -816,11 +816,11 @@ checksum = "c99d41a14f98521c617c0673a0faa41fd00029d32106a4643e1291a1813340a7"
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e2bf0a6caf1e54938bc67ca082cbeb5385969784bfb1109c187ca9dc5e1806"
+checksum = "2d28f38e1c62fed15a4de9f3c95741d6b24ef2a9e67a2b88a047eb6ea7de992e"
 dependencies = [
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-utils 2.7.0",
 ]
 
 [[package]]
@@ -843,16 +843,16 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65bb0e855afeb88d11585605f836bd0cd444375b234103e87342df2c91aba1b"
+checksum = "712206b7be3fb1a33e50e1c30aa8502b4a461155fd93ad26213d0d8b242cb08d"
 dependencies = [
- "cairo-lang-debug 2.7.0-rc.3",
- "cairo-lang-diagnostics 2.7.0-rc.3",
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-parser 2.7.0-rc.3",
- "cairo-lang-syntax 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-debug 2.7.0",
+ "cairo-lang-diagnostics 2.7.0",
+ "cairo-lang-filesystem 2.7.0",
+ "cairo-lang-parser 2.7.0",
+ "cairo-lang-syntax 2.7.0",
+ "cairo-lang-utils 2.7.0",
  "itertools 0.12.1",
  "salsa",
  "smol_str",
@@ -872,13 +872,13 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab96083f60a077d300d0b89bd4b9c31731c95f5db355a11c4657ee25f3acc198"
+checksum = "9a3c8dc2bff2411fbf602d80a83b719e6e3955c1c5d767ec18b295fc92e8616a"
 dependencies = [
- "cairo-lang-debug 2.7.0-rc.3",
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-debug 2.7.0",
+ "cairo-lang-filesystem 2.7.0",
+ "cairo-lang-utils 2.7.0",
  "itertools 0.12.1",
 ]
 
@@ -896,11 +896,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf2aaa50fa5b15070b2bf02c60a62f917f9aa1ff6dedf5a2627ecafe8e33cfa"
+checksum = "eaa8ac24c97770739f5a78d630b8515273c8b9f4aff34e1f88b988fac50340de"
 dependencies = [
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-utils 2.7.0",
  "good_lp",
 ]
 
@@ -920,12 +920,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8094bcf7e44204c2fc2f10760e7e2e5769a6267cba5d8a303c0331dd480d5663"
+checksum = "4596331565fe61d10a0a6a03ace2b9d0ba93f03ee12a8450fe9252a6fee770f3"
 dependencies = [
- "cairo-lang-debug 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-debug 2.7.0",
+ "cairo-lang-utils 2.7.0",
  "path-clean 1.0.1",
  "salsa",
  "serde",
@@ -934,16 +934,16 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-formatter"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a1d92f1163b3b0e22e6392d22f7a275b9e64ab453f32b8b62bb1aeedbe73e04"
+checksum = "69b8eb08e511d6e6df51370cdc7d85f0de9a38c8b14a15762665c60c2df6d32d"
 dependencies = [
  "anyhow",
- "cairo-lang-diagnostics 2.7.0-rc.3",
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-parser 2.7.0-rc.3",
- "cairo-lang-syntax 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-diagnostics 2.7.0",
+ "cairo-lang-filesystem 2.7.0",
+ "cairo-lang-parser 2.7.0",
+ "cairo-lang-syntax 2.7.0",
+ "cairo-lang-utils 2.7.0",
  "diffy",
  "ignore",
  "itertools 0.12.1",
@@ -980,19 +980,19 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25eb629a773c07c2863717d1711fd3ecc17807c1fc094bb90cccac56061056a4"
+checksum = "6d535dc591513875b39b799270df21db10540033fd7710917760c22fc063a4ae"
 dependencies = [
- "cairo-lang-debug 2.7.0-rc.3",
- "cairo-lang-defs 2.7.0-rc.3",
- "cairo-lang-diagnostics 2.7.0-rc.3",
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-parser 2.7.0-rc.3",
- "cairo-lang-proc-macros 2.7.0-rc.3",
- "cairo-lang-semantic 2.7.0-rc.3",
- "cairo-lang-syntax 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-debug 2.7.0",
+ "cairo-lang-defs 2.7.0",
+ "cairo-lang-diagnostics 2.7.0",
+ "cairo-lang-filesystem 2.7.0",
+ "cairo-lang-parser 2.7.0",
+ "cairo-lang-proc-macros 2.7.0",
+ "cairo-lang-semantic 2.7.0",
+ "cairo-lang-syntax 2.7.0",
+ "cairo-lang-utils 2.7.0",
  "id-arena",
  "itertools 0.12.1",
  "log",
@@ -1026,15 +1026,15 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7b1d7af8e1bff971b8b9bbce796650a57de93dfb092bc0c17c2f85d915de6e"
+checksum = "73019d5873715964f428ff10467efb607d6dc007ae164a21547bf20d9b5dcc72"
 dependencies = [
- "cairo-lang-diagnostics 2.7.0-rc.3",
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-syntax 2.7.0-rc.3",
- "cairo-lang-syntax-codegen 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-diagnostics 2.7.0",
+ "cairo-lang-filesystem 2.7.0",
+ "cairo-lang-syntax 2.7.0",
+ "cairo-lang-syntax-codegen 2.7.1",
+ "cairo-lang-utils 2.7.0",
  "colored",
  "itertools 0.12.1",
  "num-bigint",
@@ -1065,16 +1065,16 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eccf06d643d155a72057dc93c40cf34dabe11e8c629dbf3111c528a3d750a66"
+checksum = "96e52fca18bc696011a47a4ded0dc00e2e0ac7c81a8052eddd4ad546c46b818e"
 dependencies = [
- "cairo-lang-defs 2.7.0-rc.3",
- "cairo-lang-diagnostics 2.7.0-rc.3",
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-parser 2.7.0-rc.3",
- "cairo-lang-syntax 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-defs 2.7.0",
+ "cairo-lang-diagnostics 2.7.0",
+ "cairo-lang-filesystem 2.7.0",
+ "cairo-lang-parser 2.7.0",
+ "cairo-lang-syntax 2.7.0",
+ "cairo-lang-utils 2.7.0",
  "indent",
  "indoc",
  "itertools 0.12.1",
@@ -1095,11 +1095,11 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa10434f9ce0828e8d77f3a13ae2f878da453345b14d54a66de3e196c0e4674"
+checksum = "3d55dcf98a6e1a03e0b36129fad4253f9e6666a1746ab9c075d212ba68a4e9c1"
 dependencies = [
- "cairo-lang-debug 2.7.0-rc.3",
+ "cairo-lang-debug 2.7.0",
  "quote",
  "syn 2.0.70",
 ]
@@ -1119,12 +1119,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4882d2263fb7c95dbab0c3b5578d8c0e2417fd680df8cc61aa50321b6a5a40d"
+checksum = "e3ddb432e5199a65e37bab97ef6322afabd60e0e638ada31178d9c23d237219d"
 dependencies = [
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-filesystem 2.7.0",
+ "cairo-lang-utils 2.7.0",
  "serde",
  "smol_str",
  "thiserror",
@@ -1140,15 +1140,15 @@ dependencies = [
  "ark-ff",
  "ark-secp256k1",
  "ark-secp256r1",
- "cairo-lang-casm 2.7.0-rc.3",
- "cairo-lang-lowering 2.7.0-rc.3",
- "cairo-lang-sierra 2.7.0-rc.3",
- "cairo-lang-sierra-ap-change 2.7.0-rc.3",
- "cairo-lang-sierra-generator 2.7.0-rc.3",
- "cairo-lang-sierra-to-casm 2.7.0-rc.3",
+ "cairo-lang-casm 2.7.0",
+ "cairo-lang-lowering 2.7.0",
+ "cairo-lang-sierra 2.7.0",
+ "cairo-lang-sierra-ap-change 2.7.0",
+ "cairo-lang-sierra-generator 2.7.0",
+ "cairo-lang-sierra-to-casm 2.7.0",
  "cairo-lang-sierra-type-size",
  "cairo-lang-starknet 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-utils 2.7.0",
  "cairo-vm",
  "itertools 0.12.1",
  "keccak",
@@ -1187,20 +1187,20 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba49614f98322e1ccda33265f8193f66cbd88eff23b0deb94db981aa0666650"
+checksum = "393325820207491a7475269e98163e0db7e85e4b215f4d801ca537ce1cd6daa7"
 dependencies = [
- "cairo-lang-debug 2.7.0-rc.3",
- "cairo-lang-defs 2.7.0-rc.3",
- "cairo-lang-diagnostics 2.7.0-rc.3",
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-parser 2.7.0-rc.3",
- "cairo-lang-plugins 2.7.0-rc.3",
- "cairo-lang-proc-macros 2.7.0-rc.3",
- "cairo-lang-syntax 2.7.0-rc.3",
+ "cairo-lang-debug 2.7.0",
+ "cairo-lang-defs 2.7.0",
+ "cairo-lang-diagnostics 2.7.0",
+ "cairo-lang-filesystem 2.7.0",
+ "cairo-lang-parser 2.7.0",
+ "cairo-lang-plugins 2.7.0",
+ "cairo-lang-proc-macros 2.7.0",
+ "cairo-lang-syntax 2.7.0",
  "cairo-lang-test-utils",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-utils 2.7.0",
  "id-arena",
  "indoc",
  "itertools 0.12.1",
@@ -1237,12 +1237,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a41d56c6afebdbe2c5ffb4e216f60b07391c29c91fccf0a60790817f49ba68"
+checksum = "918fb0611203fb8cdd1fcdb434f395a59e0ebb0db64b11a0e15bfbfb03552821"
 dependencies = [
  "anyhow",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-utils 2.7.0",
  "const-fnv1a-hash",
  "convert_case 0.6.0",
  "derivative",
@@ -1278,14 +1278,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667050b93db661ebce0b33c92ce44abffebde37c5645e4761722ad3c49a1c34f"
+checksum = "7fa1834ec729e89fcbd00df03f2a64a18515fcf07eb18dfef39afe020a10955d"
 dependencies = [
- "cairo-lang-eq-solver 2.7.0-rc.3",
- "cairo-lang-sierra 2.7.0-rc.3",
+ "cairo-lang-eq-solver 2.7.0",
+ "cairo-lang-sierra 2.7.0",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-utils 2.7.0",
  "itertools 0.12.1",
  "num-bigint",
  "num-traits 0.2.19",
@@ -1307,14 +1307,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27fcbf81e8ed4efe7e9c30bbdfa8074b9af01a5e16154999dd9527baba27f1fb"
+checksum = "6b00927d39f910dd5ae1047cef9b46b2ee11617d33d290f875bc00dfc7e3d992"
 dependencies = [
- "cairo-lang-eq-solver 2.7.0-rc.3",
- "cairo-lang-sierra 2.7.0-rc.3",
+ "cairo-lang-eq-solver 2.7.0",
+ "cairo-lang-sierra 2.7.0",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-utils 2.7.0",
  "itertools 0.12.1",
  "num-bigint",
  "num-traits 0.2.19",
@@ -1349,20 +1349,20 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058c05d10913a130fb21964f0bf1a37b05eafcf2f50a73cd4aa3e11da7e4cfc7"
+checksum = "7620a6a7becf5997093a83d289a5e3b3162bc8fd031ad75df82a5bc04f8cc954"
 dependencies = [
- "cairo-lang-debug 2.7.0-rc.3",
- "cairo-lang-defs 2.7.0-rc.3",
- "cairo-lang-diagnostics 2.7.0-rc.3",
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-lowering 2.7.0-rc.3",
- "cairo-lang-parser 2.7.0-rc.3",
- "cairo-lang-semantic 2.7.0-rc.3",
- "cairo-lang-sierra 2.7.0-rc.3",
- "cairo-lang-syntax 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-debug 2.7.0",
+ "cairo-lang-defs 2.7.0",
+ "cairo-lang-diagnostics 2.7.0",
+ "cairo-lang-filesystem 2.7.0",
+ "cairo-lang-lowering 2.7.0",
+ "cairo-lang-parser 2.7.0",
+ "cairo-lang-semantic 2.7.0",
+ "cairo-lang-sierra 2.7.0",
+ "cairo-lang-syntax 2.7.0",
+ "cairo-lang-utils 2.7.0",
  "itertools 0.12.1",
  "num-traits 0.2.19",
  "once_cell",
@@ -1397,17 +1397,17 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8607cc5cf16f3a930ad4b3799e986b0ca36ada2c0da1dd6bd2ef35cbb1eb9e74"
+checksum = "67bd155770abf91d4290a31b0c0a1fb393ecee85eb0af40c16893b4601eff4d6"
 dependencies = [
  "assert_matches",
- "cairo-lang-casm 2.7.0-rc.3",
- "cairo-lang-sierra 2.7.0-rc.3",
- "cairo-lang-sierra-ap-change 2.7.0-rc.3",
- "cairo-lang-sierra-gas 2.7.0-rc.3",
+ "cairo-lang-casm 2.7.0",
+ "cairo-lang-sierra 2.7.0",
+ "cairo-lang-sierra-ap-change 2.7.0",
+ "cairo-lang-sierra-gas 2.7.0",
  "cairo-lang-sierra-type-size",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-utils 2.7.0",
  "indoc",
  "itertools 0.12.1",
  "num-bigint",
@@ -1418,12 +1418,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224624b1e279b3eea7693680f577335e66e6dd5fbfbd2576f4a7d0b5d697f61d"
+checksum = "fbae9458999da692c272501678b6cfec358a6bcadb54921bf35d21afdcd91251"
 dependencies = [
- "cairo-lang-sierra 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-sierra 2.7.0",
+ "cairo-lang-utils 2.7.0",
 ]
 
 [[package]]
@@ -1474,18 +1474,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81a54ebea4ea990a33a2158ecdf46ffb3cb1af8fff6a79c3dd310c6a9ed43e82"
 dependencies = [
  "anyhow",
- "cairo-lang-compiler 2.7.0-rc.3",
- "cairo-lang-defs 2.7.0-rc.3",
- "cairo-lang-diagnostics 2.7.0-rc.3",
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-lowering 2.7.0-rc.3",
- "cairo-lang-plugins 2.7.0-rc.3",
- "cairo-lang-semantic 2.7.0-rc.3",
- "cairo-lang-sierra 2.7.0-rc.3",
- "cairo-lang-sierra-generator 2.7.0-rc.3",
+ "cairo-lang-compiler 2.7.0",
+ "cairo-lang-defs 2.7.0",
+ "cairo-lang-diagnostics 2.7.0",
+ "cairo-lang-filesystem 2.7.0",
+ "cairo-lang-lowering 2.7.0",
+ "cairo-lang-plugins 2.7.0",
+ "cairo-lang-semantic 2.7.0",
+ "cairo-lang-sierra 2.7.0",
+ "cairo-lang-sierra-generator 2.7.0",
  "cairo-lang-starknet-classes",
- "cairo-lang-syntax 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-syntax 2.7.0",
+ "cairo-lang-utils 2.7.0",
  "const_format",
  "indent",
  "indoc",
@@ -1500,14 +1500,14 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet-classes"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb66ae799e1963318e1bab782848f53797787c396dfd590be539f3f12d56ac4"
+checksum = "aa17b313f46fcf7ff4de32b86c250eaf584d1e2c8e37ed16db155b221721e735"
 dependencies = [
- "cairo-lang-casm 2.7.0-rc.3",
- "cairo-lang-sierra 2.7.0-rc.3",
- "cairo-lang-sierra-to-casm 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-casm 2.7.0",
+ "cairo-lang-sierra 2.7.0",
+ "cairo-lang-sierra-to-casm 2.7.0",
+ "cairo-lang-utils 2.7.0",
  "convert_case 0.6.0",
  "itertools 0.12.1",
  "num-bigint",
@@ -1541,13 +1541,13 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e673dc1058a8639c094a330a701e8902cbd34defe659a3d95bcf6c3f3de249d"
+checksum = "0d0ca518ed7c3674d9b62470f7482f4b07553eb3a02d83e0ae61bd6b5ecb4ec8"
 dependencies = [
- "cairo-lang-debug 2.7.0-rc.3",
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-debug 2.7.0",
+ "cairo-lang-filesystem 2.7.0",
+ "cairo-lang-utils 2.7.0",
  "num-bigint",
  "num-traits 0.2.19",
  "salsa",
@@ -1569,9 +1569,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.7.0-rc.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0dd466dbac4263573b81b83e22534285da30a4e7c15b888407fbb33d8accb9"
+checksum = "01f276bc28f6302fc63032046a12b60d18498906e65f646acb963244eed97f7c"
 dependencies = [
  "genco",
  "xshell",
@@ -1579,12 +1579,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-utils"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09431da22acc1cf081b1802b73ff484bdc75ca1cd5ad6fa9b84fba8753b2e08f"
+checksum = "e6a2365bd502a657437f9d0d665e32e017054d0effdbecb1dda776bfcc11235d"
 dependencies = [
  "cairo-lang-formatter",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-utils 2.7.0",
  "colored",
  "log",
  "pretty_assertions",
@@ -1609,9 +1609,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.7.0-rc.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97498c08958be8d569c16982cac431d785adc3effdfa6d0775c65aec578dfd91"
+checksum = "8bd5c8c127b9362a12ffb9dede38e792c81b4ded5a98b448baec157b745f47d1"
 dependencies = [
  "hashbrown 0.14.5",
  "indexmap 2.2.6",
@@ -5833,19 +5833,19 @@ dependencies = [
  "base64 0.22.1",
  "bigdecimal",
  "blockifier",
- "cairo-lang-casm 2.7.0-rc.3",
- "cairo-lang-compiler 2.7.0-rc.3",
- "cairo-lang-defs 2.7.0-rc.3",
- "cairo-lang-diagnostics 2.7.0-rc.3",
- "cairo-lang-filesystem 2.7.0-rc.3",
- "cairo-lang-lowering 2.7.0-rc.3",
- "cairo-lang-semantic 2.7.0-rc.3",
- "cairo-lang-sierra 2.7.0-rc.3",
- "cairo-lang-sierra-generator 2.7.0-rc.3",
- "cairo-lang-sierra-to-casm 2.7.0-rc.3",
+ "cairo-lang-casm 2.7.0",
+ "cairo-lang-compiler 2.7.0",
+ "cairo-lang-defs 2.7.0",
+ "cairo-lang-diagnostics 2.7.0",
+ "cairo-lang-filesystem 2.7.0",
+ "cairo-lang-lowering 2.7.0",
+ "cairo-lang-semantic 2.7.0",
+ "cairo-lang-sierra 2.7.0",
+ "cairo-lang-sierra-generator 2.7.0",
+ "cairo-lang-sierra-to-casm 2.7.0",
  "cairo-lang-starknet-classes",
- "cairo-lang-syntax 2.7.0-rc.3",
- "cairo-lang-utils 2.7.0-rc.3",
+ "cairo-lang-syntax 2.7.0",
+ "cairo-lang-utils 2.7.0",
  "cairo-vm",
  "flate2",
  "num-bigint",
@@ -6660,13 +6660,13 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "universal-sierra-compiler"
-version = "2.2.0-rc.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3fbb2e7933045aacac674e381e0d9a3ca87e696da2e917b069aaae967d478e3"
+checksum = "f0ab0193fb9cc11e4717f67736e9358035ff9a3bf99d6fc7f53ccaec9b6e1c9a"
 dependencies = [
  "anyhow",
- "cairo-lang-sierra 2.7.0-rc.3",
- "cairo-lang-sierra-to-casm 2.7.0-rc.3",
+ "cairo-lang-sierra 2.7.0",
+ "cairo-lang-sierra-to-casm 2.7.0",
  "cairo-lang-starknet 1.0.0-rc0",
  "cairo-lang-starknet-classes",
  "clap 4.5.4",


### PR DESCRIPTION
## Usage related changes

- None

## Development related changes

- Ensure failure in CI if Cargo.lock not synchronized with Cargo.toml
- Motivated by Cargo.lock changes not included in #576 

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
