### PR TITLE
Fix optional request body; fix payload size check

### DIFF
--- a/crates/starknet-devnet-server/src/rpc_handler.rs
+++ b/crates/starknet-devnet-server/src/rpc_handler.rs
@@ -72,13 +72,13 @@ macro_rules! http_rpc_router {
                 #[allow(non_snake_case)]
                 pub async fn $rpc_method_name<THandler: RpcHandler>(
                     State(handler): State<THandler>,
-                    Json(request): Json<serde_json::Map<String, serde_json::Value>>,
+                    request: Option<Json<serde_json::Map<String, serde_json::Value>>>,
                 ) -> HttpApiResult<Json<serde_json::Value>>{
                     // Convert normal HTTP request to RPC by wrapping
                     let rpc_call = RpcCall::MethodCall(RpcMethodCall {
                         jsonrpc: Version::V2,
                         method: stringify!($rpc_method_name).to_string(),
-                        params: RequestParams::Object(request),
+                        params: RequestParams::Object(request.unwrap_or_default().0),
                         id: Id::Number(0),
                     });
 

--- a/crates/starknet-devnet-server/src/server.rs
+++ b/crates/starknet-devnet-server/src/server.rs
@@ -104,8 +104,10 @@ pub async fn serve_http_api_json_rpc(
 
     routes = routes
         .layer(TimeoutLayer::new(Duration::from_secs(server_config.timeout.into())))
-        // .layer(DefaultBodyLimit::max(server_config.request_body_size_limit))
-        .layer(axum::middleware::from_fn_with_state(server_config.request_body_size_limit, reject_too_big))
+        .layer(axum::middleware::from_fn_with_state(
+            server_config.request_body_size_limit,
+            reject_too_big,
+        ))
         .layer(
             // More details: https://docs.rs/tower-http/latest/tower_http/cors/index.html
             CorsLayer::new()

--- a/crates/starknet-devnet/tests/common/reqwest_client.rs
+++ b/crates/starknet-devnet/tests/common/reqwest_client.rs
@@ -47,6 +47,11 @@ impl ReqwestClient {
             request_builder.json(&body).send().await.map_err(ReqwestError::Error)
         }
     }
+
+    pub async fn post_no_body(&self, path: &str) -> Result<reqwest::Response, ReqwestError> {
+        let url = format!("{}{}", self.url, path);
+        self.reqwest_client.post(&url).send().await.map_err(ReqwestError::Error)
+    }
 }
 
 #[async_trait::async_trait]

--- a/crates/starknet-devnet/tests/general_integration_tests.rs
+++ b/crates/starknet-devnet/tests/general_integration_tests.rs
@@ -29,11 +29,11 @@ mod general_integration_tests {
         let args = ["--request-body-size-limit", &limit.to_string()];
         let devnet = BackgroundDevnet::spawn_with_additional_args(&args).await.unwrap();
 
-        let too_big_path = "a".repeat(limit + 100);
+        let too_long_path = "a".repeat(limit + 100);
         let err = PostReqwestSender::<serde_json::Value, HttpEmptyResponseBody>::post_json_async(
             devnet.reqwest_client(),
             "/load",
-            json!({"path": too_big_path}),
+            json!({"path": too_long_path}),
         )
         .await
         .expect_err("Request should have been rejected");
@@ -60,9 +60,9 @@ mod general_integration_tests {
         let args = ["--request-body-size-limit", &limit.to_string()];
         let devnet = BackgroundDevnet::spawn_with_additional_args(&args).await.unwrap();
 
-        let too_big_path = "a".repeat(limit + 100);
+        let too_long_path = "a".repeat(limit + 100);
         let error = devnet
-            .send_custom_rpc("devnet_load", serde_json::json!({ "path": too_big_path }))
+            .send_custom_rpc("devnet_load", serde_json::json!({ "path": too_long_path }))
             .await
             .expect_err("Request should have been rejected");
 

--- a/crates/starknet-devnet/tests/general_integration_tests.rs
+++ b/crates/starknet-devnet/tests/general_integration_tests.rs
@@ -3,6 +3,7 @@
 pub mod common;
 
 mod general_integration_tests {
+    use reqwest::StatusCode;
     use serde_json::json;
     use server::rpc_core::error::{ErrorCode, RpcError};
     use starknet_core::constants::{
@@ -37,7 +38,7 @@ mod general_integration_tests {
         .await
         .expect_err("Request should have been rejected");
 
-        assert_eq!(err.status(), reqwest::StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(err.status(), StatusCode::PAYLOAD_TOO_LARGE);
 
         // subtract enough so that the rest of the json body doesn't overflow the limit
         let nonexistent_path = "a".repeat(limit - 100);
@@ -49,7 +50,7 @@ mod general_integration_tests {
         .await
         .expect_err("Request should have been rejected");
 
-        assert_eq!(err.status(), reqwest::StatusCode::BAD_REQUEST);
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
         assert_eq!(err.error_message(), json!({ "error": "The file does not exist" }).to_string());
     }
 
@@ -65,7 +66,10 @@ mod general_integration_tests {
             .await
             .expect_err("Request should have been rejected");
 
-        assert_eq!(error.code, ErrorCode::ServerError(413));
+        assert_eq!(
+            error.code,
+            ErrorCode::ServerError(StatusCode::PAYLOAD_TOO_LARGE.as_u16().into())
+        );
 
         // subtract enough so that the rest of the json body doesn't overflow the limit
         let nonexistent_path = "a".repeat(limit - 100);

--- a/crates/starknet-devnet/tests/test_blocks_generation.rs
+++ b/crates/starknet-devnet/tests/test_blocks_generation.rs
@@ -23,7 +23,6 @@ mod blocks_generation_tests {
 
     use crate::common::background_devnet::BackgroundDevnet;
     use crate::common::constants;
-    use crate::common::reqwest_client::PostReqwestSender;
     use crate::common::utils::{
         assert_equal_elements, assert_tx_successful, get_contract_balance,
         get_contract_balance_by_block_id, get_events_contract_in_sierra_and_compiled_class_hash,
@@ -651,11 +650,9 @@ mod blocks_generation_tests {
 
         let last_block_before = devnet.get_latest_block_with_tx_hashes().await.unwrap();
 
-        let _: serde_json::Value =
-            devnet.reqwest_client().post_json_async("/create_block", json!({})).await.unwrap();
+        let _ = devnet.reqwest_client().post_no_body("/create_block").await.unwrap();
 
         let last_block_after = devnet.get_latest_block_with_tx_hashes().await.unwrap();
-
         assert_eq!(last_block_after.block_number, last_block_before.block_number + 1);
     }
 }

--- a/crates/starknet-devnet/tests/test_restart.rs
+++ b/crates/starknet-devnet/tests/test_restart.rs
@@ -245,4 +245,18 @@ mod test_restart {
 
         remove_file(dump_file_name);
     }
+
+    #[tokio::test]
+    async fn restarting_via_non_rpc() {
+        let devnet = BackgroundDevnet::spawn().await.unwrap();
+
+        let dummy_address = Felt::ONE;
+        let mint_amount = 100;
+        devnet.mint(dummy_address, mint_amount).await;
+
+        devnet.reqwest_client().post_no_body("/restart").await.unwrap();
+
+        let balance_after = devnet.get_balance_latest(&dummy_address, FeeUnit::WEI).await.unwrap();
+        assert_eq!(balance_after, Felt::ZERO);
+    }
 }


### PR DESCRIPTION
## Usage related changes

- Optional body support for some non-RPC request originally introduced in #543 and compromised with #572
- Close #598
- #505 was closed with `wontfix`, but this PR also resolves its problem

## Development related changes

- Add method to `reqwest_client` property of `BackgroundDevnet` for POSTing requests without a body.

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
