### PR TITLE
Fix L1-L2 message order

### DIFF
--- a/crates/starknet-devnet-core/src/messaging/ethereum.rs
+++ b/crates/starknet-devnet-core/src/messaging/ethereum.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::expect_used)]
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -250,10 +250,10 @@ impl EthereumMessaging {
         &self,
         from_block: u64,
         to_block: u64,
-    ) -> DevnetResult<HashMap<u64, Vec<Log>>> {
+    ) -> DevnetResult<BTreeMap<u64, Vec<Log>>> {
         trace!("Fetching logs for blocks {} - {}.", from_block, to_block);
 
-        let mut block_to_logs: HashMap<u64, Vec<Log>> = HashMap::new();
+        let mut block_to_logs = BTreeMap::<u64, Vec<Log>>::new();
 
         // `sendMessageToL2` topic.
         let log_msg_to_l2_topic =
@@ -275,15 +275,11 @@ impl EthereumMessaging {
             if let Some(block_number) = log.block_number {
                 let block_number = block_number.try_into().map_err(|e| {
                     Error::MessagingError(MessagingError::EthersError(format!(
-                        "Ethereum block number into u64: {}",
-                        e
+                        "Ethereum block number into u64: {e}",
                     )))
                 })?;
 
-                block_to_logs
-                    .entry(block_number)
-                    .and_modify(|v| v.push(log.clone()))
-                    .or_insert(vec![log]);
+                block_to_logs.entry(block_number).or_default().push(log);
             }
         }
 

--- a/crates/starknet-devnet-core/src/messaging/ethereum.rs
+++ b/crates/starknet-devnet-core/src/messaging/ethereum.rs
@@ -214,19 +214,15 @@ impl EthereumMessaging {
                 .map_err(|e| Error::MessagingError(MessagingError::EthersError(
                     format!("Error sending transaction on ethereum: {}", e)
                 )))?
-            // wait for the tx to be mined
-                .await?
+                .await? // wait for the tx to be mined
             {
-                Some(receipt) => {
-                    trace!(
-                        "Message {:064x} sent on L1 with transaction hash {:#x}",
-                        message_hash, receipt.transaction_hash,
-                    );
-                }
+                Some(receipt) => trace!(
+                    "Message {message_hash:064x} sent on L1 with transaction hash {:#x}",
+                    receipt.transaction_hash,
+                ),
                 None => {
                     return Err(Error::MessagingError(MessagingError::EthersError(format!(
-                        "No receipt found for the tx of message hash: {:064x}",
-                        message_hash
+                        "No receipt found for the tx of message hash: {message_hash:064x}",
                     ))));
                 }
             };

--- a/crates/starknet-devnet/tests/common/background_anvil.rs
+++ b/crates/starknet-devnet/tests/common/background_anvil.rs
@@ -33,6 +33,10 @@ impl BackgroundAnvil {
     /// Anvil on this port (as Anvil will actually open the socket right after binding).
     #[allow(dead_code)] // dead_code needed to pass clippy
     pub(crate) async fn spawn() -> Result<Self, TestError> {
+        BackgroundAnvil::spawn_with_additional_args(&[]).await
+    }
+
+    pub(crate) async fn spawn_with_additional_args(args: &[&str]) -> Result<Self, TestError> {
         // Relies on `background_devnet::BackgroundDevnet` starting its check from smaller values
         // (1025). Relies on the probability of M simultaneously spawned Anvils occupying
         // different ports being fairly big (N*(N-1)*...*(N-M+1) / N**M; N=65_000-20_000+1)
@@ -42,6 +46,7 @@ impl BackgroundAnvil {
             .arg("--port")
             .arg(port.to_string())
             .arg("--silent")
+            .args(args)
             .spawn()
             .expect("Could not start background Anvil");
 

--- a/crates/starknet-devnet/tests/common/background_anvil.rs
+++ b/crates/starknet-devnet/tests/common/background_anvil.rs
@@ -121,13 +121,13 @@ impl BackgroundAnvil {
             .await
             .map_err(|e| {
                 TestError::EthersError(format!(
-                    "tx for withdraw l1l2 contract on ethereum failed: {e}"
+                    "tx for withdrawing from l1-l2 contract on ethereum failed: {e}"
                 ))
             })?
             .await
             .map_err(|e| {
                 TestError::EthersError(format!(
-                    "tx for withdraw l1l2 contract on ethereum has no receipt: {e}"
+                    "tx for withdrawing from l1-l2 contract on ethereum has no receipt: {e}"
                 ))
             })?;
 

--- a/crates/starknet-devnet/tests/common/background_anvil.rs
+++ b/crates/starknet-devnet/tests/common/background_anvil.rs
@@ -116,13 +116,13 @@ impl BackgroundAnvil {
             .await
             .map_err(|e| {
                 TestError::EthersError(format!(
-                    "tx for deposit l1l2 contract on ethereum failed: {e}"
+                    "tx for withdraw l1l2 contract on ethereum failed: {e}"
                 ))
             })?
             .await
             .map_err(|e| {
                 TestError::EthersError(format!(
-                    "tx for deposit l1l2 contract on ethereum no receipt: {e}"
+                    "tx for withdraw l1l2 contract on ethereum has no receipt: {e}"
                 ))
             })?;
 
@@ -155,7 +155,7 @@ impl BackgroundAnvil {
             .await
             .map_err(|e| {
                 TestError::EthersError(format!(
-                    "tx for deposit l1l2 contract on ethereum no receipt: {e}"
+                    "tx for deposit l1l2 contract on ethereum has no receipt: {e}"
                 ))
             })?;
 

--- a/crates/starknet-devnet/tests/common/utils.rs
+++ b/crates/starknet-devnet/tests/common/utils.rs
@@ -341,8 +341,8 @@ where
 }
 
 /// Shall succeed if `f` fits into u128
-pub fn felt_to_u256(f: Felt) -> Result<U256, anyhow::Error> {
-    Ok(u128::try_from(f.to_biguint())?.into())
+pub fn felt_to_u256(f: Felt) -> U256 {
+    U256::from_big_endian(&f.to_bytes_be())
 }
 
 #[cfg(test)]

--- a/crates/starknet-devnet/tests/common/utils.rs
+++ b/crates/starknet-devnet/tests/common/utils.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use std::process::{Child, Command};
 use std::sync::Arc;
 
+use ethers::types::U256;
 use server::test_utils::assert_contains;
 use starknet_core::constants::CAIRO_1_ACCOUNT_CONTRACT_SIERRA_HASH;
 use starknet_core::random_number_generator::generate_u32_random_number;
@@ -337,6 +338,11 @@ where
     for e in iterable1 {
         assert!(iterable2.contains(e));
     }
+}
+
+/// Shall succeed if `f` fits into u128
+pub fn felt_to_u256(f: Felt) -> Result<U256, anyhow::Error> {
+    Ok(u128::try_from(f.to_biguint())?.into())
 }
 
 #[cfg(test)]

--- a/crates/starknet-devnet/tests/common/utils.rs
+++ b/crates/starknet-devnet/tests/common/utils.rs
@@ -340,7 +340,6 @@ where
     }
 }
 
-/// Shall succeed if `f` fits into u128
 pub fn felt_to_u256(f: Felt) -> U256 {
     U256::from_big_endian(&f.to_bytes_be())
 }

--- a/crates/starknet-devnet/tests/test_messaging.rs
+++ b/crates/starknet-devnet/tests/test_messaging.rs
@@ -452,7 +452,7 @@ mod test_messaging {
         let user_balance_eth = anvil.get_balance_l1l2(eth_l1l2_address, user_eth).await.unwrap();
         assert_eq!(user_balance_eth, 0.into());
 
-        let sn_l1l2_contract_u256 = felt_to_u256(sn_l1l2_contract).unwrap();
+        let sn_l1l2_contract_u256 = felt_to_u256(sn_l1l2_contract);
 
         // Consume the message to increase the balance.
         anvil
@@ -614,7 +614,7 @@ mod test_messaging {
         // Flush to send the messages.
         devnet.send_custom_rpc("devnet_postmanFlush", json!({})).await.expect("flush failed");
 
-        let sn_l1l2_contract_u256 = felt_to_u256(sn_l1l2_contract).unwrap();
+        let sn_l1l2_contract_u256 = felt_to_u256(sn_l1l2_contract);
 
         // Consume the message to increase the L1 balance.
         anvil
@@ -623,7 +623,7 @@ mod test_messaging {
             .unwrap();
 
         // Send back the amount 1 to the user 1 on L2. Do it n times to have n transactions,
-        // for the purpose of message order testing (n = init balance)
+        // for the purpose of message order testing (n = init_balance)
         for _ in 0..init_balance {
             anvil
                 .deposit_l1l2(eth_l1l2_address, sn_l1l2_contract_u256, user_eth, 1.into())
@@ -639,7 +639,8 @@ mod test_messaging {
             .as_array()
             .unwrap()
             .iter()
-            .map(|msg| msg["nonce"].as_u64().unwrap())
+            .map(|msg| msg["nonce"].as_str().unwrap())
+            .map(|nonce| u64::from_str_radix(nonce.strip_prefix("0x").unwrap(), 16).unwrap())
             .collect();
 
         let expected_nonces: Vec<_> = (0..init_balance).collect();

--- a/crates/starknet-devnet/tests/test_messaging.rs
+++ b/crates/starknet-devnet/tests/test_messaging.rs
@@ -596,12 +596,12 @@ mod test_messaging {
         let user_sn = Felt::ONE;
         let user_eth: U256 = 1.into();
 
-        // Set balance to 1 for the user 1 on L2.
+        // Set balance for the user on L2.
         let init_balance = 5_u64;
         increase_balance(Arc::clone(&sn_account), sn_l1l2_contract, user_sn, init_balance.into())
             .await;
 
-        // Withdraw the amount 1 from user 1 balance on L2 to send it on L1 with a l2->l1 message.
+        // Withdraw the set amount from user 1 balance on L2 to send it on L1 with a l2->l1 message.
         withdraw(
             Arc::clone(&sn_account),
             sn_l1l2_contract,


### PR DESCRIPTION
## Usage related changes

- Close #586 

## Development related changes

- Use `BTreeMap` instead of `HashMap`
- Simplify code to reduce line count in `ethereum.rs`
- Add `spawn_with_additional_args` to `BackgroundAnvil`.
- Fix wrong messages in `BackgroundAnvil` method errors.
- Add utility method `felt_to_u256`.
- Minor refactoring in test `can_interact_with_l1` that improves readability.

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
