### PR TITLE
Support subscribing to events via ws

### DIFF
--- a/crates/starknet-devnet-core/src/starknet/events.rs
+++ b/crates/starknet-devnet-core/src/starknet/events.rs
@@ -86,7 +86,7 @@ pub(crate) fn get_events(
 /// * `address` - Optional. The address to filter the event by.
 /// * `keys_filter` - Optional. The keys to filter the event by.
 /// * `event` - The event to check if it applies to the filters.
-fn check_if_filter_applies_for_event(
+pub fn check_if_filter_applies_for_event(
     address: &Option<ContractAddress>,
     keys_filter: &Option<Vec<Vec<Felt>>>,
     event: &Event,

--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -85,7 +85,7 @@ mod add_l1_handler_transaction;
 mod cheats;
 pub(crate) mod defaulter;
 mod estimations;
-mod events;
+pub mod events;
 mod get_class_impls;
 mod predeployed;
 pub mod starknet_config;
@@ -1032,6 +1032,17 @@ impl Starknet {
             .get_by_hash(transaction_hash)
             .map(|starknet_transaction| &starknet_transaction.inner)
             .ok_or(Error::NoTransaction)
+    }
+
+    pub fn get_unlimited_events(
+        &self,
+        from_block: Option<BlockId>,
+        to_block: Option<BlockId>,
+        address: Option<ContractAddress>,
+        keys: Option<Vec<Vec<Felt>>>,
+    ) -> DevnetResult<Vec<EmittedEvent>> {
+        events::get_events(self, from_block, to_block, address, keys, 0, None)
+            .map(|(emitted_events, _)| emitted_events)
     }
 
     pub fn get_events(

--- a/crates/starknet-devnet-server/src/api/json_rpc/endpoints_ws.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/endpoints_ws.rs
@@ -291,11 +291,11 @@ impl JsonRpcHandler {
     ) -> Result<(), ApiError> {
         let address = maybe_subscription_input
             .as_ref()
-            .and_then(|subscription_input| subscription_input.address);
+            .and_then(|subscription_input| subscription_input.from_address);
 
         let starting_block_id = maybe_subscription_input
             .as_ref()
-            .and_then(|subscription_input| subscription_input.from_block.as_ref())
+            .and_then(|subscription_input| subscription_input.block.as_ref())
             .map(|b| b.0)
             .unwrap_or(BlockId::Tag(BlockTag::Latest));
 

--- a/crates/starknet-devnet-server/src/api/json_rpc/endpoints_ws.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/endpoints_ws.rs
@@ -318,7 +318,6 @@ impl JsonRpcHandler {
             address,
             keys_filter,
         )?;
-        // has_more is expected to be false
 
         for event in events {
             socket_context.notify(subscription_id, SubscriptionNotification::Event(event)).await;

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -311,6 +311,17 @@ impl JsonRpcHandler {
                     }),
                 ));
             }
+
+            let events = starknet.get_unlimited_events(
+                Some(BlockId::Tag(BlockTag::Latest)),
+                Some(BlockId::Tag(BlockTag::Latest)),
+                None,
+                None,
+            )?;
+
+            for event in events {
+                notifications.push(SubscriptionNotification::Event(event));
+            }
         }
 
         let sockets = self.api.sockets.lock().await;

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -17,9 +17,9 @@ use futures::stream::SplitSink;
 use futures::{SinkExt, StreamExt};
 use models::{
     BlockAndClassHashInput, BlockAndContractAddressInput, BlockAndIndexInput, BlockInput,
-    CallInput, EstimateFeeInput, EventsInput, GetStorageInput, L1TransactionHashInput,
-    PendingTransactionsSubscriptionInput, SubscriptionIdInput, TransactionBlockInput,
-    TransactionHashInput, TransactionHashOutput,
+    CallInput, EstimateFeeInput, EventsInput, EventsSubscriptionInput, GetStorageInput,
+    L1TransactionHashInput, PendingTransactionsSubscriptionInput, SubscriptionIdInput,
+    TransactionBlockInput, TransactionHashInput, TransactionHashOutput,
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -757,7 +757,7 @@ pub enum JsonRpcSubscriptionRequest {
     #[serde(rename = "starknet_subscribePendingTransactions", with = "optional_params")]
     PendingTransactions(Option<PendingTransactionsSubscriptionInput>),
     #[serde(rename = "starknet_subscribeEvents")]
-    Events,
+    Events(Option<EventsSubscriptionInput>),
     #[serde(rename = "starknet_unsubscribe")]
     Unsubscribe(SubscriptionIdInput),
 }

--- a/crates/starknet-devnet-server/src/api/json_rpc/models.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/models.rs
@@ -210,8 +210,8 @@ pub struct PendingTransactionsSubscriptionInput {
 #[derive(Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct EventsSubscriptionInput {
-    pub from_block: Option<BlockId>,
-    pub address: Option<ContractAddress>,
+    pub block: Option<BlockId>,
+    pub from_address: Option<ContractAddress>,
     pub keys: Option<Vec<Vec<Felt>>>,
 }
 

--- a/crates/starknet-devnet-server/src/api/json_rpc/models.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/models.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
-use starknet_rs_core::types::{Hash256, TransactionExecutionStatus, TransactionFinalityStatus};
+use starknet_rs_core::types::{
+    Felt, Hash256, TransactionExecutionStatus, TransactionFinalityStatus,
+};
 use starknet_types::contract_address::ContractAddress;
 use starknet_types::felt::{BlockHash, ClassHash, TransactionHash};
 use starknet_types::patricia_key::PatriciaKey;
@@ -203,6 +205,14 @@ pub struct TransactionBlockInput {
 pub struct PendingTransactionsSubscriptionInput {
     pub transaction_details: Option<bool>,
     pub sender_address: Option<Vec<ContractAddress>>,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct EventsSubscriptionInput {
+    pub from_block: Option<BlockId>,
+    pub address: Option<ContractAddress>,
+    pub keys: Option<Vec<Vec<Felt>>>,
 }
 
 #[cfg(test)]

--- a/crates/starknet-devnet-server/src/subscribe.rs
+++ b/crates/starknet-devnet-server/src/subscribe.rs
@@ -94,7 +94,7 @@ impl Subscription {
             }
             Subscription::Events { address, keys_filter } => {
                 if let SubscriptionNotification::Event(event) = notification {
-                    check_if_filter_applies_for_event(address, keys_filter, &event.into());
+                    return check_if_filter_applies_for_event(address, keys_filter, &event.into());
                 }
             }
         }

--- a/crates/starknet-devnet-server/src/subscribe.rs
+++ b/crates/starknet-devnet-server/src/subscribe.rs
@@ -7,6 +7,7 @@ use futures::SinkExt;
 use serde::{self, Serialize};
 use starknet_rs_core::types::BlockTag;
 use starknet_types::contract_address::ContractAddress;
+use starknet_types::emitted_event::EmittedEvent;
 use starknet_types::felt::TransactionHash;
 use starknet_types::rpc::block::BlockHeader;
 use starknet_types::rpc::transactions::{TransactionStatus, TransactionWithHash};
@@ -141,6 +142,7 @@ pub enum SubscriptionNotification {
     NewHeads(Box<BlockHeader>),
     TransactionStatus(NewTransactionStatus),
     PendingTransaction(PendingTransactionNotification),
+    Event(EmittedEvent),
 }
 
 impl SubscriptionNotification {
@@ -152,7 +154,8 @@ impl SubscriptionNotification {
             }
             SubscriptionNotification::PendingTransaction(_) => {
                 "starknet_subscriptionPendingTransactions"
-            } // SubscriptionNotification::Events => "starknet_subscriptionEvents",
+            }
+            SubscriptionNotification::Event(_) => "starknet_subscriptionEvents",
         }
     }
 }

--- a/crates/starknet-devnet-types/src/rpc/emitted_event.rs
+++ b/crates/starknet-devnet-types/src/rpc/emitted_event.rs
@@ -41,3 +41,13 @@ impl From<&blockifier::execution::call_info::OrderedEvent> for OrderedEvent {
         }
     }
 }
+
+impl From<&EmittedEvent> for Event {
+    fn from(emitted_event: &EmittedEvent) -> Self {
+        Self {
+            from_address: emitted_event.from_address,
+            keys: emitted_event.keys.clone(),
+            data: emitted_event.data.clone(),
+        }
+    }
+}

--- a/crates/starknet-devnet/tests/test_subscription_to_events.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_events.rs
@@ -1,0 +1,165 @@
+#![cfg(test)]
+pub mod common;
+
+mod event_subscription_support {
+    use serde::Serialize;
+    use serde_json::json;
+    use starknet_rs_accounts::{Account, ExecutionEncoding, SingleOwnerAccount};
+    use starknet_rs_core::types::{BlockId, Call, Felt, InvokeTransactionResult};
+    use starknet_rs_core::utils::get_selector_from_name;
+    use starknet_rs_providers::jsonrpc::HttpTransport;
+    use starknet_rs_providers::JsonRpcClient;
+    use starknet_rs_signers::LocalWallet;
+    use starknet_types::contract_address::ContractAddress;
+    use tokio::net::TcpStream;
+    use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+
+    use crate::common::background_devnet::BackgroundDevnet;
+    use crate::common::constants;
+    use crate::common::utils::{
+        assert_no_notifications, declare_v3_deploy_v3,
+        get_events_contract_in_sierra_and_compiled_class_hash, receive_rpc_via_ws,
+        send_text_rpc_via_ws, unsubscribe,
+    };
+
+    async fn subscribe_events(
+        ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
+        params: serde_json::Value,
+    ) -> Result<i64, anyhow::Error> {
+        let subscription_confirmation =
+            send_text_rpc_via_ws(ws, "starknet_subscribeEvents", params).await?;
+        subscription_confirmation["result"]
+            .as_i64()
+            .ok_or(anyhow::Error::msg("Subscription did not return a numeric ID"))
+    }
+
+    #[derive(Serialize)]
+    struct EventParams {
+        from_address: Option<ContractAddress>,
+        keys: Option<Vec<Vec<Felt>>>,
+        block: Option<BlockId>,
+    }
+
+    async fn get_single_owner_account(
+        devnet: &BackgroundDevnet,
+    ) -> SingleOwnerAccount<&JsonRpcClient<HttpTransport>, LocalWallet> {
+        let (signer, account_address) = devnet.get_first_predeployed_account().await;
+
+        SingleOwnerAccount::new(
+            &devnet.json_rpc_client,
+            signer,
+            account_address,
+            constants::CHAIN_ID,
+            ExecutionEncoding::New,
+        )
+    }
+
+    /// Returns deployment address.
+    async fn deploy_events_contract(
+        account: &SingleOwnerAccount<&JsonRpcClient<HttpTransport>, LocalWallet>,
+    ) -> Felt {
+        let (sierra, casm_hash) = get_events_contract_in_sierra_and_compiled_class_hash();
+
+        let (_, address) = declare_v3_deploy_v3(account, sierra, casm_hash, &[]).await.unwrap();
+        address
+    }
+
+    async fn emit_static_event(
+        account: &SingleOwnerAccount<&JsonRpcClient<HttpTransport>, LocalWallet>,
+        contract_address: Felt,
+    ) -> Result<InvokeTransactionResult, anyhow::Error> {
+        account
+            .execute_v3(vec![Call {
+                to: contract_address,
+                selector: get_selector_from_name("emit_event").unwrap(),
+                calldata: vec![Felt::ZERO], // what kind of event to emit
+            }])
+            .send()
+            .await
+            .map_err(|e| anyhow::Error::msg(e.to_string()))
+    }
+
+    #[tokio::test]
+    async fn event_subscription_with_no_params_until_unsubscription() {
+        let devnet = BackgroundDevnet::spawn().await.unwrap();
+        let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
+
+        let subscription_id = subscribe_events(&mut ws, json!({})).await.unwrap();
+
+        let account = get_single_owner_account(&devnet).await;
+        let contract_address = deploy_events_contract(&account).await;
+
+        let invocation = emit_static_event(&account, contract_address).await.unwrap();
+
+        let notification = receive_rpc_via_ws(&mut ws).await.unwrap();
+        assert_eq!(
+            notification,
+            json!({
+                "jsonrpc": "2.0",
+                "method": "starknet_subscriptionEvents",
+                "params": {
+                    "subscription_id": subscription_id,
+                    "result": todo!()
+                }
+            })
+        );
+
+        assert_no_notifications(&mut ws).await;
+
+        unsubscribe(&mut ws, subscription_id).await.unwrap();
+
+        emit_static_event(&account, contract_address).await.unwrap();
+
+        assert_no_notifications(&mut ws).await;
+    }
+
+    #[tokio::test]
+    async fn should_notify_only_from_filtered_address() {
+        let devnet = BackgroundDevnet::spawn().await.unwrap();
+        let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
+
+        let subscription_id = subscribe_events(&mut ws, json!({})).await.unwrap();
+
+        todo!()
+    }
+
+    #[tokio::test]
+    async fn should_notify_only_from_filtered_key() {
+        let devnet = BackgroundDevnet::spawn().await.unwrap();
+        let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
+
+        let subscription_id = subscribe_events(&mut ws, json!({})).await.unwrap();
+
+        todo!()
+    }
+
+    #[tokio::test]
+    async fn should_notify_only_from_filtered_key_and_address() {
+        let devnet = BackgroundDevnet::spawn().await.unwrap();
+        let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
+
+        let subscription_id = subscribe_events(&mut ws, json!({})).await.unwrap();
+
+        todo!()
+    }
+
+    #[tokio::test]
+    async fn should_notify_of_events_in_old_blocks_with_no_filters() {
+        unimplemented!()
+    }
+
+    #[tokio::test]
+    async fn should_notify_of_events_in_old_blocks_with_address_filter() {
+        unimplemented!()
+    }
+
+    #[tokio::test]
+    async fn should_notify_of_events_in_old_blocks_with_key_filter() {
+        unimplemented!()
+    }
+
+    #[tokio::test]
+    async fn should_notify_of_events_in_old_blocks_with_address_and_key_filter() {
+        unimplemented!()
+    }
+}

--- a/crates/starknet-devnet/tests/test_subscription_to_events.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_events.rs
@@ -4,8 +4,9 @@ pub mod common;
 mod event_subscription_support {
     use serde::Serialize;
     use serde_json::json;
+    use starknet_core::constants::{ETH_ERC20_CONTRACT_ADDRESS, UDC_CONTRACT_ADDRESS};
     use starknet_rs_accounts::{Account, ExecutionEncoding, SingleOwnerAccount};
-    use starknet_rs_core::types::{BlockId, Call, Felt, InvokeTransactionResult};
+    use starknet_rs_core::types::{BlockId, BlockTag, Call, Felt, InvokeTransactionResult};
     use starknet_rs_core::utils::get_selector_from_name;
     use starknet_rs_providers::jsonrpc::HttpTransport;
     use starknet_rs_providers::JsonRpcClient;
@@ -79,6 +80,10 @@ mod event_subscription_support {
             .map_err(|e| anyhow::Error::msg(e.to_string()))
     }
 
+    fn static_event_key() -> Felt {
+        get_selector_from_name("StaticEvent").unwrap()
+    }
+
     #[tokio::test]
     async fn event_subscription_with_no_params_until_unsubscription() {
         let devnet = BackgroundDevnet::spawn().await.unwrap();
@@ -89,7 +94,13 @@ mod event_subscription_support {
         let account = get_single_owner_account(&devnet).await;
         let contract_address = deploy_events_contract(&account).await;
 
-        let _invocation = emit_static_event(&account, contract_address).await.unwrap();
+        // discard notifications emitted by system contracts
+        receive_rpc_via_ws(&mut ws).await.unwrap(); // erc20 - fee charge
+        receive_rpc_via_ws(&mut ws).await.unwrap(); // erc20 - fee charge
+        receive_rpc_via_ws(&mut ws).await.unwrap(); // udc   - deployment
+
+        let invocation = emit_static_event(&account, contract_address).await.unwrap();
+        let latest_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
 
         let notification = receive_rpc_via_ws(&mut ws).await.unwrap();
         assert_eq!(
@@ -99,11 +110,19 @@ mod event_subscription_support {
                 "method": "starknet_subscriptionEvents",
                 "params": {
                     "subscription_id": subscription_id,
-                    "result": {},
+                    "result": {
+                        "transaction_hash": invocation.transaction_hash,
+                        "block_hash": latest_block.block_hash,
+                        "block_number": latest_block.block_number,
+                        "from_address": contract_address,
+                        "keys": [static_event_key()],
+                        "data": []
+                    },
                 }
             })
         );
 
+        receive_rpc_via_ws(&mut ws).await.unwrap(); // erc20 - fee charge
         assert_no_notifications(&mut ws).await;
 
         unsubscribe(&mut ws, subscription_id).await.unwrap();
@@ -123,7 +142,8 @@ mod event_subscription_support {
         let subscription_params = json!({ "from_address": contract_address });
         let subscription_id = subscribe_events(&mut ws, subscription_params).await.unwrap();
 
-        emit_static_event(&account, contract_address).await.unwrap();
+        let invocation = emit_static_event(&account, contract_address).await.unwrap();
+        let latest_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
 
         let notification = receive_rpc_via_ws(&mut ws).await.unwrap();
         assert_eq!(
@@ -133,7 +153,14 @@ mod event_subscription_support {
                 "method": "starknet_subscriptionEvents",
                 "params": {
                     "subscription_id": subscription_id,
-                    "result": {},
+                    "result": {
+                        "transaction_hash": invocation.transaction_hash,
+                        "block_hash": latest_block.block_hash,
+                        "block_number": latest_block.block_number,
+                        "from_address": contract_address,
+                        "keys": [static_event_key()],
+                        "data": []
+                    },
                 }
             })
         );
@@ -142,17 +169,18 @@ mod event_subscription_support {
     }
 
     #[tokio::test]
-    async fn should_notify_of_new_events_only_from_filtered_key_and_address() {
+    async fn should_notify_of_new_events_only_from_filtered_key() {
         let devnet = BackgroundDevnet::spawn().await.unwrap();
         let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
 
         let account = get_single_owner_account(&devnet).await;
         let contract_address = deploy_events_contract(&account).await;
 
-        let subscription_params = json!({ "from_address": contract_address, "keys": [[]] });
+        let subscription_params = json!({ "keys": [[static_event_key()]] });
         let subscription_id = subscribe_events(&mut ws, subscription_params).await.unwrap();
 
-        emit_static_event(&account, contract_address).await.unwrap();
+        let invocation = emit_static_event(&account, contract_address).await.unwrap();
+        let latest_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
 
         let notification = receive_rpc_via_ws(&mut ws).await.unwrap();
         assert_eq!(
@@ -162,7 +190,14 @@ mod event_subscription_support {
                 "method": "starknet_subscriptionEvents",
                 "params": {
                     "subscription_id": subscription_id,
-                    "result": {},
+                    "result": {
+                        "transaction_hash": invocation.transaction_hash,
+                        "block_hash": latest_block.block_hash,
+                        "block_number": latest_block.block_number,
+                        "from_address": contract_address,
+                        "keys": [static_event_key()],
+                        "data": []
+                    },
                 }
             })
         );
@@ -177,9 +212,11 @@ mod event_subscription_support {
 
         let account = get_single_owner_account(&devnet).await;
         let contract_address = deploy_events_contract(&account).await;
-        emit_static_event(&account, contract_address).await.unwrap();
+        let invocation = emit_static_event(&account, contract_address).await.unwrap();
+        let latest_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
 
-        let subscription_id = subscribe_events(&mut ws, json!({})).await.unwrap();
+        let subscription_id =
+            subscribe_events(&mut ws, json!({ "from_address": contract_address })).await.unwrap();
         let notification = receive_rpc_via_ws(&mut ws).await.unwrap();
 
         assert_eq!(
@@ -189,7 +226,14 @@ mod event_subscription_support {
                 "method": "starknet_subscriptionEvents",
                 "params": {
                     "subscription_id": subscription_id,
-                    "result": {},
+                    "result": {
+                        "transaction_hash": invocation.transaction_hash,
+                        "block_hash": latest_block.block_hash,
+                        "block_number": latest_block.block_number,
+                        "from_address": contract_address,
+                        "keys": [static_event_key()],
+                        "data": []
+                    },
                 }
             })
         );
@@ -203,15 +247,18 @@ mod event_subscription_support {
         let devnet = BackgroundDevnet::spawn_with_additional_args(&devnet_args).await.unwrap();
         let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
 
-        let account = get_single_owner_account(&devnet).await;
+        let mut account = get_single_owner_account(&devnet).await;
+        account.set_block_id(BlockId::Tag(BlockTag::Pending)); // for correct nonce in deployment
+
         let contract_address = deploy_events_contract(&account).await;
         // to have declare+deploy and invoke in two separate blocks
         devnet.create_block().await.unwrap();
 
-        emit_static_event(&account, contract_address).await.unwrap();
-        devnet.create_block().await.unwrap();
+        let invocation = emit_static_event(&account, contract_address).await.unwrap();
+        let latest_block_hash = devnet.create_block().await.unwrap();
 
-        let subscription_id = subscribe_events(&mut ws, json!({})).await.unwrap();
+        let subscription_id =
+            subscribe_events(&mut ws, json!({ "from_address": contract_address })).await.unwrap();
         let notification = receive_rpc_via_ws(&mut ws).await.unwrap();
 
         assert_eq!(
@@ -221,7 +268,14 @@ mod event_subscription_support {
                 "method": "starknet_subscriptionEvents",
                 "params": {
                     "subscription_id": subscription_id,
-                    "result": {},
+                    "result": {
+                        "transaction_hash": invocation.transaction_hash,
+                        "block_hash": latest_block_hash,
+                        "block_number": 2, // genesis = 0, then two block creations
+                        "from_address": contract_address,
+                        "keys": [static_event_key()],
+                        "data": []
+                    },
                 }
             })
         );
@@ -235,20 +289,21 @@ mod event_subscription_support {
         let devnet = BackgroundDevnet::spawn_with_additional_args(&devnet_args).await.unwrap();
         let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
 
-        let account = get_single_owner_account(&devnet).await;
-        let contract_address = deploy_events_contract(&account).await;
+        let mut account = get_single_owner_account(&devnet).await;
+        account.set_block_id(BlockId::Tag(BlockTag::Pending)); // for correct nonce in deployment
 
+        let contract_address = deploy_events_contract(&account).await;
         // to have declare+deploy and invoke in two separate blocks
         devnet.create_block().await.unwrap();
 
-        let subscription_params = json!({ "from_address": contract_address });
-        let subscription_id = subscribe_events(&mut ws, subscription_params).await.unwrap();
+        let subscription_id =
+            subscribe_events(&mut ws, json!({ "from_address": contract_address })).await.unwrap();
 
-        // only receive event once pending->latest
-        emit_static_event(&account, contract_address).await.unwrap();
+        // only receive event when pending->latest
+        let invocation = emit_static_event(&account, contract_address).await.unwrap();
         assert_no_notifications(&mut ws).await;
 
-        devnet.create_block().await.unwrap();
+        let latest_block_hash = devnet.create_block().await.unwrap();
         let notification = receive_rpc_via_ws(&mut ws).await.unwrap();
 
         assert_eq!(
@@ -258,7 +313,14 @@ mod event_subscription_support {
                 "method": "starknet_subscriptionEvents",
                 "params": {
                     "subscription_id": subscription_id,
-                    "result": {},
+                    "result": {
+                        "transaction_hash": invocation.transaction_hash,
+                        "block_hash": latest_block_hash,
+                        "block_number": 2, // genesis = 0, then two block creations
+                        "from_address": contract_address,
+                        "keys": [static_event_key()],
+                        "data": []
+                    },
                 }
             })
         );
@@ -274,16 +336,68 @@ mod event_subscription_support {
         let account = get_single_owner_account(&devnet).await;
         let contract_address = deploy_events_contract(&account).await;
 
-        emit_static_event(&account, contract_address).await.unwrap();
+        let invocation = emit_static_event(&account, contract_address).await.unwrap();
+        let latest_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
 
-        // The declaration happens at block_number=1
-        subscribe_events(&mut ws, json!({ "block": BlockId::Number(1) })).await.unwrap();
+        // The declaration happens at block_number=1 so we query from there to latest
+        let subscription_params =
+            json!({ "block": BlockId::Number(1), "from_address": contract_address });
+        let subscription_id = subscribe_events(&mut ws, subscription_params).await.unwrap();
 
-        let _declaration_notification = receive_rpc_via_ws(&mut ws).await.unwrap();
-        let _deployment_notification = receive_rpc_via_ws(&mut ws).await.unwrap();
+        // declaration of events contract fee charge
+        let declaration_fee_notification = receive_rpc_via_ws(&mut ws).await.unwrap();
+        assert_eq!(declaration_fee_notification["params"]["result"]["block_number"], 1);
+        assert_eq!(
+            declaration_fee_notification["params"]["result"]["from_address"],
+            ETH_ERC20_CONTRACT_ADDRESS.to_hex_string()
+        );
+
+        // deployment of events contract fee charge and udc invocation
+        let deployment_fee_notification = receive_rpc_via_ws(&mut ws).await.unwrap();
+        assert_eq!(deployment_fee_notification["params"]["result"]["block_number"], 2);
+        assert_eq!(
+            declaration_fee_notification["params"]["result"]["from_address"],
+            ETH_ERC20_CONTRACT_ADDRESS.to_hex_string()
+        );
+
+        let deployment_udc_notification = receive_rpc_via_ws(&mut ws).await.unwrap();
+        assert_eq!(deployment_udc_notification["params"]["result"]["block_number"], 2);
+        assert_eq!(
+            declaration_fee_notification["params"]["result"]["from_address"],
+            UDC_CONTRACT_ADDRESS.to_hex_string(),
+        );
+
+        // invocation of events contract
         let invocation_notification = receive_rpc_via_ws(&mut ws).await.unwrap();
+        assert_eq!(
+            invocation_notification,
+            json!({
+               "jsonrpc": "2.0",
+               "method": "starknet_subscriptionEvents",
+               "params": {
+                   "subscription_id": subscription_id,
+                   "result": {
+                       "transaction_hash": invocation.transaction_hash,
+                       "block_hash": latest_block.block_hash,
+                       "block_number": latest_block.block_number,
+                       "from_address": contract_address,
+                       "keys": [static_event_key()],
+                       "data": []
+                   },
+               }
+            })
+        );
 
-        assert_eq!(invocation_notification, json!({}));
+        // invocation of events contract fee charge
+        let invocation_fee_notification = receive_rpc_via_ws(&mut ws).await.unwrap();
+        assert_eq!(
+            invocation_fee_notification["params"]["result"]["block_number"],
+            latest_block.block_number
+        );
+        assert_eq!(
+            invocation_fee_notification["params"]["result"]["from_address"],
+            ETH_ERC20_CONTRACT_ADDRESS.to_hex_string()
+        );
 
         assert_no_notifications(&mut ws).await;
     }

--- a/crates/starknet-devnet/tests/test_subscription_to_events.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_events.rs
@@ -19,8 +19,8 @@ mod event_subscription_support {
     use crate::common::constants;
     use crate::common::utils::{
         assert_no_notifications, declare_v3_deploy_v3,
-        get_events_contract_in_sierra_and_compiled_class_hash, receive_rpc_via_ws,
-        send_text_rpc_via_ws, unsubscribe,
+        get_events_contract_in_sierra_and_compiled_class_hash, receive_notification,
+        receive_rpc_via_ws, send_text_rpc_via_ws, unsubscribe,
     };
 
     async fn subscribe_events(
@@ -102,23 +102,18 @@ mod event_subscription_support {
         let invocation = emit_static_event(&account, contract_address).await.unwrap();
         let latest_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
 
-        let notification = receive_rpc_via_ws(&mut ws).await.unwrap();
+        let event = receive_notification(&mut ws, "starknet_subscriptionEvents", subscription_id)
+            .await
+            .unwrap();
         assert_eq!(
-            notification,
+            event,
             json!({
-                "jsonrpc": "2.0",
-                "method": "starknet_subscriptionEvents",
-                "params": {
-                    "subscription_id": subscription_id,
-                    "result": {
-                        "transaction_hash": invocation.transaction_hash,
-                        "block_hash": latest_block.block_hash,
-                        "block_number": latest_block.block_number,
-                        "from_address": contract_address,
-                        "keys": [static_event_key()],
-                        "data": []
-                    },
-                }
+                "transaction_hash": invocation.transaction_hash,
+                "block_hash": latest_block.block_hash,
+                "block_number": latest_block.block_number,
+                "from_address": contract_address,
+                "keys": [static_event_key()],
+                "data": []
             })
         );
 
@@ -145,23 +140,18 @@ mod event_subscription_support {
         let invocation = emit_static_event(&account, contract_address).await.unwrap();
         let latest_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
 
-        let notification = receive_rpc_via_ws(&mut ws).await.unwrap();
+        let event = receive_notification(&mut ws, "starknet_subscriptionEvents", subscription_id)
+            .await
+            .unwrap();
         assert_eq!(
-            notification,
+            event,
             json!({
-                "jsonrpc": "2.0",
-                "method": "starknet_subscriptionEvents",
-                "params": {
-                    "subscription_id": subscription_id,
-                    "result": {
-                        "transaction_hash": invocation.transaction_hash,
-                        "block_hash": latest_block.block_hash,
-                        "block_number": latest_block.block_number,
-                        "from_address": contract_address,
-                        "keys": [static_event_key()],
-                        "data": []
-                    },
-                }
+                "transaction_hash": invocation.transaction_hash,
+                "block_hash": latest_block.block_hash,
+                "block_number": latest_block.block_number,
+                "from_address": contract_address,
+                "keys": [static_event_key()],
+                "data": []
             })
         );
 
@@ -182,23 +172,18 @@ mod event_subscription_support {
         let invocation = emit_static_event(&account, contract_address).await.unwrap();
         let latest_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
 
-        let notification = receive_rpc_via_ws(&mut ws).await.unwrap();
+        let event = receive_notification(&mut ws, "starknet_subscriptionEvents", subscription_id)
+            .await
+            .unwrap();
         assert_eq!(
-            notification,
+            event,
             json!({
-                "jsonrpc": "2.0",
-                "method": "starknet_subscriptionEvents",
-                "params": {
-                    "subscription_id": subscription_id,
-                    "result": {
-                        "transaction_hash": invocation.transaction_hash,
-                        "block_hash": latest_block.block_hash,
-                        "block_number": latest_block.block_number,
-                        "from_address": contract_address,
-                        "keys": [static_event_key()],
-                        "data": []
-                    },
-                }
+                "transaction_hash": invocation.transaction_hash,
+                "block_hash": latest_block.block_hash,
+                "block_number": latest_block.block_number,
+                "from_address": contract_address,
+                "keys": [static_event_key()],
+                "data": []
             })
         );
 
@@ -217,24 +202,19 @@ mod event_subscription_support {
 
         let subscription_id =
             subscribe_events(&mut ws, json!({ "from_address": contract_address })).await.unwrap();
-        let notification = receive_rpc_via_ws(&mut ws).await.unwrap();
+        let event = receive_notification(&mut ws, "starknet_subscriptionEvents", subscription_id)
+            .await
+            .unwrap();
 
         assert_eq!(
-            notification,
+            event,
             json!({
-                "jsonrpc": "2.0",
-                "method": "starknet_subscriptionEvents",
-                "params": {
-                    "subscription_id": subscription_id,
-                    "result": {
-                        "transaction_hash": invocation.transaction_hash,
-                        "block_hash": latest_block.block_hash,
-                        "block_number": latest_block.block_number,
-                        "from_address": contract_address,
-                        "keys": [static_event_key()],
-                        "data": []
-                    },
-                }
+                "transaction_hash": invocation.transaction_hash,
+                "block_hash": latest_block.block_hash,
+                "block_number": latest_block.block_number,
+                "from_address": contract_address,
+                "keys": [static_event_key()],
+                "data": []
             })
         );
 
@@ -259,24 +239,19 @@ mod event_subscription_support {
 
         let subscription_id =
             subscribe_events(&mut ws, json!({ "from_address": contract_address })).await.unwrap();
-        let notification = receive_rpc_via_ws(&mut ws).await.unwrap();
 
+        let event = receive_notification(&mut ws, "starknet_subscriptionEvents", subscription_id)
+            .await
+            .unwrap();
         assert_eq!(
-            notification,
+            event,
             json!({
-                "jsonrpc": "2.0",
-                "method": "starknet_subscriptionEvents",
-                "params": {
-                    "subscription_id": subscription_id,
-                    "result": {
-                        "transaction_hash": invocation.transaction_hash,
-                        "block_hash": latest_block_hash,
-                        "block_number": 2, // genesis = 0, then two block creations
-                        "from_address": contract_address,
-                        "keys": [static_event_key()],
-                        "data": []
-                    },
-                }
+                "transaction_hash": invocation.transaction_hash,
+                "block_hash": latest_block_hash,
+                "block_number": 2, // genesis = 0, then two block creations
+                "from_address": contract_address,
+                "keys": [static_event_key()],
+                "data": []
             })
         );
 
@@ -304,24 +279,20 @@ mod event_subscription_support {
         assert_no_notifications(&mut ws).await;
 
         let latest_block_hash = devnet.create_block().await.unwrap();
-        let notification = receive_rpc_via_ws(&mut ws).await.unwrap();
+        let notification =
+            receive_notification(&mut ws, "starknet_subscriptionEvents", subscription_id)
+                .await
+                .unwrap();
 
         assert_eq!(
             notification,
             json!({
-                "jsonrpc": "2.0",
-                "method": "starknet_subscriptionEvents",
-                "params": {
-                    "subscription_id": subscription_id,
-                    "result": {
-                        "transaction_hash": invocation.transaction_hash,
-                        "block_hash": latest_block_hash,
-                        "block_number": 2, // genesis = 0, then two block creations
-                        "from_address": contract_address,
-                        "keys": [static_event_key()],
-                        "data": []
-                    },
-                }
+                "transaction_hash": invocation.transaction_hash,
+                "block_hash": latest_block_hash,
+                "block_number": 2, // genesis = 0, then two block creations
+                "from_address": contract_address,
+                "keys": [static_event_key()],
+                "data": []
             })
         );
 
@@ -344,60 +315,53 @@ mod event_subscription_support {
         let subscription_id = subscribe_events(&mut ws, subscription_params).await.unwrap();
 
         // declaration of events contract fee charge
-        let declaration_fee_notification = receive_rpc_via_ws(&mut ws).await.unwrap();
-        assert_eq!(declaration_fee_notification["params"]["result"]["block_number"], 1);
-        assert_eq!(
-            declaration_fee_notification["params"]["result"]["from_address"],
-            STRK_ERC20_CONTRACT_ADDRESS.to_hex_string()
-        );
+        let declaration_fee_event =
+            receive_notification(&mut ws, "starknet_subscriptionEvents", subscription_id)
+                .await
+                .unwrap();
+        assert_eq!(declaration_fee_event["block_number"], 1);
+        assert_eq!(declaration_fee_event["from_address"], json!(STRK_ERC20_CONTRACT_ADDRESS));
 
         // deployment of events contract: udc invocation
-        let deployment_udc_notification = receive_rpc_via_ws(&mut ws).await.unwrap();
-        assert_eq!(deployment_udc_notification["params"]["result"]["block_number"], 2);
-        assert_eq!(
-            deployment_udc_notification["params"]["result"]["from_address"],
-            UDC_CONTRACT_ADDRESS.to_hex_string()
-        );
+        let deployment_udc_event =
+            receive_notification(&mut ws, "starknet_subscriptionEvents", subscription_id)
+                .await
+                .unwrap();
+        assert_eq!(deployment_udc_event["block_number"], 2);
+        assert_eq!(deployment_udc_event["from_address"], json!(UDC_CONTRACT_ADDRESS));
 
         // deployment of events contract: fee charge
-        let deployment_fee_notification = receive_rpc_via_ws(&mut ws).await.unwrap();
-        assert_eq!(deployment_fee_notification["params"]["result"]["block_number"], 2);
-        assert_eq!(
-            deployment_fee_notification["params"]["result"]["from_address"],
-            STRK_ERC20_CONTRACT_ADDRESS.to_hex_string(),
-        );
+        let deployment_fee_event =
+            receive_notification(&mut ws, "starknet_subscriptionEvents", subscription_id)
+                .await
+                .unwrap();
+        assert_eq!(deployment_fee_event["block_number"], 2);
+        assert_eq!(deployment_fee_event["from_address"], json!(STRK_ERC20_CONTRACT_ADDRESS),);
 
         // invocation of events contract
-        let invocation_notification = receive_rpc_via_ws(&mut ws).await.unwrap();
+        let invocation_event =
+            receive_notification(&mut ws, "starknet_subscriptionEvents", subscription_id)
+                .await
+                .unwrap();
         assert_eq!(
-            invocation_notification,
+            invocation_event,
             json!({
-               "jsonrpc": "2.0",
-               "method": "starknet_subscriptionEvents",
-               "params": {
-                   "subscription_id": subscription_id,
-                   "result": {
-                       "transaction_hash": invocation.transaction_hash,
-                       "block_hash": latest_block.block_hash,
-                       "block_number": latest_block.block_number,
-                       "from_address": contract_address,
-                       "keys": [static_event_key()],
-                       "data": []
-                   },
-               }
+                "transaction_hash": invocation.transaction_hash,
+                "block_hash": latest_block.block_hash,
+                "block_number": latest_block.block_number,
+                "from_address": contract_address,
+                "keys": [static_event_key()],
+                "data": []
             })
         );
 
         // invocation of events contract fee charge
-        let invocation_fee_notification = receive_rpc_via_ws(&mut ws).await.unwrap();
-        assert_eq!(
-            invocation_fee_notification["params"]["result"]["block_number"],
-            latest_block.block_number
-        );
-        assert_eq!(
-            invocation_fee_notification["params"]["result"]["from_address"],
-            STRK_ERC20_CONTRACT_ADDRESS.to_hex_string()
-        );
+        let invocation_fee_event =
+            receive_notification(&mut ws, "starknet_subscriptionEvents", subscription_id)
+                .await
+                .unwrap();
+        assert_eq!(invocation_fee_event["block_number"], latest_block.block_number);
+        assert_eq!(invocation_fee_event["from_address"], json!(STRK_ERC20_CONTRACT_ADDRESS));
 
         assert_no_notifications(&mut ws).await;
     }
@@ -419,23 +383,19 @@ mod event_subscription_support {
         let subscription_id = subscribe_events(&mut ws, subscription_params).await.unwrap();
 
         // assert presence of old event (event that was triggered before the subscription)
-        let invocation_notification = receive_rpc_via_ws(&mut ws).await.unwrap();
+        let old_invocation_event =
+            receive_notification(&mut ws, "starknet_subscriptionEvents", subscription_id)
+                .await
+                .unwrap();
         assert_eq!(
-            invocation_notification,
+            old_invocation_event,
             json!({
-               "jsonrpc": "2.0",
-               "method": "starknet_subscriptionEvents",
-               "params": {
-                   "subscription_id": subscription_id,
-                   "result": {
-                       "transaction_hash": old_invocation.transaction_hash,
-                       "block_hash": block_before_subscription.block_hash,
-                       "block_number": block_before_subscription.block_number,
-                       "from_address": contract_address,
-                       "keys": [static_event_key()],
-                       "data": []
-                   },
-               }
+               "transaction_hash": old_invocation.transaction_hash,
+                "block_hash": block_before_subscription.block_hash,
+                "block_number": block_before_subscription.block_number,
+                "from_address": contract_address,
+                "keys": [static_event_key()],
+                "data": []
             })
         );
         assert_no_notifications(&mut ws).await;
@@ -443,23 +403,19 @@ mod event_subscription_support {
         // new event (after subscription)
         let new_invocation = emit_static_event(&account, contract_address).await.unwrap();
         let latest_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
-        let invocation_notification = receive_rpc_via_ws(&mut ws).await.unwrap();
+        let new_invocation_event =
+            receive_notification(&mut ws, "starknet_subscriptionEvents", subscription_id)
+                .await
+                .unwrap();
         assert_eq!(
-            invocation_notification,
+            new_invocation_event,
             json!({
-               "jsonrpc": "2.0",
-               "method": "starknet_subscriptionEvents",
-               "params": {
-                   "subscription_id": subscription_id,
-                   "result": {
-                       "transaction_hash": new_invocation.transaction_hash,
-                       "block_hash": latest_block.block_hash,
-                       "block_number": latest_block.block_number,
-                       "from_address": contract_address,
-                       "keys": [static_event_key()],
-                       "data": []
-                   },
-               }
+               "transaction_hash": new_invocation.transaction_hash,
+                "block_hash": latest_block.block_hash,
+                "block_number": latest_block.block_number,
+                "from_address": contract_address,
+                "keys": [static_event_key()],
+                "data": []
             })
         );
         assert_no_notifications(&mut ws).await;
@@ -482,23 +438,19 @@ mod event_subscription_support {
         let subscription_id = subscribe_events(&mut ws, subscription_params).await.unwrap();
 
         // assert presence of old event (event that was triggered before the subscription)
-        let invocation_notification = receive_rpc_via_ws(&mut ws).await.unwrap();
+        let invocation_event =
+            receive_notification(&mut ws, "starknet_subscriptionEvents", subscription_id)
+                .await
+                .unwrap();
         assert_eq!(
-            invocation_notification,
+            invocation_event,
             json!({
-               "jsonrpc": "2.0",
-               "method": "starknet_subscriptionEvents",
-               "params": {
-                   "subscription_id": subscription_id,
-                   "result": {
-                       "transaction_hash": old_invocation.transaction_hash,
-                       "block_hash": block_before_subscription.block_hash,
-                       "block_number": block_before_subscription.block_number,
-                       "from_address": contract_address,
-                       "keys": [static_event_key()],
-                       "data": []
-                   },
-               }
+                "transaction_hash": old_invocation.transaction_hash,
+                "block_hash": block_before_subscription.block_hash,
+                "block_number": block_before_subscription.block_number,
+                "from_address": contract_address,
+                "keys": [static_event_key()],
+                "data": []
             })
         );
         assert_no_notifications(&mut ws).await;
@@ -506,23 +458,19 @@ mod event_subscription_support {
         // new event (after subscription)
         let new_invocation = emit_static_event(&account, contract_address).await.unwrap();
         let latest_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
-        let invocation_notification = receive_rpc_via_ws(&mut ws).await.unwrap();
+        let invocation_event =
+            receive_notification(&mut ws, "starknet_subscriptionEvents", subscription_id)
+                .await
+                .unwrap();
         assert_eq!(
-            invocation_notification,
+            invocation_event,
             json!({
-               "jsonrpc": "2.0",
-               "method": "starknet_subscriptionEvents",
-               "params": {
-                   "subscription_id": subscription_id,
-                   "result": {
-                       "transaction_hash": new_invocation.transaction_hash,
-                       "block_hash": latest_block.block_hash,
-                       "block_number": latest_block.block_number,
-                       "from_address": contract_address,
-                       "keys": [static_event_key()],
-                       "data": []
-                   },
-               }
+                "transaction_hash": new_invocation.transaction_hash,
+                "block_hash": latest_block.block_hash,
+                "block_number": latest_block.block_number,
+                "from_address": contract_address,
+                "keys": [static_event_key()],
+                "data": []
             })
         );
         assert_no_notifications(&mut ws).await;


### PR DESCRIPTION
## Usage related changes

- Support subscribing to events via ws (`starknet_subscribeEvents`)
- Address partially #613 

## Development related changes

- Reuse existing event extraction logic (required exporting parts of old code).

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
