### PR TITLE
Fix too-big-request error

### DIFF
--- a/crates/starknet-devnet-server/src/server.rs
+++ b/crates/starknet-devnet-server/src/server.rs
@@ -180,7 +180,11 @@ async fn reject_too_big(
 
     let too_large = |content_length: usize| -> (StatusCode, String) {
         (StatusCode::PAYLOAD_TOO_LARGE, serde_json::json!({
-            "error": format!("Received: {content_length} bytes, maximum (specifiable via --request-body-size-limit): {payload_limit} bytes")
+            "error": {
+                "code": -1,
+                "message": format!("Request too big! Server received: {content_length} bytes; maximum (specifiable via --request-body-size-limit): {payload_limit} bytes"),
+                "data": null,
+            }
         }).to_string())
     };
 

--- a/tests/integration/common/background_devnet.rs
+++ b/tests/integration/common/background_devnet.rs
@@ -200,11 +200,21 @@ impl BackgroundDevnet {
 
         let json_rpc_result: serde_json::Value =
             self.reqwest_client().post_json_async(RPC_PATH, body_json).await.map_err(|err| {
-                RpcError {
-                    code: err.status().as_u16().into(),
-                    message: err.error_message().into(),
-                    data: None,
+                let err_msg = err.error_message();
+
+                if let Ok(rpc_error) = serde_json::from_str::<RpcError>(&err_msg) {
+                    return rpc_error;
+                };
+
+                if let Ok(err_val) = serde_json::from_str::<serde_json::Value>(&err_msg) {
+                    if let Some(e) = err_val.get("error").cloned() {
+                        if let Ok(e) = serde_json::from_value::<RpcError>(e) {
+                            return e;
+                        }
+                    }
                 }
+
+                panic!("Cannot extract RPC error from: {err_msg}")
             })?;
 
         if let Some(result) = json_rpc_result.get("result") {

--- a/tests/integration/common/background_devnet.rs
+++ b/tests/integration/common/background_devnet.rs
@@ -158,7 +158,7 @@ impl BackgroundDevnet {
         let safe_process = SafeChild { process };
 
         let sleep_time = time::Duration::from_millis(500);
-        let max_retries = 40;
+        let max_retries = 60;
         let port = get_acquired_port(safe_process.id(), sleep_time, max_retries)
             .await
             .map_err(|e| TestError::DevnetNotStartable(format!("Cannot determine port: {e:?}")))?;
@@ -198,6 +198,7 @@ impl BackgroundDevnet {
             body_json["params"] = params;
         }
 
+        // Convert HTTP error to RPC error; panic if not possible.
         let json_rpc_result: serde_json::Value =
             self.reqwest_client().post_json_async(RPC_PATH, body_json).await.map_err(|err| {
                 let err_msg = err.error_message();

--- a/tests/integration/common/background_devnet.rs
+++ b/tests/integration/common/background_devnet.rs
@@ -208,9 +208,9 @@ impl BackgroundDevnet {
                 };
 
                 if let Ok(err_val) = serde_json::from_str::<serde_json::Value>(&err_msg) {
-                    if let Some(e) = err_val.get("error").cloned() {
-                        if let Ok(e) = serde_json::from_value::<RpcError>(e) {
-                            return e;
+                    if let Some(err_prop) = err_val.get("error").cloned() {
+                        if let Ok(rpc_error) = serde_json::from_value::<RpcError>(err_prop) {
+                            return rpc_error;
                         }
                     }
                 }

--- a/tests/integration/common/background_devnet.rs
+++ b/tests/integration/common/background_devnet.rs
@@ -158,7 +158,7 @@ impl BackgroundDevnet {
         let safe_process = SafeChild { process };
 
         let sleep_time = time::Duration::from_millis(500);
-        let max_retries = 60;
+        let max_retries = 40;
         let port = get_acquired_port(safe_process.id(), sleep_time, max_retries)
             .await
             .map_err(|e| TestError::DevnetNotStartable(format!("Cannot determine port: {e:?}")))?;

--- a/tests/integration/general_integration_tests.rs
+++ b/tests/integration/general_integration_tests.rs
@@ -48,9 +48,8 @@ async fn too_big_request_rejected_via_non_rpc() {
         serde_json::from_str::<serde_json::Value>(&err.error_message()).unwrap(),
         json!({
             "error": {
-                "code": -1,
+                "code": -32600,
                 "message": format!("Request too big! Server received: 1111 bytes; maximum (specifiable via --request-body-size-limit): {limit} bytes"),
-                "data": null
             }
         })
     );
@@ -84,7 +83,7 @@ async fn too_big_request_rejected_via_rpc() {
     assert_eq!(
         error,
         RpcError {
-            code: -1,
+            code: -32600,
             message: format!(
                 "Request too big! Server received: 1168 bytes; maximum (specifiable via \
                  --request-body-size-limit): {limit} bytes"

--- a/tests/integration/general_integration_tests.rs
+++ b/tests/integration/general_integration_tests.rs
@@ -44,6 +44,16 @@ async fn too_big_request_rejected_via_non_rpc() {
     .expect_err("Request should have been rejected");
 
     assert_eq!(err.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&err.error_message()).unwrap(),
+        json!({
+            "error": {
+                "code": -1,
+                "message": format!("Request too big! Server received: 1111 bytes; maximum (specifiable via --request-body-size-limit): {limit} bytes"),
+                "data": null
+            }
+        })
+    );
 
     // subtract enough so that the rest of the json body doesn't overflow the limit
     let nonexistent_path = "a".repeat(limit - 100);

--- a/tests/integration/general_integration_tests.rs
+++ b/tests/integration/general_integration_tests.rs
@@ -81,7 +81,18 @@ async fn too_big_request_rejected_via_rpc() {
         .await
         .expect_err("Request should have been rejected");
 
-    assert_eq!(error.code, StatusCode::PAYLOAD_TOO_LARGE.as_u16() as i64);
+    assert_eq!(
+        error,
+        RpcError {
+            code: -1,
+            message: format!(
+                "Request too big! Server received: 1168 bytes; maximum (specifiable via \
+                 --request-body-size-limit): {limit} bytes"
+            )
+            .into(),
+            data: None
+        }
+    );
 
     // subtract enough so that the rest of the json body doesn't overflow the limit
     let nonexistent_path = "a".repeat(limit - 100);


### PR DESCRIPTION
## Usage related changes

- Address the wrong RPC error format issue described on [Slack](https://spaceshard.slack.com/archives/C03QYDV8CQP/p1734532957167609).

## Development related changes

- Improve existing tests.
- Fix `BackgroundDevnet::send_custom_rpc` error mapping.

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
