### PR TITLE
Refactor tests: to_hex_felt and remove unused method

### DIFF
--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -1724,9 +1724,7 @@ mod tests {
         let predeployed_account = &starknet.predeployed_accounts.get_accounts()[0].clone();
         let result = get_balance_at(&mut starknet, predeployed_account.account_address).unwrap();
 
-        let balance_hex = format!("0x{:x}", DEVNET_DEFAULT_INITIAL_BALANCE);
-        let balance_felt = felt_from_prefixed_hex(balance_hex.as_str()).unwrap();
-        let balance_uint256 = vec![balance_felt, Felt::ZERO];
+        let balance_uint256 = vec![Felt::from(DEVNET_DEFAULT_INITIAL_BALANCE), Felt::ZERO];
         assert_eq!(result, balance_uint256);
     }
 

--- a/crates/starknet-devnet-types/src/rpc/felt.rs
+++ b/crates/starknet-devnet-types/src/rpc/felt.rs
@@ -3,10 +3,6 @@ use starknet_types_core::felt::Felt;
 
 use crate::error::{ConversionError, DevnetResult, Error};
 
-pub fn biguint_max() -> BigUint {
-    (BigUint::from(1_u8) << 256) - 1_u8
-}
-
 /// Returns (high, low)
 pub fn split_biguint(biguint: BigUint) -> (Felt, Felt) {
     let high = Felt::from(&biguint >> 128);

--- a/crates/starknet-devnet/tests/general_integration_tests.rs
+++ b/crates/starknet-devnet/tests/general_integration_tests.rs
@@ -14,7 +14,7 @@ mod general_integration_tests {
 
     use crate::common::background_devnet::BackgroundDevnet;
     use crate::common::reqwest_client::{HttpEmptyResponseBody, PostReqwestSender};
-    use crate::common::utils::UniqueAutoDeletableFile;
+    use crate::common::utils::{to_hex_felt, UniqueAutoDeletableFile};
 
     #[tokio::test]
     /// Asserts that a background instance can be spawned
@@ -94,8 +94,8 @@ mod general_integration_tests {
             },
             "block_generation_on": "demand",
             "lite_mode": false,
-            "eth_erc20_class_hash": format!("0x{:x}", CAIRO_1_ERC20_CONTRACT_CLASS_HASH),
-            "strk_erc20_class_hash": format!("0x{:x}", CAIRO_1_ERC20_CONTRACT_CLASS_HASH),
+            "eth_erc20_class_hash": to_hex_felt(&CAIRO_1_ERC20_CONTRACT_CLASS_HASH),
+            "strk_erc20_class_hash": to_hex_felt(&CAIRO_1_ERC20_CONTRACT_CLASS_HASH),
         });
 
         let devnet = BackgroundDevnet::spawn_with_additional_args(&[

--- a/crates/starknet-devnet/tests/test_balance.rs
+++ b/crates/starknet-devnet/tests/test_balance.rs
@@ -3,6 +3,7 @@ pub mod common;
 
 mod balance_tests {
     use serde_json::json;
+    use starknet_rs_core::types::Felt;
     use starknet_types::felt::felt_from_prefixed_hex;
     use starknet_types::rpc::transaction_receipt::FeeUnit;
 
@@ -19,9 +20,7 @@ mod balance_tests {
         let retrieved_result =
             devnet.get_balance_latest(&contract_address, FeeUnit::WEI).await.unwrap();
 
-        let expected_hex_balance = format!("0x{PREDEPLOYED_ACCOUNT_INITIAL_BALANCE:x}");
-        let expected_balance = felt_from_prefixed_hex(expected_hex_balance.as_str()).unwrap();
-        assert_eq!(retrieved_result, expected_balance);
+        assert_eq!(retrieved_result, Felt::from(PREDEPLOYED_ACCOUNT_INITIAL_BALANCE));
     }
 
     #[tokio::test]

--- a/crates/starknet-devnet/tests/test_estimate_fee.rs
+++ b/crates/starknet-devnet/tests/test_estimate_fee.rs
@@ -32,7 +32,7 @@ mod estimate_fee_tests {
     };
     use crate::common::utils::{
         assert_tx_reverted, assert_tx_successful, get_deployable_account_signer,
-        get_flattened_sierra_contract_and_casm_hash,
+        get_flattened_sierra_contract_and_casm_hash, to_hex_felt,
     };
 
     fn assert_fee_estimation(fee_estimation: &FeeEstimate) {
@@ -554,12 +554,12 @@ mod estimate_fee_tests {
                             sender_address: account_address,
                             calldata: [
                                 "0x1",
-                                format!("0x{:x}", UDC_CONTRACT_ADDRESS).as_str(),
+                                &to_hex_felt(&UDC_CONTRACT_ADDRESS),
                                 deployment_selector.as_str(),
                                 "0x0",
                                 "0x4",
                                 "0x4",
-                                format!("0x{:x}", class_hash).as_str(),
+                                &to_hex_felt(&class_hash),
                                 "0x123", // salt
                                 "0x0",
                                 "0x0",

--- a/crates/starknet-devnet/tests/test_gas_modification.rs
+++ b/crates/starknet-devnet/tests/test_gas_modification.rs
@@ -85,11 +85,11 @@ mod gas_modification_tests {
             .unwrap()[0];
         assert_eq!(
             resp_no_flags["fee_estimation"]["gas_price"],
-            format!("0x{:x}", DEVNET_DEFAULT_GAS_PRICE)
+            to_hex_felt(&DEVNET_DEFAULT_GAS_PRICE)
         );
         assert_eq!(
             resp_no_flags["fee_estimation"]["data_gas_price"],
-            format!("0x{:x}", DEVNET_DEFAULT_GAS_PRICE)
+            to_hex_felt(&DEVNET_DEFAULT_GAS_PRICE)
         );
         assert_eq!(resp_no_flags["fee_estimation"]["overall_fee"], "0xa7275ca6d3000");
 
@@ -100,11 +100,11 @@ mod gas_modification_tests {
             .unwrap()[0];
         assert_eq!(
             resp_skip_validation["fee_estimation"]["gas_price"],
-            format!("0x{:x}", DEVNET_DEFAULT_GAS_PRICE)
+            to_hex_felt(&DEVNET_DEFAULT_GAS_PRICE)
         );
         assert_eq!(
             resp_skip_validation["fee_estimation"]["data_gas_price"],
-            format!("0x{:x}", DEVNET_DEFAULT_GAS_PRICE)
+            to_hex_felt(&DEVNET_DEFAULT_GAS_PRICE)
         );
         assert_eq!(resp_skip_validation["fee_estimation"]["overall_fee"], "0xa7247397f6000");
 
@@ -142,24 +142,18 @@ mod gas_modification_tests {
             .await
             .unwrap()[0];
 
-        assert_eq!(resp_no_flags["fee_estimation"]["gas_price"], format!("0x{:x}", wei_price));
-        assert_eq!(
-            resp_no_flags["fee_estimation"]["data_gas_price"],
-            format!("0x{:x}", wei_price_data)
-        );
+        assert_eq!(resp_no_flags["fee_estimation"]["gas_price"], to_hex_felt(&wei_price));
+        assert_eq!(resp_no_flags["fee_estimation"]["data_gas_price"], to_hex_felt(&wei_price_data));
         assert_eq!(resp_no_flags["fee_estimation"]["overall_fee"], "0x38008384ec45ab780000");
 
         let resp_skip_validation = &devnet
             .send_custom_rpc("starknet_simulateTransactions", params_skip_validation)
             .await
             .unwrap()[0];
-        assert_eq!(
-            resp_skip_validation["fee_estimation"]["gas_price"],
-            format!("0x{:x}", wei_price)
-        );
+        assert_eq!(resp_skip_validation["fee_estimation"]["gas_price"], to_hex_felt(&wei_price));
         assert_eq!(
             resp_skip_validation["fee_estimation"]["data_gas_price"],
-            format!("0x{:x}", wei_price_data)
+            to_hex_felt(&wei_price_data)
         );
         assert_eq!(resp_skip_validation["fee_estimation"]["overall_fee"], "0x37ff89b813a3e6700000");
 


### PR DESCRIPTION
## Usage related changes

None

## Development related changes

- More widespread use of to_hex_felt.
- Remove unused method `biguint_max`.
- In a couple of places avoid serializing to string only to be parsed to felt.

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
