### PR TITLE
Apply v0.8.0-rc1 changes

### DIFF
--- a/crates/starknet-devnet-server/src/api/json_rpc/endpoints_ws.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/endpoints_ws.rs
@@ -6,8 +6,8 @@ use starknet_types::starknet_api::block::{BlockNumber, BlockStatus};
 
 use super::error::ApiError;
 use super::models::{
-    BlockInput, EventsSubscriptionInput, PendingTransactionsSubscriptionInput, SubscriptionIdInput,
-    TransactionBlockInput,
+    BlockIdInput, EventsSubscriptionInput, PendingTransactionsSubscriptionInput,
+    SubscriptionIdInput, TransactionBlockInput,
 };
 use super::{JsonRpcHandler, JsonRpcSubscriptionRequest};
 use crate::rpc_core::request::Id;
@@ -95,12 +95,12 @@ impl JsonRpcHandler {
     /// subscribed to new blocks.
     async fn subscribe_new_heads(
         &self,
-        block_input: Option<BlockInput>,
+        block_input: Option<BlockIdInput>,
         rpc_request_id: Id,
         socket_id: SocketId,
     ) -> Result<(), ApiError> {
-        let block_id = if let Some(BlockInput { block }) = block_input {
-            block.into()
+        let block_id = if let Some(BlockIdInput { block_id }) = block_input {
+            block_id.into()
         } else {
             // if no block ID input, this eventually just subscribes the user to new blocks
             BlockId::Tag(BlockTag::Latest)
@@ -225,9 +225,9 @@ impl JsonRpcHandler {
         rpc_request_id: Id,
         socket_id: SocketId,
     ) -> Result<(), ApiError> {
-        let TransactionBlockInput { transaction_hash, block } = transaction_block_input;
+        let TransactionBlockInput { transaction_hash, block_id } = transaction_block_input;
 
-        let query_block_id = if let Some(block_id) = block {
+        let query_block_id = if let Some(block_id) = block_id {
             block_id.0
         } else {
             // if no block ID input, this eventually just subscribes the user to new blocks
@@ -295,7 +295,7 @@ impl JsonRpcHandler {
 
         let starting_block_id = maybe_subscription_input
             .as_ref()
-            .and_then(|subscription_input| subscription_input.block.as_ref())
+            .and_then(|subscription_input| subscription_input.block_id.as_ref())
             .map(|b| b.0)
             .unwrap_or(BlockId::Tag(BlockTag::Latest));
 

--- a/crates/starknet-devnet-server/src/api/json_rpc/error.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/error.rs
@@ -64,6 +64,8 @@ pub enum ApiError {
     CompiledClassHashMismatch,
     #[error("Cannot go back more than 1024 blocks")]
     TooManyBlocksBack,
+    #[error("This method does not support being called on the pending block")]
+    CallOnPending,
     #[error("Invalid subscription id")]
     InvalidSubscriptionId,
 }
@@ -211,6 +213,11 @@ impl ApiError {
             ApiError::HttpApiError(http_api_error) => http_api_error.http_api_error_to_rpc_error(),
             ApiError::TooManyBlocksBack => RpcError {
                 code: crate::rpc_core::error::ErrorCode::ServerError(68),
+                message: error_message.into(),
+                data: None,
+            },
+            ApiError::CallOnPending => RpcError {
+                code: crate::rpc_core::error::ErrorCode::ServerError(69),
                 message: error_message.into(),
                 data: None,
             },

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -16,8 +16,8 @@ use enum_helper_macros::{AllVariantsSerdeRenames, VariantName};
 use futures::stream::SplitSink;
 use futures::{SinkExt, StreamExt};
 use models::{
-    BlockAndClassHashInput, BlockAndContractAddressInput, BlockAndIndexInput, BlockInput,
-    CallInput, EstimateFeeInput, EventsInput, EventsSubscriptionInput, GetStorageInput,
+    BlockAndClassHashInput, BlockAndContractAddressInput, BlockAndIndexInput, CallInput,
+    EstimateFeeInput, EventsInput, EventsSubscriptionInput, GetStorageInput,
     L1TransactionHashInput, PendingTransactionsSubscriptionInput, SubscriptionIdInput,
     TransactionBlockInput, TransactionHashInput, TransactionHashOutput,
 };
@@ -866,7 +866,7 @@ impl JsonRpcRequest {
 #[serde(tag = "method", content = "params")]
 pub enum JsonRpcSubscriptionRequest {
     #[serde(rename = "starknet_subscribeNewHeads", with = "optional_params")]
-    NewHeads(Option<BlockInput>),
+    NewHeads(Option<BlockIdInput>),
     #[serde(rename = "starknet_subscribeTransactionStatus")]
     TransactionStatus(TransactionBlockInput),
     #[serde(rename = "starknet_subscribePendingTransactions", with = "optional_params")]

--- a/crates/starknet-devnet-server/src/api/json_rpc/models.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/models.rs
@@ -21,13 +21,6 @@ pub struct BlockIdInput {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
-/// Similar to BlockIdInput, but without the _id, as required by ws methods.
-pub struct BlockInput {
-    pub block: BlockId,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(deny_unknown_fields)]
 pub struct TransactionHashInput {
     pub transaction_hash: TransactionHash,
 }
@@ -197,7 +190,7 @@ pub struct SubscriptionIdInput {
 #[serde(deny_unknown_fields)]
 pub struct TransactionBlockInput {
     pub transaction_hash: TransactionHash,
-    pub block: Option<BlockId>,
+    pub block_id: Option<BlockId>,
 }
 
 #[derive(Deserialize, Clone, Debug)]
@@ -210,7 +203,7 @@ pub struct PendingTransactionsSubscriptionInput {
 #[derive(Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct EventsSubscriptionInput {
-    pub block: Option<BlockId>,
+    pub block_id: Option<BlockId>,
     pub from_address: Option<ContractAddress>,
     pub keys: Option<Vec<Vec<Felt>>>,
 }

--- a/crates/starknet-devnet/tests/common/utils.rs
+++ b/crates/starknet-devnet/tests/common/utils.rs
@@ -440,9 +440,9 @@ pub async fn subscribe(
     params: serde_json::Value,
 ) -> Result<i64, anyhow::Error> {
     let subscription_confirmation = send_text_rpc_via_ws(ws, subscription_method, params).await?;
-    subscription_confirmation["result"]
-        .as_i64()
-        .ok_or(anyhow::Error::msg("Subscription did not return a numeric ID"))
+    subscription_confirmation["result"].as_i64().ok_or(anyhow::Error::msg(format!(
+        "No ID in subscription response: {subscription_confirmation}"
+    )))
 }
 
 /// Tries to read from the provided ws stream. To prevent deadlock, waits for a second at most.
@@ -480,11 +480,7 @@ pub async fn subscribe_new_heads(
     ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
     block_specifier: serde_json::Value,
 ) -> Result<i64, anyhow::Error> {
-    let subscription_confirmation =
-        send_text_rpc_via_ws(ws, "starknet_subscribeNewHeads", block_specifier).await?;
-    subscription_confirmation["result"]
-        .as_i64()
-        .ok_or(anyhow::Error::msg("Subscription did not return a numeric ID"))
+    subscribe(ws, "starknet_subscribeNewHeads", block_specifier).await
 }
 
 pub async fn unsubscribe(

--- a/crates/starknet-devnet/tests/common/utils.rs
+++ b/crates/starknet-devnet/tests/common/utils.rs
@@ -465,7 +465,7 @@ pub async fn receive_notification(
     assert_eq!(notification["jsonrpc"], "2.0");
     assert_eq!(notification["method"], method);
     assert_eq!(notification["params"]["subscription_id"], expected_subscription_id);
-    Ok(notification["params"].take()["result"].take())
+    Ok(notification["params"]["result"].take())
 }
 
 pub async fn assert_no_notifications(ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>) {

--- a/crates/starknet-devnet/tests/test_subscription_to_blocks.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_blocks.rs
@@ -97,7 +97,7 @@ mod block_subscription_support {
 
         // request notifications for all blocks starting with genesis
         let subscription_id =
-            subscribe_new_heads(&mut ws, json!({ "block": BlockId::Number(0) })).await.unwrap();
+            subscribe_new_heads(&mut ws, json!({ "block_id": BlockId::Number(0) })).await.unwrap();
 
         for block_i in 0..=n_blocks {
             let notification = receive_rpc_via_ws(&mut ws).await.unwrap();
@@ -128,7 +128,7 @@ mod block_subscription_support {
         // request notifications for all blocks starting with genesis
         let subscription_id = subscribe_new_heads(
             &mut ws,
-            json!({ "block": BlockId::Hash(genesis_block.block_hash)}),
+            json!({ "block_id": BlockId::Hash(genesis_block.block_hash)}),
         )
         .await
         .unwrap();
@@ -156,10 +156,10 @@ mod block_subscription_support {
 
         // create two subscriptions: one to latest, one to pending
         let subscription_id_latest =
-            subscribe_new_heads(&mut ws_latest, json!({ "block": "latest" })).await.unwrap();
+            subscribe_new_heads(&mut ws_latest, json!({ "block_id": "latest" })).await.unwrap();
 
         let subscription_id_pending =
-            subscribe_new_heads(&mut ws_pending, json!({ "block": "pending" })).await.unwrap();
+            subscribe_new_heads(&mut ws_pending, json!({ "block_id": "pending" })).await.unwrap();
 
         assert_ne!(subscription_id_latest, subscription_id_pending);
 
@@ -319,7 +319,7 @@ mod block_subscription_support {
             let subscription_resp = send_text_rpc_via_ws(
                 &mut ws,
                 "starknet_subscribeNewHeads",
-                json!({ "block": block_id }),
+                json!({ "block_id": block_id }),
             )
             .await
             .unwrap();
@@ -343,7 +343,7 @@ mod block_subscription_support {
         let subscription_resp = send_text_rpc_via_ws(
             &mut ws,
             "starknet_subscribeNewHeads",
-            json!({ "block": BlockId::Hash(new_block_hash) }),
+            json!({ "block_id": BlockId::Hash(new_block_hash) }),
         )
         .await
         .unwrap();

--- a/crates/starknet-devnet/tests/test_subscription_to_blocks.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_blocks.rs
@@ -7,14 +7,13 @@ mod block_subscription_support {
 
     use serde_json::json;
     use starknet_core::constants::ETH_ERC20_CONTRACT_ADDRESS;
-    use starknet_rs_core::types::{BlockId, BlockTag, Felt};
+    use starknet_rs_core::types::{BlockId, BlockTag};
     use starknet_rs_providers::Provider;
     use tokio_tungstenite::connect_async;
 
     use crate::common::background_devnet::BackgroundDevnet;
     use crate::common::utils::{
-        assert_no_notifications, receive_rpc_via_ws, send_text_rpc_via_ws, subscribe_new_heads,
-        unsubscribe,
+        assert_no_notifications, receive_rpc_via_ws, subscribe_new_heads, unsubscribe,
     };
 
     #[tokio::test]
@@ -308,49 +307,5 @@ mod block_subscription_support {
 
         // this assertion is skipped due to CI instability
         // assert_no_notifications(&mut ws).await;
-    }
-
-    #[tokio::test]
-    async fn test_subscribing_to_non_existent_block() {
-        let devnet = BackgroundDevnet::spawn().await.unwrap();
-        let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
-
-        for block_id in [BlockId::Number(1), BlockId::Hash(Felt::ONE)] {
-            let subscription_resp = send_text_rpc_via_ws(
-                &mut ws,
-                "starknet_subscribeNewHeads",
-                json!({ "block_id": block_id }),
-            )
-            .await
-            .unwrap();
-
-            assert_eq!(
-                subscription_resp,
-                json!({ "jsonrpc": "2.0", "id": 0, "error": { "code": 24, "message": "Block not found" } })
-            );
-        }
-    }
-
-    #[tokio::test]
-    async fn test_aborted_blocks_not_subscribable() {
-        let devnet_args = ["--state-archive-capacity", "full"];
-        let devnet = BackgroundDevnet::spawn_with_additional_args(&devnet_args).await.unwrap();
-        let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
-
-        let new_block_hash = devnet.create_block().await.unwrap();
-        devnet.abort_blocks(&BlockId::Hash(new_block_hash)).await.unwrap();
-
-        let subscription_resp = send_text_rpc_via_ws(
-            &mut ws,
-            "starknet_subscribeNewHeads",
-            json!({ "block_id": BlockId::Hash(new_block_hash) }),
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(
-            subscription_resp,
-            json!({ "jsonrpc": "2.0", "id": 0, "error": { "code": 24, "message": "Block not found" } })
-        );
     }
 }

--- a/crates/starknet-devnet/tests/test_subscription_to_events.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_events.rs
@@ -20,7 +20,7 @@ mod event_subscription_support {
     use crate::common::utils::{
         assert_no_notifications, declare_v3_deploy_v3,
         get_events_contract_in_sierra_and_compiled_class_hash, receive_notification,
-        receive_rpc_via_ws, send_text_rpc_via_ws, subscribe, unsubscribe,
+        receive_rpc_via_ws, subscribe, unsubscribe,
     };
 
     async fn subscribe_events(
@@ -454,25 +454,5 @@ mod event_subscription_support {
             .unwrap();
 
         assert_no_notifications(&mut ws).await;
-    }
-
-    #[tokio::test]
-    async fn should_return_error_for_subscribing_to_non_existent_block() {
-        let devnet = BackgroundDevnet::spawn().await.unwrap();
-        let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
-
-        let non_existent_hash = Felt::from(1234);
-        let subscription_resp = send_text_rpc_via_ws(
-            &mut ws,
-            "starknet_subscribeNewHeads",
-            json!({ "block_id": BlockId::Hash(non_existent_hash) }),
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(
-            subscription_resp,
-            json!({ "jsonrpc": "2.0", "id": 0, "error": { "code": 24, "message": "Block not found" } })
-        );
     }
 }

--- a/crates/starknet-devnet/tests/test_subscription_to_pending_txs.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_pending_txs.rs
@@ -16,19 +16,15 @@ mod pending_transactions_subscription_support {
     use crate::common::constants;
     use crate::common::utils::{
         assert_no_notifications, declare_v3_deploy_v3,
-        get_simple_contract_in_sierra_and_compiled_class_hash, receive_rpc_via_ws,
-        send_text_rpc_via_ws, unsubscribe,
+        get_simple_contract_in_sierra_and_compiled_class_hash, receive_rpc_via_ws, subscribe,
+        unsubscribe,
     };
 
     async fn subscribe_pending_txs(
         ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
         params: serde_json::Value,
     ) -> Result<i64, anyhow::Error> {
-        let subscription_confirmation =
-            send_text_rpc_via_ws(ws, "starknet_subscribePendingTransactions", params).await?;
-        subscription_confirmation["result"]
-            .as_i64()
-            .ok_or(anyhow::Error::msg("Subscription did not return a numeric ID"))
+        subscribe(ws, "starknet_subscribePendingTransactions", params).await
     }
 
     /// Modifies the provided value by leaving a `null` in place of the returned transaction.

--- a/crates/starknet-devnet/tests/test_subscription_to_tx_status.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_tx_status.rs
@@ -9,8 +9,7 @@ mod tx_status_subscription_support {
 
     use crate::common::background_devnet::BackgroundDevnet;
     use crate::common::utils::{
-        assert_no_notifications, receive_rpc_via_ws, send_text_rpc_via_ws, subscribe,
-        subscribe_new_heads, unsubscribe,
+        assert_no_notifications, receive_rpc_via_ws, subscribe, subscribe_new_heads, unsubscribe,
     };
 
     async fn subscribe_tx_status(
@@ -322,25 +321,5 @@ mod tx_status_subscription_support {
 
         let notification = receive_rpc_via_ws(&mut ws).await.unwrap();
         assert_successful_mint_notification(notification, tx_hash, subscription_id);
-    }
-
-    #[tokio::test]
-    async fn should_return_error_for_invalid_block_id() {
-        let devnet = BackgroundDevnet::spawn().await.unwrap();
-
-        let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
-
-        for block_id in [BlockId::Number(1), BlockId::Hash(Felt::ONE)] {
-            let resp = send_text_rpc_via_ws(
-                &mut ws,
-                "starknet_subscribeTransactionStatus",
-                json!({ "transaction_hash": Felt::ONE, "block_id": block_id }),
-            )
-            .await
-            .unwrap();
-
-            let expected_error = json!({ "code": 24, "message": "Block not found" });
-            assert_eq!(resp, json!({ "jsonrpc": "2.0", "id": 0, "error": expected_error }));
-        }
     }
 }

--- a/crates/starknet-devnet/tests/test_subscription_to_tx_status.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_tx_status.rs
@@ -9,8 +9,8 @@ mod tx_status_subscription_support {
 
     use crate::common::background_devnet::BackgroundDevnet;
     use crate::common::utils::{
-        assert_no_notifications, receive_rpc_via_ws, send_text_rpc_via_ws, subscribe_new_heads,
-        unsubscribe,
+        assert_no_notifications, receive_rpc_via_ws, send_text_rpc_via_ws, subscribe,
+        subscribe_new_heads, unsubscribe,
     };
 
     async fn subscribe_tx_status(
@@ -21,14 +21,10 @@ mod tx_status_subscription_support {
         let mut params = json!({ "transaction_hash": tx_hash });
 
         if let Some(block_id) = block_id {
-            params["block"] = json!(block_id);
+            params["block_id"] = json!(block_id);
         }
 
-        let subscription_confirmation =
-            send_text_rpc_via_ws(ws, "starknet_subscribeTransactionStatus", params).await?;
-        subscription_confirmation["result"]
-            .as_i64()
-            .ok_or(anyhow::Error::msg("Subscription did not return a numeric ID"))
+        subscribe(ws, "starknet_subscribeTransactionStatus", params).await
     }
 
     /// Returns (address, amount, tx_hash), with tx_hash being the hash of the minting tx if it's
@@ -338,7 +334,7 @@ mod tx_status_subscription_support {
             let resp = send_text_rpc_via_ws(
                 &mut ws,
                 "starknet_subscribeTransactionStatus",
-                json!({ "transaction_hash": Felt::ONE, "block": block_id }),
+                json!({ "transaction_hash": Felt::ONE, "block_id": block_id }),
             )
             .await
             .unwrap();

--- a/crates/starknet-devnet/tests/test_subscription_with_invalid_block_id.rs
+++ b/crates/starknet-devnet/tests/test_subscription_with_invalid_block_id.rs
@@ -1,0 +1,69 @@
+#![cfg(test)]
+pub mod common;
+
+mod subscription_with_invalid_block_id {
+    use serde_json::json;
+    use starknet_rs_core::types::{BlockId, Felt};
+    use tokio_tungstenite::connect_async;
+
+    use crate::common::background_devnet::BackgroundDevnet;
+    use crate::common::utils::{assert_no_notifications, send_text_rpc_via_ws};
+
+    fn block_not_found_error() -> serde_json::Value {
+        json!({ "jsonrpc": "2.0", "id": 0, "error": { "code": 24, "message": "Block not found" } })
+    }
+
+    #[tokio::test]
+    async fn test_subscribing_to_non_existent_block() {
+        let devnet = BackgroundDevnet::spawn().await.unwrap();
+        let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
+
+        // Cartesian product: (subscription_method, subscription_params) x invalid_block_id
+        for (subscription_method, mut subscription_params) in [
+            ("starknet_subscribeNewHeads", json!({})),
+            ("starknet_subscribeTransactionStatus", json!({ "transaction_hash": "0x1" })),
+            ("starknet_subscribeEvents", json!({})),
+        ] {
+            for block_id in [BlockId::Number(1), BlockId::Hash(Felt::ONE)] {
+                subscription_params["block_id"] = json!(block_id);
+                let subscription_resp =
+                    send_text_rpc_via_ws(&mut ws, subscription_method, subscription_params.clone())
+                        .await
+                        .unwrap();
+
+                assert_eq!(subscription_resp, block_not_found_error())
+            }
+        }
+
+        assert_no_notifications(&mut ws).await;
+    }
+
+    #[tokio::test]
+    async fn test_aborted_blocks_not_subscribable() {
+        let devnet_args = ["--state-archive-capacity", "full"];
+        let devnet = BackgroundDevnet::spawn_with_additional_args(&devnet_args).await.unwrap();
+        let (mut ws, _) = connect_async(devnet.ws_url()).await.unwrap();
+
+        let created_block_hash = devnet.create_block().await.unwrap();
+        devnet.abort_blocks(&BlockId::Hash(created_block_hash)).await.unwrap();
+
+        // Cartesian product: (subscription_method, subscription_params) x invalid_block_id
+        for (subscription_method, mut subscription_params) in [
+            ("starknet_subscribeNewHeads", json!({})),
+            ("starknet_subscribeTransactionStatus", json!({ "transaction_hash": "0x1" })),
+            ("starknet_subscribeEvents", json!({})),
+        ] {
+            for block_id in [BlockId::Number(1), BlockId::Hash(created_block_hash)] {
+                subscription_params["block_id"] = json!(block_id);
+                let subscription_resp =
+                    send_text_rpc_via_ws(&mut ws, subscription_method, subscription_params.clone())
+                        .await
+                        .unwrap();
+
+                assert_eq!(subscription_resp, block_not_found_error())
+            }
+        }
+
+        assert_no_notifications(&mut ws).await;
+    }
+}


### PR DESCRIPTION
## Usage related changes

- Part of #613
- As per JSON-RPC rc1 of v0.8.0, apply the following changes:
  - Disallow `pending` block ID in block and events subscription (meaning it's only left for tx status subscription)
  - Rename param: block -> block_id

## Development related changes

- Expand testing of invalid block rejection to all applicable methods
  - Introduce a new test file (`test_subscription_with_invalid_block`)
    - Add new and existing tests here
- Add utility function for simplification of block notification assertion: `receive_block` (based on the recently added `receive_event`).
- Due to the disallowing of `pending` block ID in block subscription, the test `subscription_to_pending_block_is_same_as_latest` has become obsolete. It is replaced with `assert_latest_block_is_default`, since the titular fact was not tested.

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
