### PR TITLE
Support reorg subscription

### DIFF
--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -369,8 +369,8 @@ impl JsonRpcHandler {
         new_latest_block: StarknetBlock,
     ) -> Result<(), error::ApiError> {
         // Since it is impossible to determine the hash of the former successor of new_latest_block
-        // directly, we iterate from old_latest_block all the way to the block directly
-        // after new_latest_block.
+        // directly, we iterate from old_latest_block all the way to the aborted successor of
+        // new_latest_block.
         let new_latest_hash = new_latest_block.block_hash();
         let mut orphan_starting_block_hash = old_latest_block.block_hash();
         let starknet = self.api.starknet.lock().await;

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -802,6 +802,7 @@ pub enum JsonRpcRequest {
 
 impl JsonRpcRequest {
     pub fn requires_notifying(&self) -> bool {
+        #![warn(clippy::wildcard_enum_match_arm)]
         match self {
             JsonRpcRequest::SpecVersion => false,
             JsonRpcRequest::BlockWithTransactionHashes(_) => false,

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -358,11 +358,12 @@ impl JsonRpcHandler {
         let mut orphan_starting_block_hash = old_latest_block.block_hash();
         let starknet = self.api.starknet.lock().await;
         loop {
-            let candidate_block = starknet.get_block(&BlockId::Hash(orphan_starting_block_hash))?;
-            if candidate_block.block_hash() == new_latest_hash {
+            let orphan_block = starknet.get_block(&BlockId::Hash(orphan_starting_block_hash))?;
+            let parent_hash = orphan_block.parent_hash();
+            if parent_hash == new_latest_hash {
                 break;
             }
-            orphan_starting_block_hash = candidate_block.parent_hash();
+            orphan_starting_block_hash = parent_hash;
         }
 
         let notification = SubscriptionNotification::Reorg(ReorgData {

--- a/crates/starknet-devnet-server/src/api/json_rpc/write_endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/write_endpoints.rs
@@ -168,6 +168,9 @@ impl JsonRpcHandler {
         let restart_params = data.unwrap_or_default();
         self.api.starknet.lock().await.restart(restart_params.restart_l1_to_l2_messaging)?;
 
+        self.api.sockets.lock().await.clear();
+        tracing::info!("Websocket memory cleared. No subscribers.");
+
         Ok(super::JsonRpcResponse::Empty)
     }
 

--- a/crates/starknet-devnet-server/src/subscribe.rs
+++ b/crates/starknet-devnet-server/src/subscribe.rs
@@ -61,12 +61,6 @@ impl Subscription {
         match (self, notification) {
             (Subscription::NewHeads, SubscriptionNotification::NewHeads(_)) => true,
             (
-                Subscription::NewHeads
-                | Subscription::TransactionStatus { .. }
-                | Subscription::Events { .. },
-                SubscriptionNotification::Reorg(_),
-            ) => true,
-            (
                 Subscription::TransactionStatus { tag, transaction_hash: subscription_hash },
                 SubscriptionNotification::TransactionStatus(notification),
             ) => {
@@ -95,6 +89,12 @@ impl Subscription {
                 Subscription::Events { address, keys_filter },
                 SubscriptionNotification::Event(event),
             ) => check_if_filter_applies_for_event(address, keys_filter, &event.into()),
+            (
+                Subscription::NewHeads
+                | Subscription::TransactionStatus { .. }
+                | Subscription::Events { .. },
+                SubscriptionNotification::Reorg(_),
+            ) => true, // any subscription other than pending tx requires reorg notification
             _ => false,
         }
     }

--- a/crates/starknet-devnet-types/src/rpc/block.rs
+++ b/crates/starknet-devnet-types/src/rpc/block.rs
@@ -118,3 +118,17 @@ pub struct ResourcePrice {
     pub price_in_fri: Felt,
     pub price_in_wei: Felt,
 }
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(deny_unknown_fields)]
+/// Data about reorganized blocks, starting and ending block number and hash
+pub struct ReorgData {
+    /// Hash of the first known block of the orphaned chain
+    pub starting_block_hash: BlockHash,
+    /// Number of the first known block of the orphaned chain
+    pub starting_block_number: BlockNumber,
+    /// The last known block of the orphaned chain
+    pub ending_block_hash: BlockHash,
+    /// Number of the last known block of the orphaned chain
+    pub ending_block_number: BlockNumber,
+}

--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -370,6 +370,30 @@ impl BackgroundDevnet {
         }
     }
 
+    pub async fn abort_blocks(
+        &self,
+        starting_block_id: &BlockId,
+    ) -> Result<Vec<Felt>, anyhow::Error> {
+        let mut aborted_blocks = self
+            .send_custom_rpc(
+                "devnet_abortBlocks",
+                json!({ "starting_block_id" : starting_block_id }),
+            )
+            .await
+            .map_err(|e| anyhow::Error::msg(e.to_string()))?;
+
+        let aborted_blocks = aborted_blocks["aborted"]
+            .take()
+            .as_array()
+            .ok_or(anyhow::Error::msg("Invalid abort response"))?
+            .clone();
+
+        Ok(aborted_blocks
+            .into_iter()
+            .map(|block_hash| serde_json::from_value(block_hash).unwrap())
+            .collect())
+    }
+
     pub async fn get_config(&self) -> serde_json::Value {
         self.send_custom_rpc("devnet_getConfig", json!({})).await.unwrap()
     }

--- a/crates/starknet-devnet/tests/common/utils.rs
+++ b/crates/starknet-devnet/tests/common/utils.rs
@@ -434,6 +434,17 @@ pub async fn send_binary_rpc_via_ws(
     Ok(resp_body)
 }
 
+pub async fn subscribe(
+    ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
+    subscription_method: &str,
+    params: serde_json::Value,
+) -> Result<i64, anyhow::Error> {
+    let subscription_confirmation = send_text_rpc_via_ws(ws, subscription_method, params).await?;
+    subscription_confirmation["result"]
+        .as_i64()
+        .ok_or(anyhow::Error::msg("Subscription did not return a numeric ID"))
+}
+
 /// Tries to read from the provided ws stream. To prevent deadlock, waits for a second at most.
 pub async fn receive_rpc_via_ws(
     ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,

--- a/crates/starknet-devnet/tests/test_get_class.rs
+++ b/crates/starknet-devnet/tests/test_get_class.rs
@@ -240,13 +240,7 @@ mod get_class_tests {
 
         let abortable_block = devnet.get_latest_block_with_tx_hashes().await.unwrap();
 
-        devnet
-            .send_custom_rpc(
-                "devnet_abortBlocks",
-                serde_json::json!({ "starting_block_id": BlockId::Hash(abortable_block.block_hash) }),
-            )
-            .await
-            .unwrap();
+        devnet.abort_blocks(&BlockId::Hash(abortable_block.block_hash)).await.unwrap();
 
         // Getting class at the following block IDs should NOT be successful after abortion; these
         // blocks exist, but their states don't contain the class.

--- a/crates/starknet-devnet/tests/test_subscription_to_blocks.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_blocks.rs
@@ -338,13 +338,7 @@ mod block_subscription_support {
         let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
 
         let new_block_hash = devnet.create_block().await.unwrap();
-        devnet
-            .send_custom_rpc(
-                "devnet_abortBlocks",
-                json!({ "starting_block_id": BlockId::Hash(new_block_hash) }),
-            )
-            .await
-            .unwrap();
+        devnet.abort_blocks(&BlockId::Hash(new_block_hash)).await.unwrap();
 
         let subscription_resp = send_text_rpc_via_ws(
             &mut ws,

--- a/crates/starknet-devnet/tests/test_subscription_to_reorg.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_reorg.rs
@@ -1,0 +1,29 @@
+#![cfg(test)]
+pub mod common;
+
+mod reorg_subscription_support {
+    use tokio_tungstenite::connect_async;
+
+    use crate::common::background_devnet::BackgroundDevnet;
+
+    #[tokio::test]
+    async fn reorg_notification_only_for_some_subscriptions() {
+        let devnet = BackgroundDevnet::spawn().await.unwrap();
+        let (mut _ws, _) = connect_async(devnet.ws_url()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn should_not_notify_after_unsubscription() {
+        unimplemented!();
+    }
+
+    #[tokio::test]
+    async fn socket_with_two_subscriptions_should_get_one_reorg_notification() {
+        unimplemented!();
+    }
+
+    #[tokio::test]
+    async fn restarting_should_forget_all_subscribers_and_not_notify_of_reorg() {
+        unimplemented!()
+    }
+}

--- a/crates/starknet-devnet/tests/test_subscription_to_reorg.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_reorg.rs
@@ -2,19 +2,74 @@
 pub mod common;
 
 mod reorg_subscription_support {
+    use std::collections::HashMap;
+
+    use serde_json::json;
+    use starknet_rs_core::types::BlockId;
     use tokio_tungstenite::connect_async;
 
     use crate::common::background_devnet::BackgroundDevnet;
+    use crate::common::utils::{
+        assert_no_notifications, receive_rpc_via_ws, subscribe, unsubscribe,
+    };
 
     #[tokio::test]
-    async fn reorg_notification_only_for_some_subscriptions() {
-        let devnet = BackgroundDevnet::spawn().await.unwrap();
-        let (mut _ws, _) = connect_async(devnet.ws_url()).await.unwrap();
-    }
+    async fn reorg_notification_for_all_subscriptions_except_pending_tx() {
+        let devnet_args = ["--state-archive-capacity", "full"];
+        let devnet = BackgroundDevnet::spawn_with_additional_args(&devnet_args).await.unwrap();
 
-    #[tokio::test]
-    async fn should_not_notify_after_unsubscription() {
-        unimplemented!();
+        // create blocks for later abortion
+        let starting_block_hash = devnet.create_block().await.unwrap();
+        let ending_block_hash = devnet.create_block().await.unwrap();
+
+        let mut notifiable_subscribers = HashMap::new();
+        for (subscription_method, subscription_params) in [
+            ("starknet_subscribeNewHeads", json!({})),
+            ("starknet_subscribeTransactionStatus", json!({ "transaction_hash": "0x1" })),
+            // TODO ("starknet_subscribeEvents", json!({})),
+        ] {
+            let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
+            let subscription_id =
+                subscribe(&mut ws, subscription_method, subscription_params).await.unwrap();
+            notifiable_subscribers.insert(subscription_id, ws);
+        }
+
+        let (mut unnotifiable_ws, _) = connect_async(devnet.ws_url()).await.unwrap();
+        subscribe(&mut unnotifiable_ws, "starknet_subscribePendingTransactions", json!({}))
+            .await
+            .unwrap();
+
+        // assert that block-, tx_status- and event-subscribers got notified; unsubscribe them
+        devnet.abort_blocks(&BlockId::Hash(ending_block_hash)).await.unwrap();
+        for (subscription_id, ws) in notifiable_subscribers.iter_mut() {
+            let notification = receive_rpc_via_ws(ws).await.unwrap();
+            assert_eq!(
+                notification,
+                json!({
+                    "jsonrpc": "2.0",
+                    "method": "starknet_subscriptionReorg",
+                    "params": {
+                        "result": {
+                            "starting_block_hash": starting_block_hash,
+                            "starting_block_number": 1,
+                            "ending_block_hash": ending_block_hash,
+                            "ending_block_number": 2,
+                        },
+                        "subscription_id": subscription_id,
+                    }
+                })
+            );
+            unsubscribe(ws, *subscription_id).await.unwrap();
+        }
+
+        // now that all sockets are unsubscribed, abort a new block and assert no notifications
+        let additional_block_hash = devnet.create_block().await.unwrap();
+        devnet.abort_blocks(&BlockId::Hash(additional_block_hash)).await.unwrap();
+        for (_, mut ws) in notifiable_subscribers {
+            assert_no_notifications(&mut ws).await;
+        }
+
+        assert_no_notifications(&mut unnotifiable_ws).await;
     }
 
     #[tokio::test]

--- a/crates/starknet-devnet/tests/test_subscription_to_reorg.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_reorg.rs
@@ -40,7 +40,7 @@ mod reorg_subscription_support {
             .unwrap();
 
         // assert that block-, tx_status- and event-subscribers got notified; unsubscribe them
-        devnet.abort_blocks(&BlockId::Hash(ending_block_hash)).await.unwrap();
+        devnet.abort_blocks(&BlockId::Hash(starting_block_hash)).await.unwrap();
         for (subscription_id, ws) in notifiable_subscribers.iter_mut() {
             let notification = receive_rpc_via_ws(ws).await.unwrap();
             assert_eq!(

--- a/crates/starknet-devnet/tests/test_subscription_to_reorg.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_reorg.rs
@@ -79,6 +79,7 @@ mod reorg_subscription_support {
 
         let created_block_hash = devnet.create_block().await.unwrap();
 
+        // one socket, multiple subscriptions
         let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
         let mut subscription_ids = vec![];
         for subscription_method in ["starknet_subscribeNewHeads", "starknet_subscribeEvents"] {

--- a/crates/starknet-devnet/tests/test_subscription_to_reorg.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_reorg.rs
@@ -76,9 +76,4 @@ mod reorg_subscription_support {
     async fn socket_with_two_subscriptions_should_get_one_reorg_notification() {
         unimplemented!();
     }
-
-    #[tokio::test]
-    async fn restarting_should_forget_all_subscribers_and_not_notify_of_reorg() {
-        unimplemented!()
-    }
 }

--- a/crates/starknet-devnet/tests/test_websocket.rs
+++ b/crates/starknet-devnet/tests/test_websocket.rs
@@ -130,7 +130,7 @@ mod websocket_support {
     }
 
     #[tokio::test]
-    async fn restarting_should_forget_all_sockets() {
+    async fn restarting_should_forget_all_websocket_subscriptions() {
         let devnet = BackgroundDevnet::spawn().await.unwrap();
         let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
 

--- a/crates/starknet-devnet/tests/test_websocket.rs
+++ b/crates/starknet-devnet/tests/test_websocket.rs
@@ -8,7 +8,9 @@ mod websocket_support {
     use tokio_tungstenite::connect_async;
 
     use crate::common::background_devnet::BackgroundDevnet;
-    use crate::common::utils::{send_binary_rpc_via_ws, send_text_rpc_via_ws};
+    use crate::common::utils::{
+        assert_no_notifications, send_binary_rpc_via_ws, send_text_rpc_via_ws, subscribe,
+    };
 
     #[tokio::test]
     /// Testing for all non-ws methods would be longsome, so we just test for one devnet_ and one
@@ -125,5 +127,19 @@ mod websocket_support {
 
         let resp = send_text_rpc_via_ws(&mut ws, "devnet_mint", json!({})).await.unwrap();
         assert_eq!(resp["error"]["message"], "missing field `address`");
+    }
+
+    #[tokio::test]
+    async fn restarting_should_forget_all_sockets() {
+        let devnet = BackgroundDevnet::spawn().await.unwrap();
+        let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
+
+        devnet.create_block().await.unwrap();
+
+        subscribe(&mut ws, "starknet_subscribeNewHeads", json!({})).await.unwrap();
+
+        devnet.restart().await;
+
+        assert_no_notifications(&mut ws).await;
     }
 }

--- a/website/docs/blocks.md
+++ b/website/docs/blocks.md
@@ -99,7 +99,7 @@ Aborted blocks can only be queried by block hash. Devnet does not support the ab
 
 ### Reorg
 
-On block abortion, a reorg subscription notification will be sent to all websocket subscribers requiring so according to [JSON-RPC websocket API specification](https://github.com/starkware-libs/starknet-specs/blob/v0.8.0-rc1/api/starknet_ws_api.json#L256). The `starting_block` of the orphaned chain is the successor of the new latest block, and the `ending_block` of the orphaned chain is the block that was latest before aborting. One reorg notification is sent per subscription, not per websocket.
+On block abortion, a reorg subscription notification will be sent to all websocket subscribers requiring so according to [JSON-RPC websocket API specification](https://github.com/starkware-libs/starknet-specs/blob/v0.8.0-rc1/api/starknet_ws_api.json#L256). The `starting_block` of the orphaned chain is the successor of the new latest block and the `ending_block` of the orphaned chain is the block that was latest before aborting. One reorg notification is sent per subscription, not per websocket, meaning that if a websocket has n subscriptions, it will receive n reorg notifications, each with its own subscription ID.
 
 ### Request and response
 

--- a/website/docs/blocks.md
+++ b/website/docs/blocks.md
@@ -97,6 +97,10 @@ Aborted blocks can only be queried by block hash. Devnet does not support the ab
 - already aborted blocks
 - Devnet's genesis block
 
+### Reorg
+
+On block abortion, a reorg subscription notification will be sent to all websocket subscribers requiring so according to [JSON-RPC websocket API specification](https://github.com/starkware-libs/starknet-specs/blob/v0.8.0-rc1/api/starknet_ws_api.json#L256). The `starting_block` of the orphaned chain is the successor of the new latest block, and the `ending_block` of the orphaned chain is the old latest block (before aborting).
+
 ### Request and response
 
 To abort, send one of the following:

--- a/website/docs/blocks.md
+++ b/website/docs/blocks.md
@@ -99,7 +99,7 @@ Aborted blocks can only be queried by block hash. Devnet does not support the ab
 
 ### Reorg
 
-On block abortion, a reorg subscription notification will be sent to all websocket subscribers requiring so according to [JSON-RPC websocket API specification](https://github.com/starkware-libs/starknet-specs/blob/v0.8.0-rc1/api/starknet_ws_api.json#L256). The `starting_block` of the orphaned chain is the successor of the new latest block, and the `ending_block` of the orphaned chain is the old latest block (before aborting).
+On block abortion, a reorg subscription notification will be sent to all websocket subscribers requiring so according to [JSON-RPC websocket API specification](https://github.com/starkware-libs/starknet-specs/blob/v0.8.0-rc1/api/starknet_ws_api.json#L256). The `starting_block` of the orphaned chain is the successor of the new latest block, and the `ending_block` of the orphaned chain is the block that was latest before aborting. One reorg notification is sent per subscription, not per websocket.
 
 ### Request and response
 

--- a/website/docs/dump-load-restart.md
+++ b/website/docs/dump-load-restart.md
@@ -103,7 +103,7 @@ If you dumped a Devnet utilizing one class for account predeployment (e.g. `--ac
 
 ## Restarting
 
-Devnet can be restarted by making a `POST /restart` request (no body required) or `JSON-RPC` request with method name `devnet_restart`. All of the deployed contracts (including predeployed), blocks and storage updates will be restarted to the original state, without the transactions and requests that may have been loaded from a dump file on startup.
+Devnet can be restarted by making a `POST /restart` request (no body required) or `JSON-RPC` request with method name `devnet_restart`. All of the deployed contracts (including predeployed), blocks and storage updates will be restarted to the original state, without the transactions and requests that may have been loaded from a dump file on startup. Websocket subscriptions will also be forgotten.
 
 ### Restarting and L1-L2 messaging
 


### PR DESCRIPTION
## Usage related changes

- Address partially #613 

## Development related changes

- Only check for changes if request requires so (introduce new method for this: `requires_notifying`).
  - The new method relies on clippy warning to be issued if wildcard matching used, to force explicitly defining behavior for each request: `wildcard_enum_match_arm`.
- Refactor `Subscription::matches` method to avoid using `if`.
- Make `abort_blocks` a method of `BackgroundDevnet` and use it where possible instead of sending custom requests.

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
