### PR TITLE
Enable random port on --port 0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,7 +329,7 @@ checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -368,7 +368,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -506,6 +506,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.71.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.0",
+ "shlex",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,7 +612,7 @@ dependencies = [
  "starknet_api",
  "strum 0.25.0",
  "strum_macros 0.25.3",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -656,9 +676,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 dependencies = [
  "serde",
 ]
@@ -697,7 +717,7 @@ dependencies = [
  "hashbrown 0.13.2",
  "instant",
  "once_cell",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
 ]
 
@@ -744,7 +764,7 @@ dependencies = [
  "num-bigint",
  "num-traits 0.2.19",
  "serde",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -784,7 +804,7 @@ dependencies = [
  "log",
  "salsa",
  "smol_str",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -808,7 +828,7 @@ dependencies = [
  "indoc",
  "salsa",
  "smol_str",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -953,7 +973,7 @@ dependencies = [
  "salsa",
  "serde",
  "smol_str",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -1104,7 +1124,7 @@ checksum = "3d55dcf98a6e1a03e0b36129fad4253f9e6666a1746ab9c075d212ba68a4e9c1"
 dependencies = [
  "cairo-lang-debug 2.7.0",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1116,7 +1136,7 @@ dependencies = [
  "cairo-lang-filesystem 1.0.0-rc0",
  "serde",
  "smol_str",
- "thiserror",
+ "thiserror 1.0.63",
  "toml 0.4.10",
 ]
 
@@ -1130,7 +1150,7 @@ dependencies = [
  "cairo-lang-utils 2.7.0",
  "serde",
  "smol_str",
- "thiserror",
+ "thiserror 1.0.63",
  "toml 0.8.19",
 ]
 
@@ -1162,7 +1182,7 @@ dependencies = [
  "sha2",
  "smol_str",
  "starknet-types-core",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -1235,7 +1255,7 @@ dependencies = [
  "serde",
  "sha3",
  "smol_str",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -1263,7 +1283,7 @@ dependencies = [
  "sha3",
  "smol_str",
  "starknet-types-core",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -1276,7 +1296,7 @@ dependencies = [
  "cairo-lang-sierra 1.0.0-rc0",
  "cairo-lang-utils 1.0.0-rc0",
  "itertools 0.10.5",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -1292,7 +1312,7 @@ dependencies = [
  "itertools 0.12.1",
  "num-bigint",
  "num-traits 0.2.19",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -1305,7 +1325,7 @@ dependencies = [
  "cairo-lang-sierra 1.0.0-rc0",
  "cairo-lang-utils 1.0.0-rc0",
  "itertools 0.10.5",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -1321,7 +1341,7 @@ dependencies = [
  "itertools 0.12.1",
  "num-bigint",
  "num-traits 0.2.19",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -1395,7 +1415,7 @@ dependencies = [
  "log",
  "num-bigint",
  "num-traits 0.2.19",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -1416,7 +1436,7 @@ dependencies = [
  "num-bigint",
  "num-traits 0.2.19",
  "starknet-types-core",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -1467,7 +1487,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "smol_str",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -1498,7 +1518,7 @@ dependencies = [
  "serde_json",
  "smol_str",
  "starknet-types-core",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -1522,7 +1542,7 @@ dependencies = [
  "sha3",
  "smol_str",
  "starknet-types-core",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -1538,7 +1558,7 @@ dependencies = [
  "num-traits 0.2.19",
  "salsa",
  "smol_str",
- "thiserror",
+ "thiserror 1.0.63",
  "unescaper",
 ]
 
@@ -1686,7 +1706,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -1704,6 +1724,15 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -1733,6 +1762,17 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1777,7 +1817,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1799,7 +1839,7 @@ dependencies = [
  "k256",
  "serde",
  "sha2",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -1815,7 +1855,7 @@ dependencies = [
  "pbkdf2 0.12.2",
  "rand",
  "sha2",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -1835,7 +1875,7 @@ dependencies = [
  "serde_derive",
  "sha2",
  "sha3",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -2133,7 +2173,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2155,7 +2195,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2205,7 +2245,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2438,7 +2478,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sha3",
- "thiserror",
+ "thiserror 1.0.63",
  "uuid 0.8.2",
 ]
 
@@ -2455,7 +2495,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "thiserror",
+ "thiserror 1.0.63",
  "uint",
 ]
 
@@ -2534,7 +2574,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -2556,7 +2596,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "syn 2.0.77",
+ "syn 2.0.90",
  "toml 0.8.19",
  "walkdir",
 ]
@@ -2574,7 +2614,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2600,9 +2640,9 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.26.3",
- "syn 2.0.77",
+ "syn 2.0.90",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.63",
  "tiny-keccak",
  "unicode-xid",
 ]
@@ -2619,7 +2659,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.63",
  "tracing",
 ]
 
@@ -2643,7 +2683,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -2675,7 +2715,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -2702,7 +2742,7 @@ dependencies = [
  "ethers-core",
  "rand",
  "sha2",
- "thiserror",
+ "thiserror 1.0.63",
  "tracing",
 ]
 
@@ -2730,7 +2770,7 @@ dependencies = [
  "serde_json",
  "solang-parser",
  "svm-rs",
- "thiserror",
+ "thiserror 1.0.63",
  "tiny-keccak",
  "tokio",
  "tracing",
@@ -2904,7 +2944,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2975,7 +3015,7 @@ checksum = "553630feadf7b76442b0849fd25fdf89b860d933623aec9693fed19af0400c78"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3770,9 +3810,19 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "libm"
@@ -3954,6 +4004,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "netlink-packet-core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-sock-diag"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a495cb1de50560a7cd12fdcf023db70eec00e340df81be31cedbbfd4aadd6b76"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "byteorder",
+ "libc",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+ "smallvec",
+]
+
+[[package]]
+name = "netlink-packet-utils"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "paste",
+ "thiserror 1.0.63",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16c903aa70590cb93691bf97a767c8d1d6122d2cc9070433deb3bbf36ce8bd23"
+dependencies = [
+ "bytes",
+ "libc",
+ "log",
+]
+
+[[package]]
+name = "netstat2"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6422b6a8c7635e8a82323e4cdf07a90e91901e07f4c1f0f3a245d54b4637e55c"
+dependencies = [
+ "bindgen",
+ "bitflags 2.6.0",
+ "byteorder",
+ "netlink-packet-core",
+ "netlink-packet-sock-diag",
+ "netlink-packet-utils",
+ "netlink-sys",
+ "num-derive",
+ "num-traits 0.2.19",
+ "thiserror 2.0.8",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4012,6 +4129,17 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "num-integer"
@@ -4108,7 +4236,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -4189,7 +4317,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -4428,7 +4556,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -4472,7 +4600,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -4569,7 +4697,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -4597,9 +4725,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -4735,7 +4863,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -5004,6 +5132,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5126,7 +5260,7 @@ dependencies = [
  "log",
  "oorandom",
  "parking_lot 0.11.2",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "salsa-macros",
  "smallvec",
 ]
@@ -5225,7 +5359,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5347,7 +5481,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5358,7 +5492,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5443,7 +5577,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5481,7 +5615,7 @@ checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5558,7 +5692,7 @@ checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
  "num-bigint",
  "num-traits 0.2.19",
- "thiserror",
+ "thiserror 1.0.63",
  "time",
 ]
 
@@ -5612,7 +5746,7 @@ dependencies = [
  "lalrpop 0.20.2",
  "lalrpop-util 0.20.2",
  "phf",
- "thiserror",
+ "thiserror 1.0.63",
  "unicode-xid",
 ]
 
@@ -5661,7 +5795,7 @@ dependencies = [
  "starknet-crypto 0.7.2",
  "starknet-providers",
  "starknet-signers",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -5676,7 +5810,7 @@ dependencies = [
  "starknet-accounts",
  "starknet-core",
  "starknet-providers",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -5765,7 +5899,7 @@ checksum = "bbc159a1934c7be9761c237333a57febe060ace2bc9e3b337a59a37af206d19f"
 dependencies = [
  "starknet-curve 0.4.2",
  "starknet-ff",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5807,6 +5941,7 @@ dependencies = [
  "ethers",
  "futures",
  "lazy_static",
+ "netstat2",
  "reqwest 0.12.7",
  "serde",
  "serde_json",
@@ -5819,7 +5954,7 @@ dependencies = [
  "starknet-devnet-types",
  "starknet-providers",
  "starknet-signers",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -5850,7 +5985,7 @@ dependencies = [
  "starknet-signers",
  "starknet-types-core",
  "starknet_api",
- "thiserror",
+ "thiserror 1.0.63",
  "tracing",
  "universal-sierra-compiler",
  "url",
@@ -5877,7 +6012,7 @@ dependencies = [
  "starknet-core",
  "starknet-devnet-core",
  "starknet-devnet-types",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tower-http",
  "tracing",
@@ -5914,7 +6049,7 @@ dependencies = [
  "starknet-crypto 0.7.2",
  "starknet-types-core",
  "starknet_api",
- "thiserror",
+ "thiserror 1.0.63",
  "universal-sierra-compiler",
 ]
 
@@ -5947,7 +6082,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "starknet-core",
- "thiserror",
+ "thiserror 1.0.63",
  "url",
 ]
 
@@ -5965,7 +6100,7 @@ dependencies = [
  "rand",
  "starknet-core",
  "starknet-crypto 0.7.2",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -6004,7 +6139,7 @@ dependencies = [
  "starknet-types-core",
  "strum 0.24.1",
  "strum_macros 0.24.3",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -6082,7 +6217,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -6095,7 +6230,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -6119,7 +6254,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror",
+ "thiserror 1.0.63",
  "url",
  "zip",
 ]
@@ -6137,9 +6272,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6257,7 +6392,16 @@ version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.63",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f5383f3e0071702bf93ab5ee99b52d26936be9dedd9413067cbdcddcb6141a"
+dependencies = [
+ "thiserror-impl 2.0.8",
 ]
 
 [[package]]
@@ -6268,7 +6412,18 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f357fcec90b3caef6623a099691be676d033b40a058ac95d2a6ade6fa0c943"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -6394,7 +6549,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -6578,7 +6733,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -6651,7 +6806,7 @@ dependencies = [
  "rand",
  "rustls 0.21.12",
  "sha1",
- "thiserror",
+ "thiserror 1.0.63",
  "url",
  "utf-8",
 ]
@@ -6686,7 +6841,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c878a167baa8afd137494101a688ef8c67125089ff2249284bd2b5f9bfedb815"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -6898,7 +7053,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
  "wasm-bindgen-shared",
 ]
 
@@ -6932,7 +7087,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7209,7 +7364,7 @@ dependencies = [
  "pharos",
  "rustc_version",
  "send_wrapper 0.6.0",
- "thiserror",
+ "thiserror 1.0.63",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -7263,7 +7418,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -7283,7 +7438,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.90",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ parking_lot = "0.12.3"
 serial_test = "3.1.1"
 hex = "0.4.3"
 lazy_static = { version = "1.4.0" }
+netstat2 = "0.11.1"
 
 # Benchmarking
 criterion = { version = "0.3.4", features = ["async_tokio"] }

--- a/crates/starknet-devnet/Cargo.toml
+++ b/crates/starknet-devnet/Cargo.toml
@@ -53,7 +53,7 @@ usc = { workspace = true }
 reqwest = { workspace = true }
 criterion = { workspace = true }
 serial_test = { workspace = true }
-
+netstat2 = { workspace = true }
 
 [[bench]]
 name = "mint_bench"

--- a/crates/starknet-devnet/src/cli.rs
+++ b/crates/starknet-devnet/src/cli.rs
@@ -85,7 +85,7 @@ pub(crate) struct Args {
     #[arg(env = "PORT")]
     #[arg(value_name = "PORT")]
     #[arg(default_value_t = DEVNET_DEFAULT_PORT)]
-    #[arg(help = "Specify the port to listen at;")]
+    #[arg(help = "Specify the port to listen at; If 0, looks for a free random port;")]
     port: u16,
 
     // Set start time in seconds

--- a/crates/starknet-devnet/src/cli.rs
+++ b/crates/starknet-devnet/src/cli.rs
@@ -85,7 +85,7 @@ pub(crate) struct Args {
     #[arg(env = "PORT")]
     #[arg(value_name = "PORT")]
     #[arg(default_value_t = DEVNET_DEFAULT_PORT)]
-    #[arg(help = "Specify the port to listen at; If 0, looks for a free random port;")]
+    #[arg(help = "Specify the port to listen at; If 0, acquires a random free port and prints it;")]
     port: u16,
 
     // Set start time in seconds

--- a/crates/starknet-devnet/src/main.rs
+++ b/crates/starknet-devnet/src/main.rs
@@ -241,30 +241,15 @@ pub async fn set_and_log_fork_config(
     Ok(())
 }
 
-/// Finds a free port if `specified_port` is 0. The returned listener reference must not be dropped
-/// in order to keep the port reserved by the current process.
-async fn get_listener(
+async fn bind_port(
     host: IpAddr,
     specified_port: u16,
 ) -> Result<(String, TcpListener), anyhow::Error> {
-    if specified_port == 0 {
-        // if specified port == 0, find a free one
-        for candidate_port in 1025..=65_535 {
-            if let Ok(listener) = TcpListener::bind((host, candidate_port)).await {
-                let address = format!("{host}:{candidate_port}");
-                return Ok((address, listener));
-            }
-            // otherwise port is occupied
-        }
-        Err(anyhow::Error::msg(
-            "No free ports! Try using `--port` to specify a port you expect to be free.",
-        ))
-    } else {
-        let listener =
-            TcpListener::bind((host, specified_port)).await.map_err(anyhow::Error::from)?;
-        let address = format!("{host}:{specified_port}");
-        Ok((address, listener))
-    }
+    let binding_address = format!("{host}:{specified_port}");
+    let listener = TcpListener::bind(binding_address.clone()).await?;
+
+    let acquired_port = listener.local_addr()?.port();
+    Ok((format!("{host}:{acquired_port}"), listener))
 }
 
 #[tokio::main]
@@ -288,7 +273,7 @@ async fn main() -> Result<(), anyhow::Error> {
         starknet_config.chain_id = json_rpc_client.chain_id().await?.into();
     }
 
-    let (address, listener) = get_listener(server_config.host, server_config.port).await?;
+    let (address, listener) = bind_port(server_config.host, server_config.port).await?;
 
     let starknet = Starknet::new(&starknet_config)?;
     let api = Api::new(starknet);

--- a/crates/starknet-devnet/tests/common/background_anvil.rs
+++ b/crates/starknet-devnet/tests/common/background_anvil.rs
@@ -10,6 +10,7 @@ use rand::Rng;
 use reqwest::StatusCode;
 use starknet_core::messaging::ethereum::ETH_ACCOUNT_DEFAULT;
 
+use super::constants::HOST;
 use super::errors::TestError;
 
 pub struct BackgroundAnvil {
@@ -50,15 +51,13 @@ impl BackgroundAnvil {
             .spawn()
             .expect("Could not start background Anvil");
 
-        let address = "127.0.0.1";
-        let anvil_url = format!("http://{address}:{port}");
-
+        let anvil_url = format!("http://{HOST}:{port}");
         let client = reqwest::Client::new();
         let max_retries = 30;
         for _ in 0..max_retries {
             if let Ok(anvil_block_rsp) = send_dummy_request(&client, &anvil_url).await {
                 assert_eq!(anvil_block_rsp.status(), StatusCode::OK);
-                println!("Spawned background anvil at port {port} ({address})");
+                println!("Spawned background anvil at {anvil_url}");
 
                 let (provider, provider_signer) = setup_ethereum_provider(&anvil_url).await?;
 

--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -162,20 +162,15 @@ impl BackgroundDevnet {
         method: &str,
         params: serde_json::Value,
     ) -> Result<serde_json::Value, RpcError> {
-        let body_json = if params.is_null() {
-            json!({
-                "jsonrpc": "2.0",
-                "id": 0,
-                "method": method
-            })
-        } else {
-            json!({
-                "jsonrpc": "2.0",
-                "id": 0,
-                "method": method,
-                "params": params
-            })
-        };
+        let mut body_json = json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": method,
+        });
+
+        if !params.is_null() {
+            body_json["params"] = params;
+        }
 
         let json_rpc_result: serde_json::Value =
             self.reqwest_client().post_json_async(RPC_PATH, body_json).await.map_err(|err| {

--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -20,6 +20,7 @@ use starknet_rs_providers::{JsonRpcClient, Provider};
 use starknet_rs_signers::{LocalWallet, SigningKey};
 use starknet_types::felt::felt_from_prefixed_hex;
 use starknet_types::rpc::transaction_receipt::FeeUnit;
+use tokio::sync::Mutex;
 use url::Url;
 
 use super::constants::{
@@ -28,6 +29,15 @@ use super::constants::{
 use super::errors::TestError;
 use super::reqwest_client::{PostReqwestSender, ReqwestClient};
 use super::utils::{to_hex_felt, ImpersonationAction};
+
+lazy_static! {
+    /// This is to prevent TOCTOU errors; i.e. one background devnet might find one
+    /// port to be free, and while it's trying to start listening to it, another instance
+    /// finds that it's free and tries occupying it
+    /// Using the mutex in `get_free_port_listener` might be safer than using no mutex at all,
+    /// but not sufficiently safe
+    static ref BACKGROUND_DEVNET_MUTEX: Mutex<()> = Mutex::new(());
+}
 
 #[derive(Debug)]
 pub struct BackgroundDevnet {
@@ -105,6 +115,10 @@ impl BackgroundDevnet {
     }
 
     pub(crate) async fn spawn_with_additional_args(args: &[&str]) -> Result<Self, TestError> {
+        // Necessary to synchronize, otherwise multiple Devnet instances acquire the same port.
+        // We keep the reference, otherwise the mutex unlocks immediately
+        let _mutex_guard = BACKGROUND_DEVNET_MUTEX.lock().await;
+
         let process = Command::new("cargo")
                 .arg("run")
                 .arg("--release")

--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -66,6 +66,7 @@ lazy_static! {
         ("--seed", SEED.to_string()),
         ("--accounts", ACCOUNTS.to_string()),
         ("--initial-balance", PREDEPLOYED_ACCOUNT_INITIAL_BALANCE.to_string()),
+        ("--port", 0.to_string())
     ]);
 }
 

--- a/crates/starknet-devnet/tests/common/constants.rs
+++ b/crates/starknet-devnet/tests/common/constants.rs
@@ -1,7 +1,7 @@
 use starknet_core::constants::DEVNET_DEFAULT_INITIAL_BALANCE;
 use starknet_rs_core::types::Felt;
 
-pub const HOST: &str = "localhost"; // TODO replace
+pub const HOST: &str = "127.0.0.1";
 pub const SEED: usize = 42;
 pub const ACCOUNTS: usize = 3;
 pub const CHAIN_ID: Felt = starknet_rs_core::chain_id::SEPOLIA;

--- a/crates/starknet-devnet/tests/common/constants.rs
+++ b/crates/starknet-devnet/tests/common/constants.rs
@@ -1,9 +1,7 @@
 use starknet_core::constants::DEVNET_DEFAULT_INITIAL_BALANCE;
 use starknet_rs_core::types::Felt;
 
-pub const HOST: &str = "localhost";
-pub const MIN_PORT: u16 = 1025;
-pub const MAX_PORT: u16 = 65_535;
+pub const HOST: &str = "localhost"; // TODO replace
 pub const SEED: usize = 42;
 pub const ACCOUNTS: usize = 3;
 pub const CHAIN_ID: Felt = starknet_rs_core::chain_id::SEPOLIA;

--- a/crates/starknet-devnet/tests/common/errors.rs
+++ b/crates/starknet-devnet/tests/common/errors.rs
@@ -1,17 +1,17 @@
 use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum TestError {
-    #[error("No free ports")]
-    NoFreePorts,
-
     #[error("Could not parse URL")]
     UrlParseError(#[from] url::ParseError),
 
     #[error("Invalid URI")]
     InvalidUri(#[from] axum::http::uri::InvalidUri),
 
-    #[error("Could not start Devnet. Make sure you've built it with: `cargo build --release`")]
-    DevnetNotStartable,
+    #[error("Could not start Devnet: {0}")]
+    DevnetNotStartable(String),
+
+    #[error("Too many ports occupied: {0:?}")]
+    TooManyPorts(Vec<u16>),
 
     #[error("Could not start Anvil")]
     AnvilNotStartable,

--- a/crates/starknet-devnet/tests/general_integration_tests.rs
+++ b/crates/starknet-devnet/tests/general_integration_tests.rs
@@ -100,7 +100,7 @@ mod general_integration_tests {
     async fn test_config() {
         // random values
         let dump_file = UniqueAutoDeletableFile::new("dummy");
-        let mut expected_config = json!({
+        let expected_config = json!({
             "seed": 1,
             "total_accounts": 2,
             "account_contract_class_hash": "0x61dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2971b8f",
@@ -120,7 +120,7 @@ mod general_integration_tests {
             },
             "server_config": {
                 "host": "0.0.0.0",
-                // expected port added after spawning; determined by port-acquiring logic
+                "port": 0, // default value in tests, config not modified upon finding a free port
                 "timeout": 121,
                 "request_body_size_limit": 1000,
                 "restricted_methods": null,
@@ -168,8 +168,6 @@ mod general_integration_tests {
         ])
         .await
         .unwrap();
-
-        expected_config["server_config"]["port"] = devnet.port.into();
 
         let fetched_config = devnet.get_config().await;
         assert_eq!(fetched_config, expected_config);

--- a/crates/starknet-devnet/tests/general_integration_tests.rs
+++ b/crates/starknet-devnet/tests/general_integration_tests.rs
@@ -18,9 +18,17 @@ mod general_integration_tests {
     use crate::common::utils::{to_hex_felt, UniqueAutoDeletableFile};
 
     #[tokio::test]
-    /// Asserts that a background instance can be spawned
-    async fn spawnable() {
+    async fn background_devnet_can_be_spawned() {
         BackgroundDevnet::spawn().await.expect("Could not start Devnet");
+    }
+
+    #[tokio::test]
+    async fn background_devnets_at_different_ports_with_random_acquisition() {
+        let devnet_args = ["--port", "0"];
+        let devnet1 = BackgroundDevnet::spawn_with_additional_args(&devnet_args).await.unwrap();
+        let devnet2 = BackgroundDevnet::spawn_with_additional_args(&devnet_args).await.unwrap();
+
+        assert_ne!(devnet1.url, devnet2.url);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Usage related changes

- If user specifies `--port 0`, the OS finds a random port.

## Development related changes

- `--port 0` is used in `BackgroundDevnet` as default to prevent the race condition in free port acquiring that has started to arise in #664.
- Use new dependency `netstat2` to determine the port where `BackgroundDevnet` spawned.
- Change the way spawning success is tested in `BackgroundDevnet`:
  - Test until one port associated with spawned subprocess PID. Then perform healthcheck (as before).
- Remove code duplication in `BackgroundDevnet::send_custom_rpc`.

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
