### PR TITLE
Use u64 for Subscription ID

### DIFF
--- a/crates/starknet-devnet-server/src/api/json_rpc/models.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/models.rs
@@ -180,10 +180,12 @@ pub struct L1TransactionHashInput {
     pub transaction_hash: Hash256,
 }
 
+pub type SubscriptionId = u64;
+
 #[derive(Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct SubscriptionIdInput {
-    pub subscription_id: i64,
+    pub subscription_id: SubscriptionId,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/crates/starknet-devnet-server/src/subscribe.rs
+++ b/crates/starknet-devnet-server/src/subscribe.rs
@@ -15,11 +15,10 @@ use starknet_types::rpc::transactions::{TransactionStatus, TransactionWithHash};
 use tokio::sync::Mutex;
 
 use crate::api::json_rpc::error::ApiError;
+use crate::api::json_rpc::models::SubscriptionId;
 use crate::rpc_core::request::Id;
 
 pub type SocketId = u64;
-
-type SubscriptionId = i64;
 
 #[derive(Debug)]
 pub struct AddressFilter {

--- a/crates/starknet-devnet/tests/common/utils.rs
+++ b/crates/starknet-devnet/tests/common/utils.rs
@@ -438,9 +438,9 @@ pub async fn subscribe(
     ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
     subscription_method: &str,
     params: serde_json::Value,
-) -> Result<i64, anyhow::Error> {
+) -> Result<u64, anyhow::Error> {
     let subscription_confirmation = send_text_rpc_via_ws(ws, subscription_method, params).await?;
-    subscription_confirmation["result"].as_i64().ok_or(anyhow::Error::msg(format!(
+    subscription_confirmation["result"].as_u64().ok_or(anyhow::Error::msg(format!(
         "No ID in subscription response: {subscription_confirmation}"
     )))
 }
@@ -459,7 +459,7 @@ pub async fn receive_rpc_via_ws(
 pub async fn receive_notification(
     ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
     method: &str,
-    expected_subscription_id: i64,
+    expected_subscription_id: u64,
 ) -> Result<serde_json::Value, anyhow::Error> {
     let mut notification = receive_rpc_via_ws(ws).await?;
     assert_eq!(notification["jsonrpc"], "2.0");
@@ -479,13 +479,13 @@ pub async fn assert_no_notifications(ws: &mut WebSocketStream<MaybeTlsStream<Tcp
 pub async fn subscribe_new_heads(
     ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
     block_specifier: serde_json::Value,
-) -> Result<i64, anyhow::Error> {
+) -> Result<u64, anyhow::Error> {
     subscribe(ws, "starknet_subscribeNewHeads", block_specifier).await
 }
 
 pub async fn unsubscribe(
     ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
-    subscription_id: i64,
+    subscription_id: u64,
 ) -> Result<serde_json::Value, anyhow::Error> {
     send_text_rpc_via_ws(ws, "starknet_unsubscribe", json!({ "subscription_id": subscription_id }))
         .await

--- a/crates/starknet-devnet/tests/test_subscription_to_blocks.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_blocks.rs
@@ -19,7 +19,7 @@ mod block_subscription_support {
 
     async fn receive_block(
         ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
-        subscription_id: i64,
+        subscription_id: u64,
     ) -> Result<serde_json::Value, anyhow::Error> {
         receive_notification(ws, "starknet_subscriptionNewHeads", subscription_id).await
     }

--- a/crates/starknet-devnet/tests/test_subscription_to_blocks.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_blocks.rs
@@ -15,11 +15,12 @@ mod block_subscription_support {
     use crate::common::background_devnet::BackgroundDevnet;
     use crate::common::utils::{
         assert_no_notifications, receive_notification, subscribe_new_heads, unsubscribe,
+        SubscriptionId,
     };
 
     async fn receive_block(
         ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
-        subscription_id: u64,
+        subscription_id: SubscriptionId,
     ) -> Result<serde_json::Value, anyhow::Error> {
         receive_notification(ws, "starknet_subscriptionNewHeads", subscription_id).await
     }

--- a/crates/starknet-devnet/tests/test_subscription_to_events.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_events.rs
@@ -20,19 +20,19 @@ mod event_subscription_support {
     use crate::common::utils::{
         assert_no_notifications, declare_v3_deploy_v3,
         get_events_contract_in_sierra_and_compiled_class_hash, receive_notification,
-        receive_rpc_via_ws, subscribe, unsubscribe,
+        receive_rpc_via_ws, subscribe, unsubscribe, SubscriptionId,
     };
 
     async fn subscribe_events(
         ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
         params: serde_json::Value,
-    ) -> Result<u64, anyhow::Error> {
+    ) -> Result<SubscriptionId, anyhow::Error> {
         subscribe(ws, "starknet_subscribeEvents", params).await
     }
 
     async fn receive_event(
         ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
-        subscription_id: u64,
+        subscription_id: SubscriptionId,
     ) -> Result<serde_json::Value, anyhow::Error> {
         receive_notification(ws, "starknet_subscriptionEvents", subscription_id).await
     }

--- a/crates/starknet-devnet/tests/test_subscription_to_events.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_events.rs
@@ -26,13 +26,13 @@ mod event_subscription_support {
     async fn subscribe_events(
         ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
         params: serde_json::Value,
-    ) -> Result<i64, anyhow::Error> {
+    ) -> Result<u64, anyhow::Error> {
         subscribe(ws, "starknet_subscribeEvents", params).await
     }
 
     async fn receive_event(
         ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
-        subscription_id: i64,
+        subscription_id: u64,
     ) -> Result<serde_json::Value, anyhow::Error> {
         receive_notification(ws, "starknet_subscriptionEvents", subscription_id).await
     }

--- a/crates/starknet-devnet/tests/test_subscription_to_pending_txs.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_pending_txs.rs
@@ -17,13 +17,13 @@ mod pending_transactions_subscription_support {
     use crate::common::utils::{
         assert_no_notifications, declare_v3_deploy_v3,
         get_simple_contract_in_sierra_and_compiled_class_hash, receive_rpc_via_ws, subscribe,
-        unsubscribe,
+        unsubscribe, SubscriptionId,
     };
 
     async fn subscribe_pending_txs(
         ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
         params: serde_json::Value,
-    ) -> Result<u64, anyhow::Error> {
+    ) -> Result<SubscriptionId, anyhow::Error> {
         subscribe(ws, "starknet_subscribePendingTransactions", params).await
     }
 

--- a/crates/starknet-devnet/tests/test_subscription_to_pending_txs.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_pending_txs.rs
@@ -23,7 +23,7 @@ mod pending_transactions_subscription_support {
     async fn subscribe_pending_txs(
         ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
         params: serde_json::Value,
-    ) -> Result<i64, anyhow::Error> {
+    ) -> Result<u64, anyhow::Error> {
         subscribe(ws, "starknet_subscribePendingTransactions", params).await
     }
 

--- a/crates/starknet-devnet/tests/test_subscription_to_reorg.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_reorg.rs
@@ -99,7 +99,7 @@ mod reorg_subscription_support {
             // was received per subscription_id, we extract the IDs from notifications, store them
             // in a set, and later assert equality with the set of expected subscription IDs.
             let notification_id =
-                notification["params"]["subscription_id"].take().as_i64().unwrap();
+                notification["params"]["subscription_id"].take().as_u64().unwrap();
             notification_ids.insert(notification_id);
 
             assert_eq!(

--- a/crates/starknet-devnet/tests/test_subscription_to_tx_status.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_tx_status.rs
@@ -10,13 +10,14 @@ mod tx_status_subscription_support {
     use crate::common::background_devnet::BackgroundDevnet;
     use crate::common::utils::{
         assert_no_notifications, receive_rpc_via_ws, subscribe, subscribe_new_heads, unsubscribe,
+        SubscriptionId,
     };
 
     async fn subscribe_tx_status(
         ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
         tx_hash: &Felt,
         block_id: Option<BlockId>,
-    ) -> Result<u64, anyhow::Error> {
+    ) -> Result<SubscriptionId, anyhow::Error> {
         let mut params = json!({ "transaction_hash": tx_hash });
 
         if let Some(block_id) = block_id {
@@ -38,7 +39,7 @@ mod tx_status_subscription_support {
     fn assert_successful_mint_notification(
         notification: serde_json::Value,
         tx_hash: Felt,
-        subscription_id: u64,
+        subscription_id: SubscriptionId,
     ) {
         assert_eq!(
             notification,

--- a/crates/starknet-devnet/tests/test_subscription_to_tx_status.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_tx_status.rs
@@ -16,7 +16,7 @@ mod tx_status_subscription_support {
         ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
         tx_hash: &Felt,
         block_id: Option<BlockId>,
-    ) -> Result<i64, anyhow::Error> {
+    ) -> Result<u64, anyhow::Error> {
         let mut params = json!({ "transaction_hash": tx_hash });
 
         if let Some(block_id) = block_id {
@@ -38,7 +38,7 @@ mod tx_status_subscription_support {
     fn assert_successful_mint_notification(
         notification: serde_json::Value,
         tx_hash: Felt,
-        subscription_id: i64,
+        subscription_id: u64,
     ) {
         assert_eq!(
             notification,


### PR DESCRIPTION
## Usage related changes

- No more negative IDs (not that this was ever an explicit problem)
- The spec just says the ID should be an integer
  - [Spec link](https://github.com/starkware-libs/starknet-specs/blob/v0.8.0-rc1/api/starknet_ws_api.json#L329)
  - Started a discussion [on Slack](https://spaceshard.slack.com/archives/C03QN20522D/p1733147136392279)
- Precision issue in starknet.js remains, could be removed if we used u32, but u32 is not among starknet-spec types

## Development related changes

- Define `SubscriptionId` as a type in two places:
  - json_rpc api models
  - test common utils

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
