### PR TITLE
Update starknet-rs to 0.13; allow deprecated methods in integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
  "cairo-lang-utils 2.7.0",
  "cairo-vm",
  "derive_more",
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "itertools 0.10.5",
  "keccak",
  "log",
@@ -1617,7 +1617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bd5c8c127b9362a12ffb9dede38e792c81b4ded5a98b448baec157b745f47d1"
 dependencies = [
  "hashbrown 0.14.5",
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "itertools 0.12.1",
  "num-bigint",
  "num-traits 0.2.19",
@@ -2723,6 +2723,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2996,7 +3002,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -3015,7 +3021,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -3047,6 +3053,12 @@ dependencies = [
  "allocator-api2",
  "serde",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "hashers"
@@ -3439,12 +3451,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "serde",
 ]
 
@@ -3684,9 +3696,9 @@ dependencies = [
 
 [[package]]
 name = "lambdaworks-crypto"
-version = "0.7.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb5d4f22241504f7c7b8d2c3a7d7835d7c07117f10bff2a7d96a9ef6ef217c3"
+checksum = "bbc2a4da0d9e52ccfe6306801a112e81a8fc0c76aa3e4449fefeda7fef72bb34"
 dependencies = [
  "lambdaworks-math",
  "serde",
@@ -3696,9 +3708,9 @@ dependencies = [
 
 [[package]]
 name = "lambdaworks-math"
-version = "0.7.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "358e172628e713b80a530a59654154bfc45783a6ed70ea284839800cebdf8f97"
+checksum = "d1bd2632acbd9957afc5aeec07ad39f078ae38656654043bf16e046fa2730e23"
 dependencies = [
  "serde",
  "serde_json",
@@ -4342,7 +4354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
 ]
 
 [[package]]
@@ -5286,7 +5298,7 @@ version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "itoa",
  "memchr",
  "ryu",
@@ -5345,7 +5357,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5371,7 +5383,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "itoa",
  "ryu",
  "serde",
@@ -5570,14 +5582,14 @@ dependencies = [
 
 [[package]]
 name = "starknet-accounts"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee27ded58ade61da410fccafd57ed5429b0e79a9d62a4ae8b65818cb9d6f400"
+checksum = "b3fc4364f5684e4a5dcb100847a9ea023deae3815f45526721a6fa94ab595651"
 dependencies = [
  "async-trait",
  "auto_impl",
  "starknet-core",
- "starknet-crypto 0.7.2",
+ "starknet-crypto 0.7.4",
  "starknet-providers",
  "starknet-signers",
  "thiserror",
@@ -5585,9 +5597,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-contract"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6ee5762d24c4f06ab7e9406550925df406712e73719bd2de905c879c674a87"
+checksum = "3f2102b8f763477a1bdece683da51514bc73829d5dcc3bbe75ff1b6aca6d4e02"
 dependencies = [
  "serde",
  "serde_json",
@@ -5600,21 +5612,36 @@ dependencies = [
 
 [[package]]
 name = "starknet-core"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538240cbe6663c673fe77465f294da707080f39678dd7066761554899e46100"
+checksum = "37abf0af45a3b866dd108880ace9949ae7830f6830adb8963024302ae9e82c24"
 dependencies = [
  "base64 0.21.7",
  "crypto-bigint",
  "flate2",
+ "foldhash",
  "hex",
+ "indexmap 2.7.1",
+ "num-traits 0.2.19",
  "serde",
  "serde_json",
  "serde_json_pythonic",
  "serde_with",
  "sha3",
- "starknet-crypto 0.7.2",
+ "starknet-core-derive",
+ "starknet-crypto 0.7.4",
  "starknet-types-core",
+]
+
+[[package]]
+name = "starknet-core-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08520b7d80eda7bf1a223e8db4f9bb5779a12846f15ebf8f8d76667eca7f5ad"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -5659,9 +5686,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a5064173a8e8d2675e67744fd07f310de44573924b6b7af225a6bdd8102913"
+checksum = "039a3bad70806b494c9e6b21c5238a6c8a373d66a26071859deb0ccca6f93634"
 dependencies = [
  "crypto-bigint",
  "hex",
@@ -5745,7 +5772,7 @@ dependencies = [
  "clap",
  "ethers",
  "hex",
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "nonzero_ext",
  "openssl",
  "parking_lot 0.12.3",
@@ -5820,7 +5847,7 @@ dependencies = [
  "serde",
  "serde_json",
  "starknet-core",
- "starknet-crypto 0.7.2",
+ "starknet-crypto 0.7.4",
  "starknet-types-core",
  "starknet_api",
  "thiserror",
@@ -5841,9 +5868,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-providers"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60e8e69ba7a36dea2d28333be82b4011f8784333d3ae5618482b6587c1ffb66c"
+checksum = "a9256247f718564b3e4c73cc941735012691c14903fbc25cea306745bcbfa384"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -5862,9 +5889,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-signers"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b9e01b61ae51d722e2b100d6ef913c5a2e70d1ea672733d385f7296d6055ef"
+checksum = "79b9cbae629e277fba372b5f22f52aa5dd1dd40c61924bb18bf901d4d830edd1"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -5873,15 +5900,15 @@ dependencies = [
  "getrandom",
  "rand",
  "starknet-core",
- "starknet-crypto 0.7.2",
+ "starknet-crypto 0.7.4",
  "thiserror",
 ]
 
 [[package]]
 name = "starknet-types-core"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6bacf0ba19bc721e518bc4bf389ff13daa8a7c5db5fd320600473b8aa9fcbd"
+checksum = "fa1b9e01ccb217ab6d475c5cda05dbb22c30029f7bb52b192a010a00d77a3d74"
 dependencies = [
  "lambdaworks-crypto",
  "lambdaworks-math",
@@ -5902,7 +5929,7 @@ dependencies = [
  "cairo-lang-starknet-classes",
  "derive_more",
  "hex",
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "itertools 0.12.1",
  "once_cell",
  "primitive-types",
@@ -6382,7 +6409,7 @@ version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.7.1",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,12 +80,12 @@ enum-helper-macros = "0.0.1"
 starknet-types-core = "0.1.5"
 starknet_api = { version = "0.13.0-rc.0", features = ["testing"] }
 blockifier = { version = "0.8.0" }
-starknet-rs-signers = { version = "0.10.0", package = "starknet-signers" }
-starknet-rs-core = { version = "0.12.0", package = "starknet-core" }
-starknet-rs-providers = { version = "0.12.0", package = "starknet-providers" }
-starknet-rs-accounts = { version = "0.11.0", package = "starknet-accounts" }
-starknet-rs-contract = { version = "0.11.0", package = "starknet-contract" }
-starknet-rs-crypto = { version = "0.7.2", package = "starknet-crypto" }
+starknet-rs-signers = { version = "0.10.1", package = "starknet-signers" }
+starknet-rs-core = { version = "0.12.1", package = "starknet-core" }
+starknet-rs-providers = { version = "0.12.1", package = "starknet-providers" }
+starknet-rs-accounts = { version = "0.12.0", package = "starknet-accounts" }
+starknet-rs-contract = { version = "0.12.0", package = "starknet-contract" }
+starknet-rs-crypto = { version = "0.7.4", package = "starknet-crypto" }
 cairo-vm = "=1.0.1"
 
 # Cairo-lang dependencies

--- a/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/mod.rs
@@ -774,15 +774,13 @@ mod requests_tests {
         // Errored json, hash is not prefixed with 0x
         assert_deserialization_fails(
             r#"{"method":"starknet_getTransactionByHash","params":{"transaction_hash":"134134"}}"#,
-            "Expected hex string to be prefixed by '0x'",
+            "expected hex string to be prefixed by '0x'",
         );
-        // TODO: ignored because of a Felt bug: https://github.com/starknet-io/types-rs/issues/81
-        // Errored json, hex is longer than 64 chars
-        // assert_deserialization_fails(
-        //     r#"{"method":"starknet_getTransactionByHash","params":{"transaction_hash":"
-        // 0x004134134134134134134134134134134134134134134134134134134134134134"}}"#,
-        //     "Bad input - expected #bytes: 32",
-        // );
+        // Errored json, hex longer than 64 chars; misleading error message coming from dependency
+        assert_deserialization_fails(
+            r#"{"method":"starknet_getTransactionByHash","params":{"transaction_hash":"0x004134134134134134134134134134134134134134134134134134134134134134"}}"#,
+            "expected hex string to be prefixed by '0x'",
+        );
     }
 
     #[test]
@@ -803,7 +801,7 @@ mod requests_tests {
 
         assert_deserialization_fails(
             json_str.replace("0x", "").as_str(),
-            "Expected hex string to be prefixed by '0x'",
+            "expected hex string to be prefixed by '0x'",
         );
     }
 
@@ -814,7 +812,7 @@ mod requests_tests {
 
         assert_deserialization_fails(
             json_str.replace("0x", "").as_str(),
-            "Expected hex string to be prefixed by '0x'",
+            "expected hex string to be prefixed by '0x'",
         );
     }
 
@@ -883,11 +881,11 @@ mod requests_tests {
                     r#""entry_point_selector":"134134""#,
                 )
                 .as_str(),
-            "Expected hex string to be prefixed by '0x'",
+            "expected hex string to be prefixed by '0x'",
         );
         assert_deserialization_fails(
             json_str.replace(r#""calldata":["0x134134"]"#, r#""calldata":["123"]"#).as_str(),
-            "Expected hex string to be prefixed by '0x'",
+            "expected hex string to be prefixed by '0x'",
         );
         assert_deserialization_fails(
             json_str.replace(r#""calldata":["0x134134"]"#, r#""calldata":[123]"#).as_str(),
@@ -1319,8 +1317,7 @@ mod response_tests {
     use crate::api::json_rpc::ToRpcResponseResult;
 
     #[test]
-    fn serializing_starknet_response_empty_variant_has_to_produce_empty_json_object_when_converted_to_rpc_result()
-     {
+    fn serializing_starknet_response_empty_variant_yields_empty_json_on_conversion_to_rpc_result() {
         assert_eq!(
             r#"{"result":{}}"#,
             serde_json::to_string(

--- a/crates/starknet-devnet-server/src/api/json_rpc/models.rs
+++ b/crates/starknet-devnet-server/src/api/json_rpc/models.rs
@@ -499,13 +499,12 @@ mod tests {
             r#"{"block_id": {"block_hash": "0x01"}}"#,
         );
 
-        // TODO: ignored because of a Felt bug: https://github.com/starknet-io/types-rs/issues/81
         // Block hash hex value is more than 64 chars
-        // assert_block_id_block_hash_correctness(
-        //     false,
-        //     "0x01",
-        //     r#"{"block_id": {"block_hash":
-        // "0x004134134134134134134134134134134134134134134134134134134134134134"}}"#, );
+        assert_block_id_block_hash_correctness(
+            false,
+            "0x01",
+            r#"{"block_id": {"block_hash": "0x004134134134134134134134134134134134134134134134134134134134134134"}}"#,
+        );
 
         // Block hash hex doesn't start with 0x
         assert_block_id_block_hash_correctness(
@@ -556,13 +555,12 @@ mod tests {
             ),
             (
                 r#"{"block_id": {"block_hash": 123}}"#,
-                // TODO: https://github.com/starknet-io/types-rs/issues/81#issuecomment-2230701335
-                "Invalid block ID: invalid type: number, expected Failed to deserialize \
+                "Invalid block ID: invalid type: number, expected a 32 byte array ([u8;32]) or a \
                  hexadecimal string",
             ),
             (
                 r#"{"block_id": {"block_hash": ""}}"#,
-                "Invalid block ID: Expected hex string to be prefixed by '0x",
+                "Invalid block ID: expected hex string to be prefixed by '0x",
             ),
         ] {
             match serde_json::from_str::<BlockIdInput>(json_str) {

--- a/tests/integration/common/constants.rs
+++ b/tests/integration/common/constants.rs
@@ -76,10 +76,9 @@ pub const MESSAGING_L1_CONTRACT_ADDRESS: &str = "0xe7f1725e7734ce288f8367e1bb143
 pub const INVALID_ACCOUNT_SIERRA_PATH: &str =
     "../../contracts/test_artifacts/cairo1/invalid_account/invalid_account.sierra";
 
-/// hash of the sierra artifact at commit d9f5220059c1e61ff87e4a5752522569135e464c of
-/// argentlabs/argent-contracts-starknet:main
+/// Argent v0.4.0
 pub const ARGENT_ACCOUNT_CLASS_HASH: &str =
-    "0x029927c8af6bccf3f6fda035981e765a7bdbf18a2dc0d630494f8758aa908e2b";
+    "0x36078334509b514626504edc9fb252328d1a240e4e948bef8d0c08dff45927f";
 
 // Forking
 pub const INTEGRATION_SEPOLIA_HTTP_URL: &str =

--- a/tests/integration/common/utils.rs
+++ b/tests/integration/common/utils.rs
@@ -291,7 +291,7 @@ pub async fn deploy_argent_account(
     let factory = ArgentAccountFactory::new(
         Felt::from_hex(ARGENT_ACCOUNT_CLASS_HASH)?,
         devnet.json_rpc_client.chain_id().await?,
-        Felt::ZERO,
+        None,
         signer.clone(),
         devnet.clone_provider(),
     )

--- a/tests/integration/lib.rs
+++ b/tests/integration/lib.rs
@@ -1,7 +1,8 @@
 #![cfg(test)]
-#![allow(deprecated)]
+#![allow(deprecated)] // TODO until v1 and v2 transactions are replaced with v3
 
 mod common;
+
 mod general_integration_tests;
 mod general_rpc_tests;
 mod get_transaction_by_block_id_and_index;

--- a/tests/integration/lib.rs
+++ b/tests/integration/lib.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
+#![allow(deprecated)]
 
 mod common;
-
 mod general_integration_tests;
 mod general_rpc_tests;
 mod get_transaction_by_block_id_and_index;


### PR DESCRIPTION
## Usage related changes

- None, hopefully

## Development related changes

- Update the starknet-rs dependency to 0.13
  - v1 and v2 transaction methods are deprecated, so until we completely remove them or replace them with v3 counterparts, we allow deprecated methods in the integration crate.
- Remove three TODOs, introduce one.
- Update Argent class hash.
- Unblock #658.

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
