### PR TITLE
Fix timing in tests

### DIFF
--- a/tests/integration/common/background_devnet.rs
+++ b/tests/integration/common/background_devnet.rs
@@ -158,7 +158,7 @@ impl BackgroundDevnet {
         let safe_process = SafeChild { process };
 
         let sleep_time = time::Duration::from_millis(500);
-        let max_retries = 40;
+        let max_retries = 60;
         let port = get_acquired_port(safe_process.id(), sleep_time, max_retries)
             .await
             .map_err(|e| TestError::DevnetNotStartable(format!("Cannot determine port: {e:?}")))?;


### PR DESCRIPTION
## Usage related changes

<!-- How the changes from this PR affect users. -->

## Development related changes

- Increment BackgroundDevnet max retries from 40 to 60 (20 to 30 seconds)
  - For some reason, when running Devnet with `cargo run --release` within tests, it again recompiles the production code, despite having already compiled it, which leads to occasional timeout.
  - Only used locally, CI tests execute the binary directly.
- Modify sleeping in timestamp tests:
  - Extract logic into a helper function: `sleep_until_new_timestamp`.
  - Extend sleep to 1.1 s (looks like 1 s isn't enough).

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
