### PR TITLE
Transaction resources 

### DIFF
--- a/crates/starknet-devnet-types/src/rpc/transaction_receipt.rs
+++ b/crates/starknet-devnet-types/src/rpc/transaction_receipt.rs
@@ -222,12 +222,6 @@ impl From<&blockifier::transaction::objects::TransactionExecutionInfo> for Execu
 }
 
 impl ComputationResources {
-    fn get_memory_holes_from_call_info(
-        call_info: &Option<blockifier::execution::call_info::CallInfo>,
-    ) -> usize {
-        if let Some(call) = call_info { call.resources.n_memory_holes } else { 0 }
-    }
-
     fn get_resource_from_execution_info(
         execution_info: &blockifier::transaction::objects::TransactionExecutionInfo,
         resource_name: &BuiltinName,

--- a/crates/starknet-devnet-types/src/rpc/transaction_receipt.rs
+++ b/crates/starknet-devnet-types/src/rpc/transaction_receipt.rs
@@ -170,17 +170,11 @@ impl From<&blockifier::execution::call_info::CallInfo> for ComputationResources 
 
 impl From<&blockifier::transaction::objects::TransactionExecutionInfo> for ExecutionResources {
     fn from(execution_info: &blockifier::transaction::objects::TransactionExecutionInfo) -> Self {
-        let total_memory_holes = ComputationResources::get_memory_holes_from_call_info(
-            &execution_info.execute_call_info,
-        ) + ComputationResources::get_memory_holes_from_call_info(
-            &execution_info.validate_call_info,
-        ) + ComputationResources::get_memory_holes_from_call_info(
-            &execution_info.fee_transfer_call_info,
-        );
+        let memory_holes = execution_info.transaction_receipt.resources.vm_resources.n_memory_holes;
 
         let computation_resources = ComputationResources {
             steps: execution_info.transaction_receipt.resources.total_charged_steps(),
-            memory_holes: if total_memory_holes == 0 { None } else { Some(total_memory_holes) },
+            memory_holes: if memory_holes == 0 { None } else { Some(memory_holes) },
             range_check_builtin_applications:
                 ComputationResources::get_resource_from_execution_info(
                     execution_info,


### PR DESCRIPTION
## Usage related changes

Changed the amount of memory_holes returned from transaction receipt and transaction simulation, based on findings described here: https://github.com/0xSpaceShard/starknet-devnet-rs/issues/641#issuecomment-2488424772

## Checklist:

- [ ] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
- [ ] No spelling errors - `./scripts/check_spelling.sh`
- [ ] Performed code self-review
- [ ] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [ ] Updated the docs if needed - `./website/README.md`
- [ ] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
