### PR TITLE
Fix links and details in predeployment docs (predeployed.md)

### DIFF
--- a/website/docs/predeployed.md
+++ b/website/docs/predeployed.md
@@ -1,6 +1,6 @@
 # Predeployed contracts
 
-Devnet predeploys a [UDC](https://docs.openzeppelin.com/contracts-cairo/0.6.1/udc), an [ERC20 (fee token)](https://docs.openzeppelin.com/contracts-cairo/0.8.1/erc20) contract and a set of predeployed funded accounts.
+Devnet predeploys a [UDC](https://docs.openzeppelin.com/contracts-cairo/udc), an [ERC20 (fee token)](https://docs.openzeppelin.com/contracts-cairo/erc20) contract and a set of predeployed funded accounts.
 
 The set of accounts can be controlled via [CLI options](./running/cli): `--accounts <NUMBER_OF>`, `--initial-balance <WEI>`, `--seed <VALUE>`.
 

--- a/website/docs/predeployed.md
+++ b/website/docs/predeployed.md
@@ -1,6 +1,6 @@
 # Predeployed contracts
 
-Devnet predeploys a [UDC](https://docs.openzeppelin.com/contracts-cairo/udc), an [ERC20 (fee token)](https://docs.openzeppelin.com/contracts-cairo/erc20) contract and a set of predeployed funded accounts.
+Devnet predeploys a [UDC](https://docs.openzeppelin.com/contracts-cairo/udc), two [ERC20 (fee token)](https://docs.openzeppelin.com/contracts-cairo/erc20) contracts (one for STRK, one for ETH) and a set of predeployed funded accounts.
 
 The set of accounts can be controlled via [CLI options](./running/cli): `--accounts <NUMBER_OF>`, `--initial-balance <WEI>`, `--seed <VALUE>`.
 


### PR DESCRIPTION
## Usage related changes

- Updated links for `UDC` and `ERC20` documentation to their correct URLs. 
- Fix the documented number of predeployed ERC20 instances.

## Development related changes

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [ ] Applied formatting - `./scripts/format.sh`
- [ ] No linter errors - `./scripts/clippy_check.sh`
- [ ] No unused dependencies - `./scripts/check_unused_deps.sh`
- [ ] No spelling errors - `./scripts/check_spelling.sh`
- [ ] Performed code self-review
- [ ] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [ ] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
