### PR TITLE
Fix sleeping after spawning BackgroundDevnet

### DIFF
--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -138,7 +138,6 @@ impl BackgroundDevnet {
 
         let reqwest_client = Client::new();
         let max_retries = 30;
-
         for _ in 0..max_retries {
             // give some time to the started Devnet instance to become responsive
             tokio::time::sleep(time::Duration::from_millis(500)).await;
@@ -171,9 +170,6 @@ impl BackgroundDevnet {
                     rpc_url: devnet_rpc_url,
                 });
             }
-
-            // If still in the loop, there is an error: probably a ConnectError if Devnet is not yet
-            // up, so retry.
         }
 
         Err(TestError::DevnetNotStartable(

--- a/crates/starknet-devnet/tests/common/background_devnet.rs
+++ b/crates/starknet-devnet/tests/common/background_devnet.rs
@@ -79,6 +79,49 @@ lazy_static! {
     ]);
 }
 
+async fn get_acquired_port(
+    pid: u32,
+    sleep_time: time::Duration,
+    max_retries: usize,
+) -> Result<u16, anyhow::Error> {
+    for _ in 0..max_retries {
+        let ports = get_ports_by_pid(pid)?;
+        match ports.len() {
+            0 => tokio::time::sleep(sleep_time).await, // if no ports, wait a bit more
+            1 => return Ok(ports[0]),
+            _ => {
+                return Err(anyhow::Error::msg(format!(
+                    "Too many ports associated with PID {pid}: {ports:?}"
+                )));
+            }
+        }
+    }
+
+    Err(anyhow::Error::msg(format!("No port associated with PID {pid}")))
+}
+
+async fn wait_for_successful_response(
+    client: &Client,
+    healthcheck_url: &str,
+    sleep_time: time::Duration,
+    max_retries: usize,
+) -> Result<(), anyhow::Error> {
+    for _ in 0..max_retries {
+        if let Ok(alive_resp) = client.get(healthcheck_url).send().await {
+            let status = alive_resp.status();
+            if status != StatusCode::OK {
+                return Err(anyhow::Error::msg(format!("Server responded with: {status}")));
+            }
+
+            return Ok(());
+        }
+
+        tokio::time::sleep(sleep_time).await;
+    }
+
+    Err(anyhow::Error::msg("Server not reachable at {}"))
+}
+
 impl BackgroundDevnet {
     /// Ensures the background instance spawns at a free port, checks at most `MAX_RETRIES`
     /// times
@@ -136,45 +179,30 @@ impl BackgroundDevnet {
                 .spawn()
                 .map_err(|e| TestError::DevnetNotStartable(e.to_string()))?;
 
-        let reqwest_client = Client::new();
-        let max_retries = 30;
-        for _ in 0..max_retries {
-            // give some time to the started Devnet instance to become responsive
-            tokio::time::sleep(time::Duration::from_millis(500)).await;
+        let sleep_time = time::Duration::from_millis(500);
+        let max_retries = 20;
+        let port = get_acquired_port(process.id(), sleep_time, max_retries)
+            .await
+            .map_err(|e| TestError::DevnetNotStartable(e.to_string()))?;
 
-            // attempt to get ports used by PID of the spawned subprocess
-            let port = match get_ports_by_pid(process.id()) {
-                Ok(ports) => match ports.len() {
-                    0 => continue, // if no ports, wait a bit more
-                    1 => ports[0],
-                    _ => return Err(TestError::TooManyPorts(ports)),
-                },
-                Err(e) => return Err(TestError::DevnetNotStartable(e.to_string())),
-            };
+        // now we know the port; check if it can be used to poll Devnet's endpoint
+        let client = Client::new();
+        let devnet_url = format!("http://{HOST}:{port}");
+        let healthcheck_url = format!("{devnet_url}{HEALTHCHECK_PATH}").to_string();
+        wait_for_successful_response(&client, &healthcheck_url, sleep_time, max_retries)
+            .await
+            .map_err(|e| TestError::DevnetNotStartable(e.to_string()))?;
+        println!("Spawned background devnet at {devnet_url}");
 
-            // now we know the port; check if it can be used to poll Devnet's endpoint
-            let devnet_url = format!("http://{HOST}:{port}");
-            let devnet_rpc_url = Url::parse(format!("{devnet_url}{RPC_PATH}").as_str())?;
-
-            let healthcheck_uri = format!("{devnet_url}{HEALTHCHECK_PATH}").to_string();
-
-            if let Ok(alive_resp) = reqwest_client.get(&healthcheck_uri).send().await {
-                assert_eq!(alive_resp.status(), StatusCode::OK);
-                println!("Spawned background devnet at {devnet_url}");
-                return Ok(BackgroundDevnet {
-                    reqwest_client: ReqwestClient::new(devnet_url.clone(), reqwest_client),
-                    json_rpc_client: JsonRpcClient::new(HttpTransport::new(devnet_rpc_url.clone())),
-                    process,
-                    port,
-                    url: devnet_url,
-                    rpc_url: devnet_rpc_url,
-                });
-            }
-        }
-
-        Err(TestError::DevnetNotStartable(
-            "Before testing, make sure you build Devnet with: `cargo build --release`".into(),
-        ))
+        let devnet_rpc_url = Url::parse(format!("{devnet_url}{RPC_PATH}").as_str())?;
+        Ok(BackgroundDevnet {
+            reqwest_client: ReqwestClient::new(devnet_url.clone(), client),
+            json_rpc_client: JsonRpcClient::new(HttpTransport::new(devnet_rpc_url.clone())),
+            process,
+            port,
+            url: devnet_url,
+            rpc_url: devnet_rpc_url,
+        })
     }
 
     pub async fn send_custom_rpc(


### PR DESCRIPTION
## Usage related changes

None

## Development related changes

- Fix the bug introduced by #666.
  - Still unclear: why the tests passed last year, but not this year.
- Refactor waiting into two loops (each at most 20 iterations with 500 ms of sleep = 10 s):
  1. Wait for port used by Devnet subprocess
  2. Wait for healthcheck to succeed

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
