### PR TITLE
Introduce websocket support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,7 @@ checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
 dependencies = [
  "async-trait",
  "axum-core",
+ "base64 0.21.7",
  "bytes",
  "futures-util",
  "http 1.1.0",
@@ -403,8 +404,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper 1.0.1",
  "tokio",
+ "tokio-tungstenite 0.21.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -2677,7 +2680,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.20.1",
  "tracing",
  "tracing-futures",
  "url",
@@ -6437,8 +6440,20 @@ dependencies = [
  "rustls 0.21.12",
  "tokio",
  "tokio-rustls 0.24.1",
- "tungstenite",
+ "tungstenite 0.20.1",
  "webpki-roots",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.21.0",
 ]
 
 [[package]]
@@ -6648,6 +6663,25 @@ dependencies = [
  "log",
  "rand",
  "rustls 0.21.12",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "rand",
  "sha1",
  "thiserror",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5824,6 +5824,7 @@ dependencies = [
  "starknet-signers",
  "thiserror",
  "tokio",
+ "tokio-tungstenite 0.21.0",
  "tracing",
  "tracing-subscriber",
  "universal-sierra-compiler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ keywords = ["starknet", "cairo", "testnet", "local", "server"]
 [workspace.dependencies]
 
 # axum
-axum = { version = "0.7" }
+axum = { version = "0.7", features = ["ws"] }
 http-body-util = { version = "0.1" }
 tower-http = { version = "0.5", features = ["full"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ parking_lot = "0.12.3"
 serial_test = "3.1.1"
 hex = "0.4.3"
 lazy_static = { version = "1.4.0" }
+tokio-tungstenite = { version = "0.21.0" }
 
 # Benchmarking
 criterion = { version = "0.3.4", features = ["async_tokio"] }

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -161,10 +161,10 @@ impl RpcHandler for JsonRpcHandler {
         while let Some(msg) = socket.next().await {
             match msg {
                 Ok(Message::Text(text)) => {
-                    self.handle_websocket_call(text.as_bytes(), &mut socket).await;
+                    self.on_websocket_rpc_call(text.as_bytes(), &mut socket).await;
                 }
                 Ok(Message::Binary(bytes)) => {
-                    self.handle_websocket_call(&bytes, &mut socket).await;
+                    self.on_websocket_rpc_call(&bytes, &mut socket).await;
                 }
                 Ok(Message::Close(_)) => {
                     tracing::info!("Websocket disconnected");
@@ -372,7 +372,7 @@ impl JsonRpcHandler {
     }
 
     /// Takes `bytes` to be an encoded RPC call, executes it, and sends the response back via `ws`.
-    async fn handle_websocket_call(&self, bytes: &[u8], ws: &mut WebSocket) {
+    async fn on_websocket_rpc_call(&self, bytes: &[u8], ws: &mut WebSocket) {
         match serde_json::from_slice(bytes) {
             Ok(call) => {
                 let resp = self.on_call(call).await;

--- a/crates/starknet-devnet-server/src/rpc_handler.rs
+++ b/crates/starknet-devnet-server/src/rpc_handler.rs
@@ -63,11 +63,8 @@ pub async fn handle_socket<THandler: RpcHandler>(
 ) -> impl IntoResponse {
     tracing::info!("New websocket connection!");
     ws_upgrade.on_failed_upgrade(|e| tracing::error!("Failed websocket upgrade: {e:?}")).on_upgrade(
-        move |socket| {
-            // let handler_clone = handler.clone();
-            async move {
-                handler.on_websocket(socket).await;
-            }
+        move |socket| async move {
+            handler.on_websocket(socket).await;
         },
     )
 }

--- a/crates/starknet-devnet-server/src/server.rs
+++ b/crates/starknet-devnet-server/src/server.rs
@@ -1,14 +1,12 @@
 use std::time::Duration;
 
 use axum::body::{Body, Bytes};
-use axum::extract::ws::{Message, WebSocket};
-use axum::extract::{Request, State, WebSocketUpgrade};
+use axum::extract::{Request, State};
 use axum::http::{HeaderValue, StatusCode};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post, IntoMakeService, MethodRouter};
 use axum::Router;
-use futures::StreamExt;
 use http_body_util::BodyExt;
 use lazy_static::lazy_static;
 use reqwest::{header, Method};
@@ -57,6 +55,7 @@ fn json_rpc_routes<TJsonRpcHandler: RpcHandler>(json_rpc_handler: TJsonRpcHandle
     Router::new()
         .route("/", post(rpc_handler::handle::<TJsonRpcHandler>))
         .route("/rpc", post(rpc_handler::handle::<TJsonRpcHandler>))
+        .route("/ws", get(rpc_handler::handle_socket::<TJsonRpcHandler>))
         .with_state(json_rpc_handler)
 }
 
@@ -98,7 +97,6 @@ pub async fn serve_http_api_json_rpc(
         .merge(json_rpc_routes(json_rpc_handler.clone()))
         .merge(http_api_routes(http_handler))
         .merge(converted_http_api_routes(json_rpc_handler))
-        .route("/ws", get(ws_handler))
         .layer(TraceLayer::new_for_http());
 
     if server_config.log_response {
@@ -223,36 +221,4 @@ async fn restrictive_middleware(
         }
     }
     Ok(next.run(request).await)
-}
-
-async fn ws_handler(ws: WebSocketUpgrade) -> impl IntoResponse {
-    tracing::info!("New websocket connection!");
-    ws.on_failed_upgrade(|e| tracing::error!("Failed websocket upgrade: {e:?}"))
-        .on_upgrade(handle_socket)
-}
-
-// Function to handle the WebSocket connection
-async fn handle_socket(mut socket: WebSocket) {
-    while let Some(msg) = socket.next().await {
-        match msg {
-            Ok(Message::Text(text)) => {
-                println!("Received: {}", text);
-
-                // Echo the received message back
-                if let Err(e) = socket.send(Message::Text(text)).await {
-                    tracing::error!("Error sending message: {}", e);
-                    return;
-                }
-            }
-            Ok(Message::Close(_)) => {
-                tracing::info!("Websocket disconnected");
-                return;
-            }
-            other => {
-                tracing::error!("Socket handler got an unexpected packet: {other:?}")
-            }
-        }
-    }
-
-    tracing::error!("Failed socket read");
 }

--- a/crates/starknet-devnet/Cargo.toml
+++ b/crates/starknet-devnet/Cargo.toml
@@ -53,6 +53,7 @@ usc = { workspace = true }
 reqwest = { workspace = true }
 criterion = { workspace = true }
 serial_test = { workspace = true }
+tokio-tungstenite = { workspace = true }
 
 
 [[bench]]

--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -25,7 +25,7 @@ use url::Url;
 
 use super::constants::{
     ACCOUNTS, HEALTHCHECK_PATH, HOST, MAX_PORT, MIN_PORT, PREDEPLOYED_ACCOUNT_INITIAL_BALANCE,
-    RPC_PATH, SEED,
+    RPC_PATH, SEED, WS_PATH,
 };
 use super::errors::TestError;
 use super::reqwest_client::{PostReqwestSender, ReqwestClient};
@@ -158,6 +158,10 @@ impl BackgroundDevnet {
         }
 
         Err(TestError::DevnetNotStartable)
+    }
+
+    pub fn ws_url(&self) -> String {
+        format!("ws://{HOST}:{}{WS_PATH}", self.port)
     }
 
     pub async fn send_custom_rpc(

--- a/crates/starknet-devnet/tests/common/constants.rs
+++ b/crates/starknet-devnet/tests/common/constants.rs
@@ -12,6 +12,7 @@ pub const CHAIN_ID_CLI_PARAM: &str = "TESTNET";
 // URL paths
 pub const RPC_PATH: &str = "/rpc";
 pub const HEALTHCHECK_PATH: &str = "/is_alive";
+pub const WS_PATH: &str = "/ws";
 
 // predeployed account info with seed=42
 pub const PREDEPLOYED_ACCOUNT_ADDRESS: &str =

--- a/crates/starknet-devnet/tests/test_websocket.rs
+++ b/crates/starknet-devnet/tests/test_websocket.rs
@@ -11,7 +11,7 @@ mod websocket_support {
 
     use crate::common::background_devnet::BackgroundDevnet;
 
-    async fn send_rpc_via_ws(
+    async fn send_text_rpc_via_ws(
         ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
         method: &str,
         params: serde_json::Value,
@@ -32,12 +32,33 @@ mod websocket_support {
         Ok(resp_body)
     }
 
+    async fn send_binary_rpc_via_ws(
+        ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value, anyhow::Error> {
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": method,
+            "params": params
+        });
+        let binary_body = serde_json::to_vec(&body)?;
+        ws.send(tokio_tungstenite::tungstenite::Message::Binary(binary_body)).await?;
+
+        let resp_raw =
+            ws.next().await.ok_or(anyhow::Error::msg("No response in websocket stream"))??;
+        let resp_body: serde_json::Value = serde_json::from_slice(&resp_raw.into_data())?;
+
+        Ok(resp_body)
+    }
+
     #[tokio::test]
     async fn mint_and_check_tx_via_websocket() {
         let devnet = BackgroundDevnet::spawn().await.unwrap();
         let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
 
-        let mint_resp = send_rpc_via_ws(
+        let mint_resp = send_text_rpc_via_ws(
             &mut ws,
             "devnet_mint",
             json!({
@@ -51,7 +72,7 @@ mod websocket_support {
 
         let tx_hash = mint_resp["result"]["tx_hash"].as_str().unwrap();
 
-        let tx = send_rpc_via_ws(
+        let tx = send_text_rpc_via_ws(
             &mut ws,
             "starknet_getTransactionByHash",
             json!({ "transaction_hash": tx_hash }),
@@ -60,6 +81,29 @@ mod websocket_support {
         .unwrap();
 
         assert!(tx["result"].is_object());
+    }
+
+    #[tokio::test]
+    async fn create_block_via_binary_ws_message() {
+        let devnet = BackgroundDevnet::spawn().await.unwrap();
+        let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
+
+        let block_specifier = json!({ "block_id": "latest" });
+        let block_resp_before =
+            send_binary_rpc_via_ws(&mut ws, "starknet_getBlockWithTxs", block_specifier.clone())
+                .await
+                .unwrap();
+        assert_eq!(block_resp_before["result"]["block_number"], 0);
+
+        let creation_resp =
+            send_binary_rpc_via_ws(&mut ws, "devnet_createBlock", json!({})).await.unwrap();
+        assert!(creation_resp["result"].is_object());
+
+        let block_resp_after =
+            send_binary_rpc_via_ws(&mut ws, "starknet_getBlockWithTxs", block_specifier)
+                .await
+                .unwrap();
+        assert_eq!(block_resp_after["result"]["block_number"], 1);
     }
 
     #[tokio::test]
@@ -76,7 +120,7 @@ mod websocket_support {
         let dummy_address: &str = "0x1";
         let single_mint_amount = 10;
         for ws in &mut ws_streams {
-            send_rpc_via_ws(
+            send_text_rpc_via_ws(
                 ws,
                 "devnet_mint",
                 json!({ "address": dummy_address, "amount": single_mint_amount }),
@@ -97,7 +141,7 @@ mod websocket_support {
         let devnet = BackgroundDevnet::spawn().await.unwrap();
         let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
 
-        let resp = send_rpc_via_ws(&mut ws, "devnet_mint", json!({})).await.unwrap();
+        let resp = send_text_rpc_via_ws(&mut ws, "devnet_mint", json!({})).await.unwrap();
         assert_eq!(resp["error"]["message"], "missing field `address`");
     }
 }

--- a/crates/starknet-devnet/tests/test_websocket.rs
+++ b/crates/starknet-devnet/tests/test_websocket.rs
@@ -91,4 +91,13 @@ mod websocket_support {
             .unwrap();
         assert_eq!(balance, Felt::from(single_mint_amount * iterations));
     }
+
+    #[tokio::test]
+    async fn invalid_request() {
+        let devnet = BackgroundDevnet::spawn().await.unwrap();
+        let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
+
+        let resp = send_rpc_via_ws(&mut ws, "devnet_mint", json!({})).await.unwrap();
+        assert_eq!(resp["error"]["message"], "missing field `address`");
+    }
 }

--- a/crates/starknet-devnet/tests/test_websocket.rs
+++ b/crates/starknet-devnet/tests/test_websocket.rs
@@ -1,0 +1,94 @@
+#![cfg(test)]
+pub mod common;
+
+mod websocket_support {
+    use futures::{SinkExt, StreamExt};
+    use serde_json::json;
+    use starknet_rs_core::types::Felt;
+    use starknet_types::rpc::transaction_receipt::FeeUnit;
+    use tokio::net::TcpStream;
+    use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+
+    use crate::common::background_devnet::BackgroundDevnet;
+
+    async fn send_rpc_via_ws(
+        ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value, anyhow::Error> {
+        let text_body = json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": method,
+            "params": params
+        })
+        .to_string();
+        ws.send(tokio_tungstenite::tungstenite::Message::Text(text_body)).await?;
+
+        let resp_raw =
+            ws.next().await.ok_or(anyhow::Error::msg("No response in websocket stream"))??;
+        let resp_body: serde_json::Value = serde_json::from_slice(&resp_raw.into_data())?;
+
+        Ok(resp_body)
+    }
+
+    #[tokio::test]
+    async fn mint_and_check_tx_via_websocket() {
+        let devnet = BackgroundDevnet::spawn().await.unwrap();
+        let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
+
+        let mint_resp = send_rpc_via_ws(
+            &mut ws,
+            "devnet_mint",
+            json!({
+                "address": "0x1",
+                "amount": 100,
+                "unit": "WEI",
+            }),
+        )
+        .await
+        .unwrap();
+
+        let tx_hash = mint_resp["result"]["tx_hash"].as_str().unwrap();
+
+        let tx = send_rpc_via_ws(
+            &mut ws,
+            "starknet_getTransactionByHash",
+            json!({ "transaction_hash": tx_hash }),
+        )
+        .await
+        .unwrap();
+
+        assert!(tx["result"].is_object());
+    }
+
+    #[tokio::test]
+    async fn multiple_ws_connections() {
+        let devnet = BackgroundDevnet::spawn().await.unwrap();
+        let iterations = 10;
+
+        let mut ws_streams = vec![];
+        for _ in 0..iterations {
+            let (ws, _) = connect_async(devnet.ws_url()).await.unwrap();
+            ws_streams.push(ws);
+        }
+
+        let dummy_address: &str = "0x1";
+        let single_mint_amount = 10;
+        for ws in &mut ws_streams {
+            send_rpc_via_ws(
+                ws,
+                "devnet_mint",
+                json!({ "address": dummy_address, "amount": single_mint_amount }),
+            )
+            .await
+            .unwrap();
+        }
+
+        let balance = devnet
+            .get_balance_latest(&Felt::from_hex_unchecked(dummy_address), FeeUnit::WEI)
+            .await
+            .unwrap();
+        assert_eq!(balance, Felt::from(single_mint_amount * iterations));
+    }
+}

--- a/website/docs/api.md
+++ b/website/docs/api.md
@@ -28,7 +28,7 @@ To check if a Devnet instance is alive, send an HTTP request `GET /is_alive`. If
 
 ### WebSocket
 
-All JSON-RPC methods can be accessed via the WebSocket protocol. Devnet is listening for new WebSocket connections at `ws://<HOST>:<PORT>/ws` (notice the protocol scheme). Any request body you would send to `/rpc` you can send as a text message via WebSocket. E.g. using [`wscat`](https://www.npmjs.com/package/wscat) on the same computer where Devnet is spawned at default host and port:
+All JSON-RPC methods can be accessed via the WebSocket protocol. Devnet is listening for new WebSocket connections at `ws://<HOST>:<PORT>/ws` (notice the protocol scheme). Any request body you would send to `/rpc` you can send as a text (or binary) message via WebSocket. E.g. using [`wscat`](https://www.npmjs.com/package/wscat) on the same computer where Devnet is spawned at default host and port:
 
 ```
 $ wscat -c ws://127.0.0.1:5050/ws

--- a/website/docs/api.md
+++ b/website/docs/api.md
@@ -26,6 +26,17 @@ New features are only supported as part of the JSON-RPC API. Older non-RPC reque
 
 To check if a Devnet instance is alive, send an HTTP request `GET /is_alive`. If alive, the Devnet will reply with a `200 OK` and an appropriate message.
 
+### WebSocket
+
+All JSON-RPC methods can be accessed via the WebSocket protocol. Devnet is listening for new WebSocket connections at `ws://<HOST>:<PORT>/ws` (notice the protocol scheme). Any request body you would send to `/rpc` you can send as a text message via WebSocket. E.g. using [`wscat`](https://www.npmjs.com/package/wscat) on the same computer where Devnet is spawned at default host and port:
+
+```
+$ wscat -c ws://127.0.0.1:5050/ws
+Connected (press CTRL+C to quit)
+> { "jsonrpc": "2.0", "id": 0, "method": "devnet_mint", "params": { "amount": 10, "address": "0xabc" } }
+< {"jsonrpc":"2.0","id":0,"result":{"new_balance":"10","unit":"WEI","tx_hash":"0x22aef5a981d547b4e8100b83d4ef82e69dff28e5888c6b1320f38da3a379ad5"}}
+```
+
 ## Interacting with Devnet in JavaScript and TypeScript
 
 To spawn Devnet and interact with it using the [Devnet API](#devnet-api), you can use [`starknet-devnet-js`](https://github.com/0xSpaceShard/starknet-devnet-js/). This can be especially useful in achieving [L1-L2 communication](./postman.md#l1-l2-interaction-via-postman).


### PR DESCRIPTION
## Usage related changes

- Introduce websocket support
- Address partially #613.
- Does **not** include support for new ws rpc methods from the starknet spec.

## Development related changes

- Currently targeting branch `json-rpc-v0.8.0`, but could be changed already to `main` at no breaking cost, in which case a rebase would be needed.

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
