### PR TITLE
Tests: fork integration network at safe block

### DIFF
--- a/tests/integration/common/constants.rs
+++ b/tests/integration/common/constants.rs
@@ -81,14 +81,16 @@ pub const INVALID_ACCOUNT_SIERRA_PATH: &str =
 pub const ARGENT_ACCOUNT_CLASS_HASH: &str =
     "0x029927c8af6bccf3f6fda035981e765a7bdbf18a2dc0d630494f8758aa908e2b";
 
-/// Forking
+// Forking
 pub const INTEGRATION_SEPOLIA_HTTP_URL: &str =
     "http://rpc.pathfinder.equilibrium.co/integration-sepolia/rpc/v0_7";
 
 pub const MAINNET_URL: &str = "http://rpc.pathfinder.equilibrium.co/mainnet/rpc/v0_7";
 pub const MAINNET_HTTPS_URL: &str = "https://rpc.pathfinder.equilibrium.co/mainnet/rpc/v0_7";
-pub const INTEGRATION_SEPOLIA_GENESIS_BLOCK_HASH: &str =
+pub const INTEGRATION_GENESIS_BLOCK_HASH: &str =
     "0x19f675d3fb226821493a6ab9a1955e384bba80f130de625621a418e9a7c0ca3";
+/// The number of the last block at which forking can be done; prior to v0.13.4.
+pub const INTEGRATION_SAFE_BLOCK: u64 = 64718;
 
 // copied from starknet-rs, because it is not exposed as public type
 pub const QUERY_VERSION_OFFSET: Felt =

--- a/tests/integration/test_fork.rs
+++ b/tests/integration/test_fork.rs
@@ -21,8 +21,8 @@ use starknet_rs_signers::Signer;
 use crate::common::background_devnet::BackgroundDevnet;
 use crate::common::constants::{
     self, CAIRO_1_ACCOUNT_CONTRACT_0_8_0_SIERRA_PATH, CAIRO_1_ERC20_CONTRACT_CLASS_HASH,
-    INTEGRATION_SEPOLIA_GENESIS_BLOCK_HASH, INTEGRATION_SEPOLIA_HTTP_URL, MAINNET_HTTPS_URL,
-    MAINNET_URL,
+    INTEGRATION_GENESIS_BLOCK_HASH, INTEGRATION_SAFE_BLOCK, INTEGRATION_SEPOLIA_HTTP_URL,
+    MAINNET_HTTPS_URL, MAINNET_URL,
 };
 use crate::common::utils::{
     assert_cairo1_classes_equal, assert_tx_successful, declare_v3_deploy_v3,
@@ -53,15 +53,12 @@ async fn test_fork_status() {
 
 #[tokio::test]
 async fn test_forking_sepolia_genesis_block() {
-    let cli_args = ["--fork-network", INTEGRATION_SEPOLIA_HTTP_URL];
+    let fork_block = &INTEGRATION_SAFE_BLOCK.to_string();
+    let cli_args = ["--fork-network", INTEGRATION_SEPOLIA_HTTP_URL, "--fork-block", fork_block];
     let fork_devnet = BackgroundDevnet::spawn_with_additional_args(&cli_args).await.unwrap();
 
-    let resp = &fork_devnet
-        .json_rpc_client
-        .get_block_with_tx_hashes(BlockId::Hash(Felt::from_hex_unchecked(
-            INTEGRATION_SEPOLIA_GENESIS_BLOCK_HASH,
-        )))
-        .await;
+    let block_hash = BlockId::Hash(Felt::from_hex_unchecked(INTEGRATION_GENESIS_BLOCK_HASH));
+    let resp = &fork_devnet.json_rpc_client.get_block_with_tx_hashes(block_hash).await;
 
     match resp {
         Ok(MaybePendingBlockWithTxHashes::Block(b)) => assert_eq!(b.block_number, 0),
@@ -71,7 +68,8 @@ async fn test_forking_sepolia_genesis_block() {
 
 #[tokio::test]
 async fn test_getting_non_existent_block_from_origin() {
-    let cli_args = ["--fork-network", INTEGRATION_SEPOLIA_HTTP_URL];
+    let fork_block = &INTEGRATION_SAFE_BLOCK.to_string();
+    let cli_args = ["--fork-network", INTEGRATION_SEPOLIA_HTTP_URL, "--fork-block", fork_block];
     let fork_devnet = BackgroundDevnet::spawn_with_additional_args(&cli_args).await.unwrap();
 
     let non_existent_block_hash = "0x123456";

--- a/tests/integration/test_gas_modification.rs
+++ b/tests/integration/test_gas_modification.rs
@@ -9,7 +9,9 @@ use starknet_rs_providers::ProviderError;
 use starknet_rs_signers::Signer;
 
 use crate::common::background_devnet::BackgroundDevnet;
-use crate::common::constants::{self, CAIRO_1_CONTRACT_PATH, INTEGRATION_SEPOLIA_HTTP_URL};
+use crate::common::constants::{
+    self, CAIRO_1_CONTRACT_PATH, INTEGRATION_SAFE_BLOCK, INTEGRATION_SEPOLIA_HTTP_URL,
+};
 use crate::common::fees::assert_difference_if_validation;
 use crate::common::utils::{
     assert_tx_successful, get_flattened_sierra_contract_and_casm_hash,
@@ -170,7 +172,8 @@ async fn set_gas() {
 
 #[tokio::test]
 async fn set_gas_fork() {
-    let cli_args: [&str; 2] = ["--fork-network", INTEGRATION_SEPOLIA_HTTP_URL];
+    let fork_block = &INTEGRATION_SAFE_BLOCK.to_string();
+    let cli_args = ["--fork-network", INTEGRATION_SEPOLIA_HTTP_URL, "--fork-block", fork_block];
     let fork_devnet = BackgroundDevnet::spawn_with_additional_args(&cli_args).await.unwrap();
 
     // Sepolia fork gas modification test scenario


### PR DESCRIPTION
## Usage related changes

None

## Development related changes

- Use the latest safe block in tests where the integration network is forked.
  - This is done in order to make the tests pass. They have been failing for days due to #680.
  - We can also undo this change in the future to always test with the latest integration block, which is the default if block not specified.
- Reduce var name complexity and line count.

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
