### PR TITLE
Refactor RPC execution

### DIFF
--- a/crates/starknet-devnet-server/src/api/json_rpc/error.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/error.rs
@@ -218,9 +218,9 @@ impl ApiError {
             Self::BlockNotFound
             | Self::TransactionNotFound
             | Self::NoStateAtBlock { .. }
-            | Self::NoTraceAvailable
             | Self::ClassHashNotFound => true,
             Self::StarknetDevnetError(_)
+            | Self::NoTraceAvailable
             | Self::TypesError(_)
             | Self::RpcError(_)
             | Self::ContractNotFound

--- a/crates/starknet-devnet-server/src/api/json_rpc/error.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/error.rs
@@ -211,6 +211,38 @@ impl ApiError {
             ApiError::HttpApiError(http_api_error) => http_api_error.http_api_error_to_rpc_error(),
         }
     }
+
+    pub(crate) fn is_forwardable_to_origin(&self) -> bool {
+        #[warn(clippy::wildcard_enum_match_arm)]
+        match self {
+            Self::BlockNotFound
+            | Self::TransactionNotFound
+            | Self::NoStateAtBlock { .. }
+            | Self::ClassHashNotFound => true,
+            Self::StarknetDevnetError(_)
+            | Self::TypesError(_)
+            | Self::RpcError(_)
+            | Self::ContractNotFound
+            | Self::InvalidTransactionIndexInBlock
+            | Self::ContractError { .. }
+            | Self::NoBlocks
+            | Self::RequestPageSizeTooBig
+            | Self::InvalidContinuationToken
+            | Self::TooManyKeysInFilter
+            | Self::ClassAlreadyDeclared
+            | Self::InvalidContractClass
+            | Self::OnlyLatestBlock
+            | Self::UnsupportedAction { .. }
+            | Self::InvalidTransactionNonce
+            | Self::InsufficientMaxFee
+            | Self::InsufficientAccountBalance
+            | Self::ValidationFailure { .. }
+            | Self::NoTraceAvailable // TODO
+            | Self::HttpApiError(_)
+            | Self::CompiledClassHashMismatch
+            | Self::ExecutionError { .. } => false,
+        }
+    }
 }
 
 pub type StrictRpcResult = Result<JsonRpcResponse, ApiError>;

--- a/crates/starknet-devnet-server/src/api/json_rpc/error.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/error.rs
@@ -218,6 +218,7 @@ impl ApiError {
             Self::BlockNotFound
             | Self::TransactionNotFound
             | Self::NoStateAtBlock { .. }
+            | Self::NoTraceAvailable
             | Self::ClassHashNotFound => true,
             Self::StarknetDevnetError(_)
             | Self::TypesError(_)
@@ -237,7 +238,6 @@ impl ApiError {
             | Self::InsufficientMaxFee
             | Self::InsufficientAccountBalance
             | Self::ValidationFailure { .. }
-            | Self::NoTraceAvailable // TODO
             | Self::HttpApiError(_)
             | Self::CompiledClassHashMismatch
             | Self::ExecutionError { .. } => false,

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -494,14 +494,12 @@ impl JsonRpcRequest {
             | Self::SimulateTransactions(_)
             | Self::TraceTransaction(_)
             | Self::BlockTransactionTraces(_) => true,
-            // starknet-specific, but not forwardable
             Self::SpecVersion
             | Self::ChainId
             | Self::Syncing
             | Self::AddDeclareTransaction(_)
             | Self::AddDeployAccountTransaction(_)
             | Self::AddInvokeTransaction(_)
-            // devnet-specific, thus not forwardable
             | Self::ImpersonateAccount(_)
             | Self::StopImpersonateAccount(_)
             | Self::AutoImpersonate

--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -202,6 +202,7 @@ impl BackgroundDevnet {
         JsonRpcClient::new(HttpTransport::new(self.rpc_url.clone()))
     }
 
+    /// Mint some amount of wei at `address` and return the resulting transaction hash.
     pub async fn mint(&self, address: impl LowerHex, mint_amount: u128) -> Felt {
         self.mint_unit(address, mint_amount, FeeUnit::WEI).await
     }


### PR DESCRIPTION
## Usage related changes

None, hopefully.

## Development related changes

- Simplify method `execute` for `JsonRpcHandler` so that it only matches request to response and executes it.
  - The rest of the functionality is basically moved one level up and is done in `on_request`.
- Simplify `update_dump`
  - When deciding whether to dump, rely on a bool-returning method defined for all request types instead of string matching.
- Rely on clippy's `wildcard_enum_match_arm` to warn if a wildcard matching is done in the newly defined methods.
  - This is done to ensure we consciously provide logic for new methods.
- Add one missing forking test: `test_tx_info_available_from_origin`

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
