### PR TITLE
Enable early exiting if BackgroundDevnet fails

### DIFF
--- a/crates/starknet-devnet/src/main.rs
+++ b/crates/starknet-devnet/src/main.rs
@@ -273,10 +273,10 @@ async fn main() -> Result<(), anyhow::Error> {
         starknet_config.chain_id = json_rpc_client.chain_id().await?.into();
     }
 
-    let (address, listener) = bind_port(server_config.host, server_config.port).await?;
-
     let starknet = Starknet::new(&starknet_config)?;
     let api = Api::new(starknet);
+
+    let (address, listener) = bind_port(server_config.host, server_config.port).await?;
 
     // set block timestamp shift during startup if start time is set
     if let Some(start_time) = starknet_config.start_time {


### PR DESCRIPTION
## Usage related changes

Hopefully none.

## Development related changes

- Change order of actions in `main`:
  - Perform port binding after creating `Starknet` and `Api` objects (`Starknet` creation might fail).
- If `BackgroundDevnet` fails, early exiting is enabled in port search to prevent unnecessary waiting for 30 seconds.

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
  - All tests passing except those blocked by #680.