### PR TITLE
Improve API docs and fix link [skip ci]

### DIFF
--- a/website/docs/api.md
+++ b/website/docs/api.md
@@ -14,7 +14,13 @@ Unlike Pythonic Devnet, which also supported Starknet's gateway and feeder gatew
 
 ### Devnet API
 
-Devnet has many additional features which are available via their own endpoints and [JSON-RPC](https://github.com/0xSpaceShard/starknet-devnet-rs/website/static/devnet_api.json), which are all mentioned throughout the documentation. New features are only supported as part of the JSON-RPC API. Older non-RPC requests are still supported, but considered deprecated - they will be removed in the future, except the [healthcheck endpoint](#healthcheck).
+Devnet has many additional features which are available via their own endpoints and JSON-RPC. The RPC methods are documented throughout the documentation in their corresponding pages, but are also aggregated [here](https://github.com/0xSpaceShard/starknet-devnet-rs/website/static/devnet_api.json).
+
+:::warning Deprecation notice
+
+New features are only supported as part of the JSON-RPC API. Older non-RPC requests are still supported, but considered deprecated - they will be removed in the future, except the [healthcheck endpoint](#healthcheck).
+
+:::
 
 #### Healthcheck
 


### PR DESCRIPTION
## Usage related changes

- The RPC API docs link was broken.
- It is emphasized that there is a document with all the methods in one place.

## Development related changes

None

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
