### PR TITLE
Add dummy `starknet_getStorageProof`, remove unused `Serialize`

### DIFF
--- a/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
@@ -141,6 +141,7 @@ impl JsonRpcHandler {
     /// starknet_getStorageProof
     pub async fn get_storage_proof(&self, data: GetStorageProofInput) -> StrictRpcResult {
         match self.api.starknet.lock().await.get_block(data.block_id.as_ref()) {
+            // storage proofs not applicable to Devnet
             Ok(_) => Err(ApiError::StorageProofNotSupported),
             Err(Error::NoBlock) => Err(ApiError::BlockNotFound),
             Err(unknown_error) => Err(ApiError::StarknetDevnetError(unknown_error)),

--- a/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/endpoints.rs
@@ -14,7 +14,9 @@ use starknet_types::rpc::transactions::{
 use starknet_types::starknet_api::block::BlockStatus;
 
 use super::error::{ApiError, StrictRpcResult};
-use super::models::{BlockHashAndNumberOutput, L1TransactionHashInput, SyncingOutput};
+use super::models::{
+    BlockHashAndNumberOutput, GetStorageProofInput, L1TransactionHashInput, SyncingOutput,
+};
 use super::{DevnetResponse, JsonRpcHandler, JsonRpcResponse, StarknetResponse, RPC_SPEC_VERSION};
 use crate::api::http::endpoints::accounts::{
     get_account_balance_impl, get_predeployed_accounts_impl, BalanceQuery, PredeployedAccountsQuery,
@@ -134,6 +136,15 @@ impl JsonRpcHandler {
             })?;
 
         Ok(StarknetResponse::Felt(felt).into())
+    }
+
+    /// starknet_getStorageProof
+    pub async fn get_storage_proof(&self, data: GetStorageProofInput) -> StrictRpcResult {
+        match self.api.starknet.lock().await.get_block(data.block_id.as_ref()) {
+            Ok(_) => Err(ApiError::StorageProofNotSupported),
+            Err(Error::NoBlock) => Err(ApiError::BlockNotFound),
+            Err(unknown_error) => Err(ApiError::StarknetDevnetError(unknown_error)),
+        }
     }
 
     /// starknet_getTransactionByHash

--- a/crates/starknet-devnet-server/src/api/json_rpc/error.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/error.rs
@@ -68,6 +68,8 @@ pub enum ApiError {
     CallOnPending,
     #[error("Invalid subscription id")]
     InvalidSubscriptionId,
+    #[error("Devnet doesn't support storage proofs")]
+    StorageProofNotSupported,
 }
 
 impl ApiError {
@@ -226,6 +228,11 @@ impl ApiError {
                 message: error_message.into(),
                 data: None,
             },
+            ApiError::StorageProofNotSupported => RpcError {
+                code: crate::rpc_core::error::ErrorCode::ServerError(42),
+                message: error_message.into(),
+                data: None,
+            },
         }
     }
 
@@ -260,6 +267,7 @@ impl ApiError {
             | Self::TooManyBlocksBack
             | Self::InvalidSubscriptionId
             | Self::InsufficientResourcesForValidate
+            | Self::StorageProofNotSupported
             | Self::CompiledClassHashMismatch => false,
         }
     }

--- a/crates/starknet-devnet-server/src/api/json_rpc/error.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/error.rs
@@ -68,7 +68,7 @@ pub enum ApiError {
     CallOnPending,
     #[error("Invalid subscription id")]
     InvalidSubscriptionId,
-    #[error("Devnet doesn't support storage proofs")]
+    #[error("Devnet doesn't support storage proofs")] // slightly modified spec message
     StorageProofNotSupported,
 }
 

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -17,7 +17,7 @@ use futures::stream::SplitSink;
 use futures::{SinkExt, StreamExt};
 use models::{
     BlockAndClassHashInput, BlockAndContractAddressInput, BlockAndIndexInput, CallInput,
-    EstimateFeeInput, EventsInput, EventsSubscriptionInput, GetStorageInput,
+    EstimateFeeInput, EventsInput, EventsSubscriptionInput, GetStorageInput, GetStorageProofInput,
     L1TransactionHashInput, PendingTransactionsSubscriptionInput, SubscriptionIdInput,
     TransactionBlockInput, TransactionHashInput, TransactionHashOutput,
 };
@@ -569,6 +569,7 @@ impl JsonRpcHandler {
             JsonRpcRequest::Mint(data) => self.mint(data).await,
             JsonRpcRequest::DevnetConfig => self.get_devnet_config().await,
             JsonRpcRequest::MessagesStatusByL1Hash(data) => self.get_messages_status(data).await,
+            JsonRpcRequest::StorageProof(data) => self.get_storage_proof(data).await,
         }
     }
 
@@ -667,6 +668,8 @@ pub enum JsonRpcRequest {
     StateUpdate(BlockIdInput),
     #[serde(rename = "starknet_getStorageAt")]
     StorageAt(GetStorageInput),
+    #[serde(rename = "starknet_getStorageProof")]
+    StorageProof(GetStorageProofInput),
     #[serde(rename = "starknet_getTransactionByHash")]
     TransactionByHash(TransactionHashInput),
     #[serde(rename = "starknet_getTransactionByBlockIdAndIndex")]
@@ -813,6 +816,7 @@ impl JsonRpcRequest {
             | Self::Restart(_)
             | Self::PredeployedAccounts(_)
             | Self::AccountBalance(_)
+            | Self::StorageProof(_)
             | Self::DevnetConfig => false,
         }
     }
@@ -845,6 +849,7 @@ impl JsonRpcRequest {
             | Self::TraceTransaction(_)
             | Self::MessagesStatusByL1Hash(_)
             | Self::CompiledCasmByClassHash(_)
+            | Self::StorageProof(_)
             | Self::BlockTransactionTraces(_) => true,
             Self::SpecVersion
             | Self::ChainId
@@ -929,6 +934,7 @@ impl JsonRpcRequest {
             | Self::AccountBalance(_)
             | Self::MessagesStatusByL1Hash(_)
             | Self::CompiledCasmByClassHash(_)
+            | Self::StorageProof(_)
             | Self::DevnetConfig => false,
         }
     }
@@ -1031,6 +1037,7 @@ pub enum StarknetResponse {
     TraceTransaction(TransactionTrace),
     BlockTransactionTraces(Vec<BlockTransactionTrace>),
     MessagesStatusByL1Hash(Vec<L1HandlerTransactionStatus>),
+    StorageProofs(serde_json::Value), // dummy, the corresponding RPC method always errors
 }
 
 #[derive(Serialize)]

--- a/crates/starknet-devnet-server/src/api/json_rpc/models.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/models.rs
@@ -13,14 +13,13 @@ use starknet_types::rpc::transactions::{
 };
 use starknet_types::starknet_api::block::BlockNumber;
 
-// TODO remove Serialize here and in other places
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct BlockIdInput {
     pub block_id: BlockId,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct TransactionHashInput {
     pub transaction_hash: TransactionHash,
@@ -50,34 +49,34 @@ pub struct GetStorageProofInput {
     pub contract_storage_keys: Option<ContractStorage>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct BlockAndIndexInput {
     pub block_id: BlockId,
     pub index: u64,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct BlockAndClassHashInput {
     pub block_id: BlockId,
     pub class_hash: ClassHash,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct BlockAndContractAddressInput {
     pub block_id: BlockId,
     pub contract_address: ContractAddress,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct AccountAddressInput {
     pub account_address: ContractAddress,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 #[serde(deny_unknown_fields)]
 pub struct CallInput {
@@ -108,7 +107,7 @@ pub enum SyncingOutput {
     False(bool),
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct EventsInput {
     pub filter: EventFilter,
 }

--- a/crates/starknet-devnet-server/src/api/json_rpc/models.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/models.rs
@@ -13,6 +13,7 @@ use starknet_types::rpc::transactions::{
 };
 use starknet_types::starknet_api::block::BlockNumber;
 
+// TODO remove Serialize here and in other places
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct BlockIdInput {
@@ -25,13 +26,28 @@ pub struct TransactionHashInput {
     pub transaction_hash: TransactionHash,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct GetStorageInput {
     pub contract_address: ContractAddress,
     pub key: PatriciaKey,
     pub block_id: BlockId,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct ContractStorage {
+    pub contract_address: ContractAddress,
+    pub storage_keys: Vec<Felt>,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct GetStorageProofInput {
+    pub block_id: BlockId,
+    pub class_hashes: Option<Vec<Felt>>,
+    pub contract_addresses: Option<Vec<ContractAddress>>,
+    pub contract_storage_keys: Option<ContractStorage>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -7,6 +7,7 @@ sidebar_position: 1
 :::danger Difference disclaimer
 
 - Devnet should not be used as a replacement for official testnets. After testing on Devnet, be sure to test on a testnet (alpha-sepolia)!
+- Devnet does not organize state data into Merkle-Patricia trees, so calling the `starknet_getStorageProof` RPC method shall always result in `STORAGE_PROOF_NOT_SUPPORTED`.
 - The semantics of `REJECTED` and `REVERTED` status of a transaction is not the same as on the official testnet:
 
 | Tx status  | Official testnet                                            | Devnet                                                     |


### PR DESCRIPTION
## Usage related changes

- Part of #613 

## Development related changes

- The corresponding type for `starknet_getStorageProof` is set to be a dummy `serde_json::Value` since that case should never happen.
- The input type for `starknet_getStorageProof` to serve at least as a structure verifier for users wanting to test interaction with this endpoint.
- Remove unused `Serialize` derivations on RPC input structs.
- Define `is_forwardable_to_origin` to return `true` for `starknet_getStorageProof` in case it's called with an old origin block.

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
