### PR TITLE
Fix script for fetching binary artifacts

### DIFF
--- a/scripts/fetch_ci_binaries.py
+++ b/scripts/fetch_ci_binaries.py
@@ -29,7 +29,7 @@ def get_artifact_info(job: dict) -> Optional[Tuple[str, str]]:
     Returns the artifact (URL, name) corresponding to job object.
     Returns None if job is not a binary build.
     """
-    if job["job_name"].startswith("binary-build-"):
+    if job["job_name"].startswith(BINARY_BUILD_JOB_PREFIX):
         job_id = job["job_id"]
         job_name = job["job_name"]
         artifact_name = (
@@ -109,8 +109,8 @@ def main():
     for pipeline in pipelines:
         # assuming a chronologically descending order
         if workflow_predicate(pipeline):
-            workflow_id = pipeline["workflows"]["workflow_id"]
-            log_pipeline(workflow_id, pipeline)
+            workspace_id = pipeline["workflows"]["workspace_id"]
+            log_pipeline(pipeline["workflows"]["workflow_id"], pipeline)
             break
     else:
         sys.exit("Error: Could not locate workflow ID")
@@ -118,7 +118,7 @@ def main():
     jobs = [
         pipeline["workflows"]
         for pipeline in pipelines
-        if pipeline["workflows"]["workflow_id"] == workflow_id
+        if pipeline["workflows"]["workspace_id"] == workspace_id
     ]
 
     artifact_infos = [
@@ -130,7 +130,7 @@ def main():
     if not artifact_infos:
         sys.exit("Error: No artifacts found")
 
-    write_artifacts(workflow_id, artifact_infos)
+    write_artifacts(workspace_id, artifact_infos)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Usage related changes

None

## Development related changes

- It seems that CircleCI has changed its API: I had issues with attaching artifacts to [v0.2.4](https://github.com/0xSpaceShard/starknet-devnet-rs/releases/tag/v0.2.4)
  - Had to rely on a workflow property called `workspace_id`.
- Expand usage of constants.

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
