### PR TITLE
Adapt to Starknet 0.13.2.1 (blockifier 0.8.0-rc.3); Release Devnet v0.2.0-rc.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "blockifier"
-version = "0.8.0-rc.2"
+version = "0.8.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee25790785713833ed52ecbf39032abfc59fbcc4440feb7062fcf33fb596423"
+checksum = "0fb99b6d20e12f5dff17a2b53e3e6cab54766357a638f90dafcb43c0ac933d4b"
 dependencies = [
  "anyhow",
  "ark-ec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5754,7 +5754,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-devnet"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5786,7 +5786,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-devnet-core"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 dependencies = [
  "blockifier",
  "cairo-lang-starknet-classes",
@@ -5815,7 +5815,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-devnet-server"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5842,7 +5842,7 @@ dependencies = [
 
 [[package]]
 name = "starknet-devnet-types"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 dependencies = [
  "base64 0.22.1",
  "bigdecimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,9 +96,9 @@ cairo-lang-syntax = "=2.7.0"
 cairo-lang-utils = "=2.7.0"
 
 # Inner dependencies
-starknet-types = { version = "0.2.0-rc.2", path = "crates/starknet-devnet-types", package = "starknet-devnet-types" }
-starknet-core = { version = "0.2.0-rc.2", path = "crates/starknet-devnet-core", package = "starknet-devnet-core" }
-server = { version = "0.2.0-rc.2", path = "crates/starknet-devnet-server", package = "starknet-devnet-server" }
+starknet-types = { version = "0.2.0-rc.3", path = "crates/starknet-devnet-types", package = "starknet-devnet-types" }
+starknet-core = { version = "0.2.0-rc.3", path = "crates/starknet-devnet-core", package = "starknet-devnet-core" }
+server = { version = "0.2.0-rc.3", path = "crates/starknet-devnet-server", package = "starknet-devnet-server" }
 
 # Dependabot alerts
 zerocopy = "0.7.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ enum-helper-macros = "0.0.1"
 # Starknet dependencies
 starknet-types-core = "0.1.5"
 starknet_api = { version = "0.13.0-rc.0", features = ["testing"] }
-blockifier = { version = "0.8.0-rc.2" }
+blockifier = { version = "0.8.0-rc.3" }
 starknet-rs-signers = { version = "0.9.0", package = "starknet-signers" }
 starknet-rs-core = { version = "0.11.0", package = "starknet-core" }
 starknet-rs-providers = { version = "0.11.0", package = "starknet-providers" }

--- a/crates/starknet-devnet-core/Cargo.toml
+++ b/crates/starknet-devnet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-devnet-core"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 edition.workspace = true
 repository.workspace = true
 license-file.workspace = true

--- a/crates/starknet-devnet-server/Cargo.toml
+++ b/crates/starknet-devnet-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-devnet-server"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 edition = "2021"
 repository.workspace = true
 license-file.workspace = true

--- a/crates/starknet-devnet-types/Cargo.toml
+++ b/crates/starknet-devnet-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-devnet-types"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 edition = "2021"
 description = "Starknet types for the devnet"
 repository.workspace = true

--- a/crates/starknet-devnet/Cargo.toml
+++ b/crates/starknet-devnet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet-devnet"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.3"
 edition = "2021"
 repository.workspace = true
 license-file.workspace = true

--- a/crates/starknet-devnet/tests/test_gas_modification.rs
+++ b/crates/starknet-devnet/tests/test_gas_modification.rs
@@ -91,7 +91,7 @@ mod gas_modification_tests {
             resp_no_flags["fee_estimation"]["data_gas_price"],
             to_hex_felt(&DEVNET_DEFAULT_GAS_PRICE)
         );
-        assert_eq!(resp_no_flags["fee_estimation"]["overall_fee"], "0xa7275ca6d3000");
+        assert_eq!(resp_no_flags["fee_estimation"]["overall_fee"], "0x7398c659d800");
 
         let params_skip_validation = get_params(&["SKIP_VALIDATE"]);
         let resp_skip_validation = &devnet
@@ -106,7 +106,7 @@ mod gas_modification_tests {
             resp_skip_validation["fee_estimation"]["data_gas_price"],
             to_hex_felt(&DEVNET_DEFAULT_GAS_PRICE)
         );
-        assert_eq!(resp_skip_validation["fee_estimation"]["overall_fee"], "0xa7247397f6000");
+        assert_eq!(resp_skip_validation["fee_estimation"]["overall_fee"], "0x736a356c0800");
 
         assert_difference_if_validation(
             resp_no_flags,
@@ -144,7 +144,7 @@ mod gas_modification_tests {
 
         assert_eq!(resp_no_flags["fee_estimation"]["gas_price"], to_hex_felt(&wei_price));
         assert_eq!(resp_no_flags["fee_estimation"]["data_gas_price"], to_hex_felt(&wei_price_data));
-        assert_eq!(resp_no_flags["fee_estimation"]["overall_fee"], "0x38008384ec45ab780000");
+        assert_eq!(resp_no_flags["fee_estimation"]["overall_fee"], "0x261b37abed7125c0000");
 
         let resp_skip_validation = &devnet
             .send_custom_rpc("starknet_simulateTransactions", params_skip_validation)
@@ -155,7 +155,7 @@ mod gas_modification_tests {
             resp_skip_validation["fee_estimation"]["data_gas_price"],
             to_hex_felt(&wei_price_data)
         );
-        assert_eq!(resp_skip_validation["fee_estimation"]["overall_fee"], "0x37ff89b813a3e6700000");
+        assert_eq!(resp_skip_validation["fee_estimation"]["overall_fee"], "0x260b9ade6354d540000");
 
         assert_difference_if_validation(
             resp_no_flags,


### PR DESCRIPTION
## Usage related changes

- Uses correct gas price for declaration.
- Release Devnet v0.2.0-rc.3

## Development related changes

- Increment blockifier version to the latest release candidate.

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
