### PR TITLE
Fix only-query behavior in simulation

### DIFF
--- a/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
@@ -23,9 +23,9 @@ pub fn add_declare_transaction(
         });
     }
 
-    if broadcasted_declare_transaction.is_query_only() {
+    if broadcasted_declare_transaction.is_only_query() {
         return Err(Error::UnsupportedAction {
-            msg: "query-only transactions are not supported".to_string(),
+            msg: "only-query transactions are not supported".to_string(),
         });
     }
 
@@ -195,7 +195,7 @@ mod tests {
 
         match result {
             Err(crate::error::Error::UnsupportedAction { msg }) => {
-                assert_eq!(msg, "query-only transactions are not supported")
+                assert_eq!(msg, "only-query transactions are not supported")
             }
             other => panic!("Unexpected result: {other:?}"),
         };

--- a/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_declare_transaction.rs
@@ -24,7 +24,7 @@ pub fn add_declare_transaction(
     }
 
     let blockifier_declare_transaction = broadcasted_declare_transaction
-        .create_blockifier_declare(&starknet.chain_id().to_felt())?;
+        .create_blockifier_declare(&starknet.chain_id().to_felt(), false)?;
 
     if blockifier_declare_transaction.only_query() {
         return Err(Error::UnsupportedAction {

--- a/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
@@ -21,7 +21,7 @@ pub fn add_deploy_account_transaction(
         });
     }
     let blockifier_deploy_account_transaction = broadcasted_deploy_account_transaction
-        .create_blockifier_deploy_account(&starknet.chain_id().to_felt())?;
+        .create_blockifier_deploy_account(&starknet.chain_id().to_felt(), false)?;
 
     if blockifier_deploy_account_transaction.only_query {
         return Err(Error::UnsupportedAction {
@@ -254,7 +254,7 @@ mod tests {
         );
 
         let blockifier_transaction = BroadcastedDeployAccountTransaction::V1(transaction.clone())
-            .create_blockifier_deploy_account(&DEVNET_DEFAULT_CHAIN_ID.to_felt())
+            .create_blockifier_deploy_account(&DEVNET_DEFAULT_CHAIN_ID.to_felt(), false)
             .unwrap();
 
         // change balance at address
@@ -294,7 +294,7 @@ mod tests {
         let transaction = test_deploy_account_transaction_v3(account_class_hash, 0, 4000);
 
         let blockifier_transaction = BroadcastedDeployAccountTransaction::V3(transaction.clone())
-            .create_blockifier_deploy_account(&DEVNET_DEFAULT_CHAIN_ID.to_felt())
+            .create_blockifier_deploy_account(&DEVNET_DEFAULT_CHAIN_ID.to_felt(), false)
             .unwrap();
 
         // change balance at address
@@ -352,7 +352,7 @@ mod tests {
             Felt::ONE,
         );
         let blockifier_transaction = BroadcastedDeployAccountTransaction::V1(transaction.clone())
-            .create_blockifier_deploy_account(&DEVNET_DEFAULT_CHAIN_ID.to_felt())
+            .create_blockifier_deploy_account(&DEVNET_DEFAULT_CHAIN_ID.to_felt(), false)
             .unwrap();
 
         // change balance at address

--- a/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_deploy_account_transaction.rs
@@ -21,9 +21,9 @@ pub fn add_deploy_account_transaction(
         });
     }
 
-    if broadcasted_deploy_account_transaction.is_query_only() {
+    if broadcasted_deploy_account_transaction.is_only_query() {
         return Err(Error::UnsupportedAction {
-            msg: "query-only transactions are not supported".to_string(),
+            msg: "only-query transactions are not supported".to_string(),
         });
     }
 
@@ -133,7 +133,7 @@ mod tests {
 
         match result {
             Err(crate::error::Error::UnsupportedAction { msg }) => {
-                assert_eq!(msg, "query-only transactions are not supported")
+                assert_eq!(msg, "only-query transactions are not supported")
             }
             other => panic!("Unexpected result: {other:?}"),
         };

--- a/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
@@ -18,9 +18,9 @@ pub fn add_invoke_transaction(
         return Err(Error::MaxFeeZeroError { tx_type: broadcasted_invoke_transaction.to_string() });
     }
 
-    if broadcasted_invoke_transaction.is_query_only() {
+    if broadcasted_invoke_transaction.is_only_query() {
         return Err(Error::UnsupportedAction {
-            msg: "query-only transactions are not supported".to_string(),
+            msg: "only-query transactions are not supported".to_string(),
         });
     }
 
@@ -180,7 +180,7 @@ mod tests {
         let result = Starknet::default().add_invoke_transaction(invoke_transaction);
         match result {
             Err(crate::error::Error::UnsupportedAction { msg }) => {
-                assert_eq!(msg, "query-only transactions are not supported")
+                assert_eq!(msg, "only-query transactions are not supported")
             }
             other => panic!("Unexpected result: {other:?}"),
         };

--- a/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
@@ -19,7 +19,7 @@ pub fn add_invoke_transaction(
     }
 
     let blockifier_invoke_transaction = broadcasted_invoke_transaction
-        .create_blockifier_invoke_transaction(&starknet.chain_id().to_felt())?;
+        .create_blockifier_invoke_transaction(&starknet.chain_id().to_felt(), false)?;
 
     if blockifier_invoke_transaction.only_query {
         return Err(Error::UnsupportedAction {

--- a/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
+++ b/crates/starknet-devnet-core/src/starknet/add_invoke_transaction.rs
@@ -18,14 +18,14 @@ pub fn add_invoke_transaction(
         return Err(Error::MaxFeeZeroError { tx_type: broadcasted_invoke_transaction.to_string() });
     }
 
-    let blockifier_invoke_transaction = broadcasted_invoke_transaction
-        .create_blockifier_invoke_transaction(&starknet.chain_id().to_felt(), false)?;
-
-    if blockifier_invoke_transaction.only_query {
+    if broadcasted_invoke_transaction.is_query_only() {
         return Err(Error::UnsupportedAction {
             msg: "query-only transactions are not supported".to_string(),
         });
     }
+
+    let blockifier_invoke_transaction = broadcasted_invoke_transaction
+        .create_blockifier_invoke_transaction(&starknet.chain_id().to_felt(), false)?;
 
     let transaction_hash = blockifier_invoke_transaction.tx_hash.0;
 
@@ -177,13 +177,13 @@ mod tests {
             }
         }
 
-        let txn_err = Starknet::default().add_invoke_transaction(invoke_transaction).unwrap_err();
-        match txn_err {
-            crate::error::Error::UnsupportedAction { msg } => {
-                assert_eq!(msg, "query-only transactions are not supported".to_string());
+        let result = Starknet::default().add_invoke_transaction(invoke_transaction);
+        match result {
+            Err(crate::error::Error::UnsupportedAction { msg }) => {
+                assert_eq!(msg, "query-only transactions are not supported")
             }
-            _ => panic!("Wrong error type"),
-        }
+            other => panic!("Unexpected result: {other:?}"),
+        };
     }
 
     #[test]

--- a/crates/starknet-devnet-core/src/starknet/estimations.rs
+++ b/crates/starknet-devnet-core/src/starknet/estimations.rs
@@ -33,7 +33,7 @@ pub fn estimate_fee(
             .iter()
             .map(|txn| {
                 Ok((
-                    txn.to_blockifier_account_transaction(&chain_id)?,
+                    txn.to_blockifier_account_transaction(&chain_id, true)?,
                     Starknet::should_transaction_skip_validation_if_sender_is_impersonated(
                         state, &cheats, txn,
                     )?,

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -1160,7 +1160,7 @@ impl Starknet {
                 .iter()
                 .map(|txn| {
                     Ok((
-                        txn.to_blockifier_account_transaction(&chain_id)?,
+                        txn.to_blockifier_account_transaction(&chain_id, true)?,
                         txn.get_type(),
                         Starknet::should_transaction_skip_validation_if_sender_is_impersonated(
                             state, &cheats, txn,

--- a/crates/starknet-devnet-types/src/rpc/transactions.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions.rs
@@ -269,7 +269,7 @@ pub struct BroadcastedTransactionCommon {
     pub nonce: Nonce,
 }
 
-fn is_query_only_common(version: &Felt) -> bool {
+fn is_only_query_common(version: &Felt) -> bool {
     version >= &QUERY_VERSION_OFFSET
 }
 
@@ -278,8 +278,8 @@ impl BroadcastedTransactionCommon {
         self.max_fee.0 == 0
     }
 
-    pub fn is_query_only(&self) -> bool {
-        is_query_only_common(&self.version)
+    pub fn is_only_query(&self) -> bool {
+        is_only_query_common(&self.version)
     }
 }
 
@@ -361,8 +361,8 @@ impl BroadcastedTransactionCommonV3 {
         l1_is_zero || l2_is_not_zero
     }
 
-    pub fn is_query_only(&self) -> bool {
-        is_query_only_common(&self.version)
+    pub fn is_only_query(&self) -> bool {
+        is_only_query_common(&self.version)
     }
 
     /// Returns an array of Felts that reflects the `common_tx_fields` according to SNIP-8(https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-8.md/#protocol-changes).
@@ -524,11 +524,11 @@ impl BroadcastedDeclareTransaction {
         }
     }
 
-    pub fn is_query_only(&self) -> bool {
+    pub fn is_only_query(&self) -> bool {
         match self {
-            BroadcastedDeclareTransaction::V1(tx) => tx.common.is_query_only(),
-            BroadcastedDeclareTransaction::V2(tx) => tx.common.is_query_only(),
-            BroadcastedDeclareTransaction::V3(tx) => tx.common.is_query_only(),
+            BroadcastedDeclareTransaction::V1(tx) => tx.common.is_only_query(),
+            BroadcastedDeclareTransaction::V2(tx) => tx.common.is_only_query(),
+            BroadcastedDeclareTransaction::V3(tx) => tx.common.is_only_query(),
         }
     }
 
@@ -678,10 +678,10 @@ impl BroadcastedDeployAccountTransaction {
         }
     }
 
-    pub fn is_query_only(&self) -> bool {
+    pub fn is_only_query(&self) -> bool {
         match self {
-            BroadcastedDeployAccountTransaction::V1(tx) => tx.common.is_query_only(),
-            BroadcastedDeployAccountTransaction::V3(tx) => tx.common.is_query_only(),
+            BroadcastedDeployAccountTransaction::V1(tx) => tx.common.is_only_query(),
+            BroadcastedDeployAccountTransaction::V3(tx) => tx.common.is_only_query(),
         }
     }
 
@@ -812,10 +812,10 @@ impl BroadcastedInvokeTransaction {
         }
     }
 
-    pub fn is_query_only(&self) -> bool {
+    pub fn is_only_query(&self) -> bool {
         match self {
-            BroadcastedInvokeTransaction::V1(tx) => tx.common.is_query_only(),
-            BroadcastedInvokeTransaction::V3(tx) => tx.common.is_query_only(),
+            BroadcastedInvokeTransaction::V1(tx) => tx.common.is_only_query(),
+            BroadcastedInvokeTransaction::V3(tx) => tx.common.is_only_query(),
         }
     }
 

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v1.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v1.rs
@@ -119,7 +119,7 @@ mod tests {
 
         let blockifier_declare_transaction =
             BroadcastedDeclareTransaction::V1(Box::new(broadcasted_tx))
-                .create_blockifier_declare(&ChainId::goerli_legacy_id())
+                .create_blockifier_declare(&ChainId::goerli_legacy_id(), false)
                 .unwrap();
 
         assert_eq!(

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v2.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_declare_transaction_v2.rs
@@ -101,7 +101,7 @@ mod tests {
 
         let blockifier_declare_transaction =
             BroadcastedDeclareTransaction::V2(Box::new(broadcasted_declare_transaction))
-                .create_blockifier_declare(&ChainId::goerli_legacy_id())
+                .create_blockifier_declare(&ChainId::goerli_legacy_id(), false)
                 .unwrap();
 
         assert_eq!(

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_deploy_account_transaction_v1.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_deploy_account_transaction_v1.rs
@@ -92,7 +92,7 @@ mod tests {
 
         let blockifier_deploy_account_transaction =
             BroadcastedDeployAccountTransaction::V1(broadcasted_tx)
-                .create_blockifier_deploy_account(&chain_id)
+                .create_blockifier_deploy_account(&chain_id, false)
                 .unwrap();
 
         assert_eq!(

--- a/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_invoke_transaction_v1.rs
+++ b/crates/starknet-devnet-types/src/rpc/transactions/broadcasted_invoke_transaction_v1.rs
@@ -85,7 +85,7 @@ mod tests {
 
         let chain_id = ChainId::goerli_legacy_id();
         let blockifier_transaction = BroadcastedInvokeTransaction::V1(transaction)
-            .create_blockifier_invoke_transaction(&chain_id)
+            .create_blockifier_invoke_transaction(&chain_id, false)
             .unwrap();
 
         assert_eq!(feeder_gateway_transaction.transaction_hash, blockifier_transaction.tx_hash.0);

--- a/crates/starknet-devnet/tests/test_simulate_transactions.rs
+++ b/crates/starknet-devnet/tests/test_simulate_transactions.rs
@@ -462,12 +462,10 @@ mod simulation_tests {
             .await
             .expect("Cannot deploy");
 
-        // let expected_version = Felt::ONE;
-        let expected_version = QUERY_VERSION_OFFSET + Felt::ONE;
         let calls = vec![Call {
             to: contract_address,
             selector: get_selector_from_name("assert_version").unwrap(),
-            calldata: vec![expected_version],
+            calldata: vec![QUERY_VERSION_OFFSET + Felt::ONE], // expected version
         }];
 
         let max_fee = Felt::from(1e18 as u128);


### PR DESCRIPTION
## Usage related changes

- Address the [issue reported by Braavos on Slack](https://spaceshard.slack.com/archives/C03L03VF7PB/p1725884826244199)
- Restore the simulation behavior Devnet had in v0.0.4
- `is_query_only` using `>=` instead of `>` when comparing with `QUERY_VERSION_OFFSET` (`2**128`)
  - Unrelated to the Braavos issue

## Development related changes

- Minor test refactoring

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
