### PR TITLE
Replaced classes

### DIFF
--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -562,7 +562,7 @@ impl Starknet {
     }
 
     /// Restarts pending block with information from block_context
-    fn restart_pending_block(&mut self) -> DevnetResult<()> {
+    pub(crate) fn restart_pending_block(&mut self) -> DevnetResult<()> {
         let mut block = StarknetBlock::create_pending_block();
 
         block.header.block_number = self.block_context.block_info().block_number;

--- a/crates/starknet-devnet-core/src/state/state_diff.rs
+++ b/crates/starknet-devnet-core/src/state/state_diff.rs
@@ -446,7 +446,7 @@ mod tests {
 
         let func_selector = get_selector_from_name("test_replace_class").unwrap();
         let calldata = vec![
-            Felt::ONE,                                                               /* contract address */
+            Felt::ONE,     // contract address
             func_selector, // function selector
             Felt::ONE,     // calldata len
             ContractClass::Cairo1(events_contract.clone()).generate_hash().unwrap(), // calldata

--- a/crates/starknet-devnet-core/src/state/state_diff.rs
+++ b/crates/starknet-devnet-core/src/state/state_diff.rs
@@ -446,10 +446,10 @@ mod tests {
 
         let func_selector = get_selector_from_name("test_replace_class").unwrap();
         let calldata = vec![
-            Felt::ONE,     // contract address
-            func_selector, // function selector
-            Felt::ONE,     // calldata len
-            ContractClass::Cairo1(events_contract.clone()).generate_hash().unwrap(), // calldata
+            Felt::ONE,
+            func_selector,
+            Felt::ONE,
+            ContractClass::Cairo1(events_contract.clone()).generate_hash().unwrap(),
         ];
 
         let invoke_txn = BroadcastedInvokeTransaction::V1(BroadcastedInvokeTransactionV1::new(

--- a/crates/starknet-devnet-core/src/state/state_diff.rs
+++ b/crates/starknet-devnet-core/src/state/state_diff.rs
@@ -192,9 +192,8 @@ mod tests {
     use starknet_types::felt::felt_from_prefixed_hex;
     use starknet_types::rpc::state::Balance;
     use starknet_types::rpc::transactions::broadcasted_declare_transaction_v2::BroadcastedDeclareTransactionV2;
-    use starknet_types::rpc::transactions::broadcasted_deploy_account_transaction_v1::BroadcastedDeployAccountTransactionV1;
     use starknet_types::rpc::transactions::broadcasted_invoke_transaction_v1::BroadcastedInvokeTransactionV1;
-    use starknet_types::rpc::transactions::{BroadcastedInvokeTransaction, BroadcastedTransaction};
+    use starknet_types::rpc::transactions::BroadcastedInvokeTransaction;
     use starknet_types::traits::HashProducer;
 
     use super::StateDiff;
@@ -205,9 +204,9 @@ mod tests {
     };
     use crate::starknet::starknet_config::StarknetConfig;
     use crate::starknet::Starknet;
-    use crate::state::{self, CustomState, CustomStateReader, StarknetState};
+    use crate::state::{CustomState, StarknetState};
     use crate::system_contract::SystemContract;
-    use crate::traits::{Accounted, Deployed};
+    use crate::traits::Deployed;
     use crate::utils::calculate_casm_hash;
     use crate::utils::exported_test_utils::dummy_cairo_0_contract_class;
     use crate::utils::test_utils::{
@@ -432,7 +431,7 @@ mod tests {
                 )
                 .unwrap();
         }
-        let replaceable_contract_address = ContractAddress::new(Felt::ONE).unwrap();
+        let _replaceable_contract_address = ContractAddress::new(Felt::ONE).unwrap();
         starknet
             .pending_state
             .predeploy_contract(
@@ -447,7 +446,7 @@ mod tests {
 
         let func_selector = get_selector_from_name("test_replace_class").unwrap();
         let calldata = vec![
-            Felt::ONE,                                                               /* contract address */
+            Felt::ONE,     // contract address
             func_selector, // function selector
             Felt::ONE,     // calldata len
             ContractClass::Cairo1(events_contract.clone()).generate_hash().unwrap(), // calldata
@@ -461,6 +460,8 @@ mod tests {
             &calldata,
             Felt::ONE,
         ));
+
+        starknet.add_invoke_transaction(invoke_txn).unwrap();
 
         let state_update = starknet
             .block_state_update(&starknet_rs_core::types::BlockId::Tag(

--- a/crates/starknet-devnet-core/src/state/state_diff.rs
+++ b/crates/starknet-devnet-core/src/state/state_diff.rs
@@ -185,13 +185,19 @@ mod tests {
     use starknet_rs_core::types::Felt;
     use starknet_types::contract_class::ContractClass;
     use starknet_types::felt::felt_from_prefixed_hex;
+    use starknet_types::rpc::state::Balance;
+    use starknet_types::traits::HashProducer;
 
     use super::StateDiff;
+    use crate::account::Account;
+    use crate::constants::ETH_ERC20_CONTRACT_ADDRESS;
+    use crate::starknet::Starknet;
     use crate::state::{CustomState, StarknetState};
+    use crate::traits::Deployed;
     use crate::utils::exported_test_utils::dummy_cairo_0_contract_class;
     use crate::utils::test_utils::{
-        dummy_cairo_1_contract_class, dummy_contract_address, dummy_felt,
-        DUMMY_CAIRO_1_COMPILED_CLASS_HASH,
+        cairo_0_account_without_validations, dummy_cairo_1_contract_class, dummy_contract_address,
+        dummy_felt, DUMMY_CAIRO_1_COMPILED_CLASS_HASH,
     };
 
     #[test]
@@ -324,6 +330,28 @@ mod tests {
         };
 
         assert_eq!(generated_diff, expected_diff);
+    }
+
+    #[test]
+    fn test_class_replacement_produces_correct_state_diff() {
+        let mut starknet = Starknet::default();
+
+        let account_without_validations_contract_class = cairo_0_account_without_validations();
+        let account_without_validations_class_hash =
+            account_without_validations_contract_class.generate_hash().unwrap();
+
+        let account = Account::new(
+            Balance::from(10000_u32),
+            dummy_felt(),
+            dummy_felt(),
+            account_without_validations_class_hash,
+            ContractClass::Cairo0(account_without_validations_contract_class),
+            Default::default(),
+            Default::default(),
+        )
+        .unwrap();
+
+        account.deploy(&mut starknet.pending_state).unwrap();
     }
 
     fn setup() -> StarknetState {

--- a/crates/starknet-devnet-core/src/state/state_diff.rs
+++ b/crates/starknet-devnet-core/src/state/state_diff.rs
@@ -446,7 +446,7 @@ mod tests {
 
         let func_selector = get_selector_from_name("test_replace_class").unwrap();
         let calldata = vec![
-            Felt::ONE,     // contract address
+            Felt::ONE,                                                               /* contract address */
             func_selector, // function selector
             Felt::ONE,     // calldata len
             ContractClass::Cairo1(events_contract.clone()).generate_hash().unwrap(), // calldata

--- a/crates/starknet-devnet/tests/common/utils.rs
+++ b/crates/starknet-devnet/tests/common/utils.rs
@@ -343,7 +343,7 @@ where
 mod test_unique_auto_deletable_file {
     use std::path::Path;
 
-    use super::UniqueAutoDeletableFile;
+    use crate::common::utils::UniqueAutoDeletableFile;
 
     #[test]
     fn test_deleted() {


### PR DESCRIPTION
## Usage related changes

When a replace_class syscall is executed, in the StateDiff object, the property replaced_classes will be populated

## Development related changes

<!-- How these changes affect the developers of this project. E.g. changes in dev tools, testing, CI/CD... -->

## Checklist:

- [ ] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
- [ ] No spelling errors - `./scripts/check_spelling.sh`
- [ ] Performed code self-review
- [ ] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [ ] Updated the docs if needed - `./website/README.md`
- [ ] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
