### PR TITLE
Fix L2 gas price setting

### DIFF
--- a/crates/starknet-devnet-core/src/starknet/mod.rs
+++ b/crates/starknet-devnet-core/src/starknet/mod.rs
@@ -521,12 +521,12 @@ impl Starknet {
             eth_gas_prices: GasPriceVector {
                 l1_gas_price: nonzero_gas_price!(gas_modification.gas_price_wei),
                 l1_data_gas_price: nonzero_gas_price!(gas_modification.data_gas_price_wei),
-                l2_gas_price: nonzero_gas_price!(gas_modification.gas_price_wei),
+                l2_gas_price: nonzero_gas_price!(gas_modification.l2_gas_price_wei),
             },
             strk_gas_prices: GasPriceVector {
                 l1_gas_price: nonzero_gas_price!(gas_modification.gas_price_fri),
                 l1_data_gas_price: nonzero_gas_price!(gas_modification.data_gas_price_fri),
-                l2_gas_price: nonzero_gas_price!(gas_modification.gas_price_fri),
+                l2_gas_price: nonzero_gas_price!(gas_modification.l2_gas_price_fri),
             },
         };
 


### PR DESCRIPTION
## Usage related changes

- Modifying L2 gas price via our gas modification RPC method did not work (was set to the same value as L1 gas price).
  - This is now fixed.

## Development related changes

- Reduce number of failing tests on target branch.
- Fix tests
- Address one TODO

## Checklist:

<!-- If you are not able to complete one of these steps, you can still create a PR, but note what caused you trouble. -->

- [x] Checked out the [contribution guidelines](CONTRIBUTING.md)
- [x] Applied formatting - `./scripts/format.sh`
- [x] No linter errors - `./scripts/clippy_check.sh`
- [x] No unused dependencies - `./scripts/check_unused_deps.sh`
- [x] No spelling errors - `./scripts/check_spelling.sh`
- [x] Performed code self-review
- [x] Rebased to the latest commit of the target branch (or merged it into my branch)
    -   Once you make the PR reviewable, please avoid force-pushing
- [x] Updated the docs if needed - `./website/README.md`
- [x] Linked the [issues](https://github.com/0xSpaceShard/starknet-devnet-rs/issues) resolvable by this PR - [linking info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- [ ] Updated the tests if needed; all passing - [execution info](https://github.com/0xSpaceShard/starknet-devnet-rs/blob/main/.github/CONTRIBUTING.md#test-execution)
