### PR TITLE
docs: fix RPC docs link; add account preservation note

### DIFF
--- a/website/docs/api.md
+++ b/website/docs/api.md
@@ -14,7 +14,7 @@ Unlike Pythonic Devnet, which also supported Starknet's gateway and feeder gatew
 
 ### Devnet API
 
-Devnet has many additional features which are available via their own endpoints and JSON-RPC. The RPC methods are documented throughout the documentation in their corresponding pages, but are also aggregated [here](https://github.com/0xSpaceShard/starknet-devnet-rs/website/static/devnet_api.json).
+Devnet has many additional features which are available via their own endpoints and JSON-RPC. The RPC methods are documented throughout the documentation in their corresponding pages, but are also aggregated [here](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/website/static/devnet_api.json).
 
 :::warning Deprecation notice
 

--- a/website/docs/predeployed.md
+++ b/website/docs/predeployed.md
@@ -4,6 +4,17 @@ Devnet predeploys a [UDC](https://docs.openzeppelin.com/contracts-cairo/0.6.1/ud
 
 The set of accounts can be controlled via [CLI options](./running/cli): `--accounts <NUMBER_OF>`, `--initial-balance <WEI>`, `--seed <VALUE>`.
 
+## Predeployed account preservation
+
+:::note
+
+Once you shut down your Devnet, the predeployed account you used ceases to exist. This may be a problem with tools such as `starkli` which hardcode your account details in a local file. One option then is to delete your account entry from `starkli`'s account file. Another option is to spawn the same account on next Devnet startup. To do this, you can use:
+
+- the `--seed <VALUE>` CLI option which always predeploys the same set of accounts if using the same `<VALUE>` (the seed is logged on startup)
+- the [dump and load feature](./dump-load-restart)
+
+:::
+
 ## Account class selection
 
 Choose between predeploying Cairo 0 (OpenZeppelin 0.5.1) or Cairo 1 (default; OpenZeppelin 0.8.1) accounts by using:

--- a/website/versioned_docs/version-0.2.0/api.md
+++ b/website/versioned_docs/version-0.2.0/api.md
@@ -14,7 +14,7 @@ Unlike Pythonic Devnet, which also supported Starknet's gateway and feeder gatew
 
 ### Devnet API
 
-Devnet has many additional features which are available via their own endpoints and JSON-RPC. The RPC methods are documented throughout the documentation in their corresponding pages, but are also aggregated [here](https://github.com/0xSpaceShard/starknet-devnet-rs/website/static/devnet_api.json).
+Devnet has many additional features which are available via their own endpoints and JSON-RPC. The RPC methods are documented throughout the documentation in their corresponding pages, but are also aggregated [here](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/website/static/devnet_api.json).
 
 :::warning Deprecation notice
 

--- a/website/versioned_docs/version-0.2.0/predeployed.md
+++ b/website/versioned_docs/version-0.2.0/predeployed.md
@@ -4,6 +4,17 @@ Devnet predeploys a [UDC](https://docs.openzeppelin.com/contracts-cairo/0.6.1/ud
 
 The set of accounts can be controlled via [CLI options](./running/cli): `--accounts <NUMBER_OF>`, `--initial-balance <WEI>`, `--seed <VALUE>`.
 
+## Predeployed account preservation
+
+:::note
+
+Once you shut down your Devnet, the predeployed account you used ceases to exist. This may be a problem with tools such as `starkli` which hardcode your account details in a local file. One option then is to delete your account entry from `starkli`'s account file. Another option is to spawn the same account on next Devnet startup. To do this, you can use:
+
+- the `--seed <VALUE>` CLI option which always predeploys the same set of accounts if using the same `<VALUE>` (the seed is logged on startup)
+- the [dump and load feature](./dump-load-restart)
+
+:::
+
 ## Account class selection
 
 Choose between predeploying Cairo 0 (OpenZeppelin 0.5.1) or Cairo 1 (default; OpenZeppelin 0.8.1) accounts by using:


### PR DESCRIPTION
## Usage related changes

- Replace a dead RPC docs link with a correct one.
- Add a note on preserving predeployed accounts.

## Development related changes

None

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
