### PR TITLE
Remove blockifier testing feature; use VersionedConstants 0.13.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,8 +582,6 @@ dependencies = [
  "once_cell",
  "paste",
  "phf",
- "rand",
- "rstest",
  "serde",
  "serde_json",
  "sha2",
@@ -4882,32 +4880,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "rstest"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de1bb486a691878cd320c2f0d319ba91eeaa2e894066d8b5f8f117c000e9d962"
-dependencies = [
- "futures",
- "futures-timer",
- "rstest_macros",
- "rustc_version",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290ca1a1c8ca7edb7c3283bd44dc35dd54fdec6253a3912e201ba1072018fca8"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 1.0.109",
- "unicode-ident",
 ]
 
 [[package]]

--- a/crates/starknet-devnet-core/Cargo.toml
+++ b/crates/starknet-devnet-core/Cargo.toml
@@ -12,7 +12,7 @@ description = "Starknet core logic for devnet"
 workspace = true
 
 [dependencies]
-blockifier = { workspace = true, features = ["testing"] }
+blockifier = { workspace = true }
 cairo-lang-starknet-classes = { workspace = true }
 clap = { workspace = true }
 ethers = { workspace = true }

--- a/crates/starknet-devnet-core/src/transactions.rs
+++ b/crates/starknet-devnet-core/src/transactions.rs
@@ -268,18 +268,20 @@ impl StarknetTransaction {
 
 #[cfg(test)]
 mod tests {
+    use blockifier::state::cached_state::CachedState;
     use blockifier::transaction::objects::TransactionExecutionInfo;
     use starknet_rs_core::types::{TransactionExecutionStatus, TransactionFinalityStatus};
     use starknet_types::rpc::transactions::{TransactionTrace, TransactionWithHash};
 
     use super::{StarknetTransaction, StarknetTransactions};
     use crate::starknet::transaction_trace::create_trace;
+    use crate::state::state_readers::DictState;
     use crate::traits::HashIdentifiedMut;
     use crate::utils::test_utils::dummy_declare_transaction_v1;
 
     fn dummy_trace(tx: &TransactionWithHash) -> TransactionTrace {
         create_trace(
-            &mut Default::default(),
+            &mut CachedState::<DictState>::new(Default::default()),
             tx.get_type(),
             &Default::default(),
             Default::default(),

--- a/crates/starknet-devnet-core/src/utils.rs
+++ b/crates/starknet-devnet-core/src/utils.rs
@@ -40,7 +40,7 @@ pub(crate) fn get_storage_var_address(
 }
 
 pub(crate) fn get_versioned_constants() -> VersionedConstants {
-    VersionedConstants::create_for_testing()
+    VersionedConstants::latest_constants().clone()
 }
 
 /// Values not present here: https://docs.starknet.io/tools/limits-and-triggers/

--- a/crates/starknet-devnet-core/src/utils.rs
+++ b/crates/starknet-devnet-core/src/utils.rs
@@ -1,5 +1,5 @@
 use blockifier::bouncer::{BouncerConfig, BouncerWeights, BuiltinCount};
-use blockifier::versioned_constants::VersionedConstants;
+use blockifier::versioned_constants::{StarknetVersion, VersionedConstants};
 use serde_json::Value;
 use starknet_rs_core::types::contract::CompiledClass;
 use starknet_rs_core::types::Felt;
@@ -40,7 +40,7 @@ pub(crate) fn get_storage_var_address(
 }
 
 pub(crate) fn get_versioned_constants() -> VersionedConstants {
-    VersionedConstants::latest_constants().clone()
+    VersionedConstants::get(StarknetVersion::V0_13_2).clone()
 }
 
 /// Values not present here: https://docs.starknet.io/tools/limits-and-triggers/

--- a/scripts/install_foundry.sh
+++ b/scripts/install_foundry.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 
+# If foundryup becomes buggy, consider switching to directly downloading binary from GitHub tag:
+# git_asset="https://github.com/foundry-rs/foundry/releases/download/$foundry_version/foundry_nightly_linux_amd64.tar.gz"
+# foundry_bin="$HOME/.foundry/bin"
+# mkdir -p "$foundry_bin"
+# curl -L "$git_asset" | tar -xvz -C "$foundry_bin"
+# export PATH="$PATH:$HOME/$foundry_bin"
+
 set -eu
 
-echo "Installing foundryup"
+foundry_version="nightly-5b7e4cb3c882b28f3c32ba580de27ce7381f415a"
+
+echo "Installing foundryup $foundry_version"
+
 curl -L https://foundry.paradigm.xyz | bash || echo "As expected, received a non-zero exit code"
 
 # make command available in PATH
@@ -13,7 +23,7 @@ if [ -n "$CIRCLE_BRANCH" ]; then
 fi
 
 echo "Installing foundry"
-foundryup --install nightly-5b7e4cb3c882b28f3c32ba580de27ce7381f415a
+foundryup --install "$foundry_version"
 
 # assert it works
 anvil --version

--- a/scripts/install_foundry.sh
+++ b/scripts/install_foundry.sh
@@ -11,8 +11,9 @@ set -eu
 
 foundry_version="nightly-5b7e4cb3c882b28f3c32ba580de27ce7381f415a"
 
-echo "Installing foundryup $foundry_version"
+echo "Installing foundry $foundry_version"
 
+echo "Installing foundryup"
 curl -L https://foundry.paradigm.xyz | bash || echo "As expected, received a non-zero exit code"
 
 # make command available in PATH


### PR DESCRIPTION
## Usage related changes

- Use `VersionedConstants` of Starknet v0.13.2 instead of the testing constants.

## Development related changes

- Remove the import of the `testing` feature of `blockifier`.
- Replace `CachedState::default` with custom implementation.
- This should unblock the update to `blockifier-0.14-rc.0`.
- Improve `install_foundry.sh`

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [x] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
