### PR TITLE
Introduce a socket collection abstraction

### DIFF
--- a/crates/starknet-devnet-server/src/api/json_rpc/endpoints_ws.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/endpoints_ws.rs
@@ -47,12 +47,7 @@ impl JsonRpcHandler {
             }
             JsonRpcSubscriptionRequest::Unsubscribe(SubscriptionIdInput { subscription_id }) => {
                 let mut sockets = self.api.sockets.lock().await;
-                let socket_context = sockets.get_mut(&socket_id).ok_or(
-                    ApiError::StarknetDevnetError(Error::UnexpectedInternalError {
-                        msg: format!("Unregistered socket ID: {socket_id}"),
-                    }),
-                )?;
-
+                let socket_context = sockets.get_mut(&socket_id)?;
                 socket_context.unsubscribe(rpc_request_id, subscription_id).await
             }
         }
@@ -119,9 +114,7 @@ impl JsonRpcHandler {
 
         // perform the actual subscription
         let mut sockets = self.api.sockets.lock().await;
-        let socket_context = sockets.get_mut(&socket_id).ok_or(ApiError::StarknetDevnetError(
-            Error::UnexpectedInternalError { msg: format!("Unregistered socket ID: {socket_id}") },
-        ))?;
+        let socket_context = sockets.get_mut(&socket_id)?;
         let subscription_id =
             socket_context.subscribe(rpc_request_id, Subscription::NewHeads).await;
 
@@ -195,9 +188,7 @@ impl JsonRpcHandler {
         );
 
         let mut sockets = self.api.sockets.lock().await;
-        let socket_context = sockets.get_mut(&socket_id).ok_or(ApiError::StarknetDevnetError(
-            Error::UnexpectedInternalError { msg: format!("Unregistered socket ID: {socket_id}") },
-        ))?;
+        let socket_context = sockets.get_mut(&socket_id)?;
 
         let subscription = if with_details {
             Subscription::PendingTransactionsFull { address_filter }
@@ -247,13 +238,11 @@ impl JsonRpcHandler {
 
         // perform the actual subscription
         let mut sockets = self.api.sockets.lock().await;
-        let socket_context = sockets.get_mut(&socket_id).ok_or(ApiError::StarknetDevnetError(
-            Error::UnexpectedInternalError { msg: format!("Unregistered socket ID: {socket_id}") },
-        ))?;
+        let socket_context = sockets.get_mut(&socket_id)?;
 
         // TODO if tx present, but in a block before the one specified, no point in subscribing -
         // its status shall never change (unless considering block abortion). It would make
-        // sense to just add a ReorgSubscription
+        // sense to just add a ReorgSubscription TODO TEST THIS TEST THIS TEST THIS TEST THIS?
         let subscription_tag = self.get_subscription_tag(query_block_id);
         let subscription =
             Subscription::TransactionStatus { tag: subscription_tag, transaction_hash };
@@ -314,10 +303,7 @@ impl JsonRpcHandler {
             maybe_subscription_input.and_then(|subscription_input| subscription_input.keys);
 
         let mut sockets = self.api.sockets.lock().await;
-        let socket_context = sockets.get_mut(&socket_id).ok_or(ApiError::StarknetDevnetError(
-            Error::UnexpectedInternalError { msg: format!("Unregistered socket ID: {socket_id}") },
-        ))?;
-
+        let socket_context = sockets.get_mut(&socket_id)?;
         let subscription = Subscription::Events { address, keys_filter: keys_filter.clone() };
         let subscription_id = socket_context.subscribe(rpc_request_id, subscription).await;
 

--- a/crates/starknet-devnet-server/src/api/json_rpc/endpoints_ws.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/endpoints_ws.rs
@@ -240,9 +240,6 @@ impl JsonRpcHandler {
         let mut sockets = self.api.sockets.lock().await;
         let socket_context = sockets.get_mut(&socket_id)?;
 
-        // TODO if tx present, but in a block before the one specified, no point in subscribing -
-        // its status shall never change (unless considering block abortion). It would make
-        // sense to just add a ReorgSubscription TODO TEST THIS TEST THIS TEST THIS TEST THIS?
         let subscription_tag = self.get_subscription_tag(query_block_id);
         let subscription =
             Subscription::TransactionStatus { tag: subscription_tag, transaction_hash };

--- a/crates/starknet-devnet-server/src/api/json_rpc/write_endpoints.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/write_endpoints.rs
@@ -169,7 +169,6 @@ impl JsonRpcHandler {
         self.api.starknet.lock().await.restart(restart_params.restart_l1_to_l2_messaging)?;
 
         self.api.sockets.lock().await.clear();
-        tracing::info!("Websocket memory cleared. No subscribers.");
 
         Ok(super::JsonRpcResponse::Empty)
     }

--- a/crates/starknet-devnet-server/src/api/mod.rs
+++ b/crates/starknet-devnet-server/src/api/mod.rs
@@ -2,14 +2,13 @@ pub mod http;
 pub mod json_rpc;
 pub mod serde_helpers;
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use starknet_core::starknet::Starknet;
 use tokio::sync::Mutex;
 
 use crate::dump_util::DumpEvent;
-use crate::subscribe::{SocketContext, SocketId};
+use crate::subscribe::SocketCollection;
 
 /// Data that can be shared between threads with read write lock access
 /// Whatever needs to be accessed as information outside of Starknet could be added to this struct
@@ -18,8 +17,7 @@ pub struct Api {
     // maybe the config should be added here next to the starknet instance
     pub starknet: Arc<Mutex<Starknet>>,
     pub dumpable_events: Arc<Mutex<Vec<DumpEvent>>>,
-    // TODO abstract sockets as SocketStorage instead of direct HashMap manipulation
-    pub sockets: Arc<Mutex<HashMap<SocketId, SocketContext>>>,
+    pub sockets: Arc<Mutex<SocketCollection>>,
 }
 
 impl Api {
@@ -27,7 +25,7 @@ impl Api {
         Self {
             starknet: Arc::new(Mutex::new(starknet)),
             dumpable_events: Default::default(),
-            sockets: Arc::new(Mutex::new(HashMap::new())),
+            sockets: Arc::new(Mutex::new(SocketCollection::default())),
         }
     }
 }

--- a/crates/starknet-devnet-server/src/subscribe.rs
+++ b/crates/starknet-devnet-server/src/subscribe.rs
@@ -35,6 +35,7 @@ impl SocketCollection {
         ))
     }
 
+    /// Assigns a random socket ID to the socket whose `socket_writer` is provided. Returns the ID.
     pub fn insert(&mut self, socket_writer: Arc<Mutex<SplitSink<WebSocket, Message>>>) -> SocketId {
         let socket_id = rand::random();
         self.sockets.insert(socket_id, SocketContext::from_sender(socket_writer));

--- a/crates/starknet-devnet/tests/test_subscription_to_tx_status.rs
+++ b/crates/starknet-devnet/tests/test_subscription_to_tx_status.rs
@@ -333,11 +333,13 @@ mod tx_status_subscription_support {
         let tx_hash = devnet.mint(address, amount).await;
         let subscription_id = subscribe_tx_status(&mut ws, &tx_hash, None).await.unwrap();
 
+        // as expected, the actual tx accepted notification is first
         let notification = receive_rpc_via_ws(&mut ws).await.unwrap();
         assert_successful_mint_notification(notification, tx_hash, subscription_id);
 
         devnet.abort_blocks(&BlockId::Number(1)).await.unwrap();
 
+        // only expect reorg subscription
         let notification = receive_rpc_via_ws(&mut ws).await.unwrap();
         assert_eq!(notification["method"], "starknet_subscriptionReorg");
         assert_no_notifications(&mut ws).await;

--- a/website/docs/blocks.md
+++ b/website/docs/blocks.md
@@ -97,9 +97,11 @@ Aborted blocks can only be queried by block hash. Devnet does not support the ab
 - already aborted blocks
 - Devnet's genesis block
 
-### Reorg
+### Websocket subscription notifications
 
-On block abortion, a reorg subscription notification will be sent to all websocket subscribers requiring so according to [JSON-RPC websocket API specification](https://github.com/starkware-libs/starknet-specs/blob/v0.8.0-rc1/api/starknet_ws_api.json#L256). The `starting_block` of the orphaned chain is the successor of the new latest block and the `ending_block` of the orphaned chain is the block that was latest before aborting. One reorg notification is sent per subscription, not per websocket, meaning that if a websocket has n subscriptions, it will receive n reorg notifications, each with its own subscription ID.
+On block abortion, a `starknet_subscriptionReorg` notification will be sent to all websocket subscribers requiring so according to [JSON-RPC websocket API specification](https://github.com/starkware-libs/starknet-specs/blob/v0.8.0-rc1/api/starknet_ws_api.json#L256). The `starting_block` of the orphaned chain is the successor of the new latest block and the `ending_block` of the orphaned chain is the block that was latest before aborting. One reorg notification is sent per subscription, not per websocket, meaning that if a websocket has n subscriptions, it will receive n reorg notifications, each with its own subscription ID.
+
+If a socket has subscribed to transaction status changes of a transaction `tx1` using `starknet_subscribeTransactionStatus` and the block holding `tx1` gets aborted, a `starknet_subscriptionTransactionStatus` notification shall NOT be sent. The socket shall have to rely on handling `starknet_subscriptionReorg`.
 
 ### Request and response
 


### PR DESCRIPTION
## Usage related changes

- Document that tx status subscription notification is not expected on block abortion (only reorg subscription notification)

## Development related changes

- Simplify socket manipulation through code reuse
- Remove TODOs:
  - one related to socket collection abstraction
  - one related to tx status subscription
- Add test for tx status subscription notification not happening

## Checklist:

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
